### PR TITLE
Remove stale #[allow(dead_code)] annotations

### DIFF
--- a/src/utils/adt/datetime.rs
+++ b/src/utils/adt/datetime.rs
@@ -1405,7 +1405,6 @@ pub(crate) fn format_timestamp(datetime: DateTimeValue) -> String {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn format_time(hour: u32, minute: u32, second: u32, microsecond: u32) -> String {
     if microsecond == 0 {
         format!("{hour:02}:{minute:02}:{second:02}")

--- a/src/utils/adt/misc.rs
+++ b/src/utils/adt/misc.rs
@@ -1346,7 +1346,6 @@ fn render_query_to_sql(query: &crate::parser::ast::Query, pretty: bool) -> Strin
     sql
 }
 
-#[allow(dead_code)]
 fn render_select_to_sql(select: &crate::parser::ast::SelectStatement) -> String {
     let mut sql = String::from("SELECT");
 
@@ -1459,7 +1458,6 @@ fn render_select_to_sql(select: &crate::parser::ast::SelectStatement) -> String 
     sql
 }
 
-#[allow(dead_code)]
 fn render_table_expr_to_sql(table: &crate::parser::ast::TableExpression) -> String {
     use crate::parser::ast::TableExpression;
 
@@ -1533,7 +1531,6 @@ fn render_table_expr_to_sql(table: &crate::parser::ast::TableExpression) -> Stri
     }
 }
 
-#[allow(dead_code)]
 fn unary_op_to_sql(op: &crate::parser::ast::UnaryOp) -> &'static str {
     use crate::parser::ast::UnaryOp;
     match op {
@@ -1543,7 +1540,6 @@ fn unary_op_to_sql(op: &crate::parser::ast::UnaryOp) -> &'static str {
     }
 }
 
-#[allow(dead_code)]
 fn binary_op_to_sql(op: &crate::parser::ast::BinaryOp) -> &'static str {
     use crate::parser::ast::BinaryOp;
     match op {
@@ -1587,7 +1583,6 @@ fn binary_op_to_sql(op: &crate::parser::ast::BinaryOp) -> &'static str {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn render_expr_to_sql(expr: &crate::parser::ast::Expr) -> String {
     use crate::parser::ast::Expr;
 


### PR DESCRIPTION
## Summary

- Removes 6 stale `#[allow(dead_code)]` annotations from functions that are actively called in production code
- **`src/utils/adt/misc.rs`**: Removed annotations from `render_select_to_sql()`, `render_table_expr_to_sql()`, `unary_op_to_sql()`, `binary_op_to_sql()`, and `render_expr_to_sql()`
- **`src/utils/adt/datetime.rs`**: Removed annotation from `format_time()`
- Verified via `cargo check` that all removed annotations were truly stale (no dead_code warnings after removal)
- Note: The `storage/btree.rs` annotations mentioned in #78 were investigated but found to be **not stale** (removing them produces dead_code warnings), so they were intentionally kept

Closes #78

## Test plan

- [x] `cargo check` passes with zero warnings after annotation removal
- [ ] `cargo test` confirms no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)