### PR TITLE
fix: integer overflow safety, timestamp +infinity, math fixes (#39, #45)

### DIFF
--- a/src/executor/exec_expr.rs
+++ b/src/executor/exec_expr.rs
@@ -2325,7 +2325,12 @@ pub(crate) fn eval_unary(op: UnaryOp, value: ScalarValue) -> Result<ScalarValue,
                 message: "invalid unary operation".to_string(),
             })
         }
-        (UnaryOp::Minus, ScalarValue::Int(v)) => Ok(ScalarValue::Int(-v)),
+        (UnaryOp::Minus, ScalarValue::Int(v)) => {
+            let negated = v.checked_neg().ok_or_else(|| EngineError {
+                message: "bigint out of range".to_string(),
+            })?;
+            Ok(ScalarValue::Int(negated))
+        }
         (UnaryOp::Minus, ScalarValue::Float(v)) => Ok(ScalarValue::Float(-v)),
         (UnaryOp::Minus, ScalarValue::Text(text)) => {
             if is_interval_text(&text) {

--- a/src/utils/adt/math_functions.rs
+++ b/src/utils/adt/math_functions.rs
@@ -61,15 +61,17 @@ pub(crate) fn coerce_to_f64(v: &ScalarValue, context: &str) -> Result<f64, Engin
     }
 }
 
-pub(crate) fn gcd_i64(mut a: i64, mut b: i64) -> i64 {
-    a = a.abs();
-    b = b.abs();
-    while b != 0 {
-        let t = b;
-        b = a % b;
-        a = t;
+pub(crate) fn gcd_i64(a: i64, b: i64) -> Result<i64, EngineError> {
+    let mut left = i128::from(a).abs();
+    let mut right = i128::from(b).abs();
+    while right != 0 {
+        let next = left % right;
+        left = right;
+        right = next;
     }
-    a
+    i64::try_from(left).map_err(|_| EngineError {
+        message: "bigint out of range".to_string(),
+    })
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Overflow safety, +infinity timestamps, 14 new lib tests. Per-file statement gains but no new file flips — groundwork for next batch.