### PR TITLE
Remove dead with_cte_context()

### DIFF
--- a/src/tcop/pquery.rs
+++ b/src/tcop/pquery.rs
@@ -1301,16 +1301,6 @@ pub(crate) fn current_cte_binding(name: &str) -> Option<CteBinding> {
     })
 }
 
-#[allow(dead_code)]
-fn with_cte_context<T>(ctes: HashMap<String, CteBinding>, f: impl FnOnce() -> T) -> T {
-    ACTIVE_CTE_STACK.with(|stack| {
-        stack.borrow_mut().push(ctes);
-        let out = f();
-        stack.borrow_mut().pop();
-        out
-    })
-}
-
 pub(crate) async fn with_cte_context_async<T, F, Fut>(ctes: HashMap<String, CteBinding>, f: F) -> T
 where
     F: FnOnce() -> Fut,


### PR DESCRIPTION
## Summary
- Removes the dead synchronous `with_cte_context()` function from `src/tcop/pquery.rs`
- This function was superseded by `with_cte_context_async()` during the sync-to-async refactor
- All 4 call sites already use the async version
- Removes the accompanying `#[allow(dead_code)]` annotation

Closes #80

## Test plan
- [x] `cargo check` passes with no errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)