### PR TITLE
Annotate incomplete feature scaffolding

### DIFF
--- a/src/replication/client.rs
+++ b/src/replication/client.rs
@@ -174,6 +174,10 @@ pub struct ReplicationSlot {
     pub snapshot_name: Option<String>,
 }
 
+// TODO(#79): CopyBothResponse is parsed from the wire but the streaming replication
+// handler discards the payload (see WireMessage::CopyBothResponse(_) => continue).
+// The overall_format and column_formats fields are never inspected. Wire up the read
+// path when the replication stream needs to negotiate text vs binary column encoding.
 #[derive(Debug)]
 pub struct CopyBothResponse {
     pub overall_format: u8,

--- a/src/tcop/engine.rs
+++ b/src/tcop/engine.rs
@@ -804,6 +804,10 @@ pub(crate) fn sync_wasm_ws_state(conn_id: i64) {
     }
 }
 
+// TODO(#79): UserEnumType metadata is stored but never read back for type dispatch.
+// The proxy does not yet use this information to handle user-defined enum types in
+// query results. Implement a read path or remove the scaffolding when enum support
+// is prioritized.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub(crate) struct UserEnumType {
@@ -811,6 +815,10 @@ pub(crate) struct UserEnumType {
     pub(crate) labels: Vec<String>,
 }
 
+// TODO(#79): UserDomain metadata is stored but never read back for type dispatch.
+// The proxy does not yet resolve domain types to their base types when processing
+// query results. Implement a read path or remove the scaffolding when domain support
+// is prioritized.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub(crate) struct UserDomain {


### PR DESCRIPTION
## Summary
- Adds `TODO(#79)` comments to `UserEnumType` and `UserDomain` in `src/tcop/engine.rs` explaining that metadata is stored but never read back for type dispatch.
- Adds a `TODO(#79)` comment to `CopyBothResponse` in `src/replication/client.rs` explaining that the message is parsed but the streaming replication handler discards the payload.
- No code behavior changes; documentation-only.

Closes #79

## Test plan
- [x] `cargo check` passes with no errors or new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)