### PR TITLE
feat(pgvector): Complete vector extension for AI workflows (#90)

### DIFF
--- a/src/analyzer/functions.rs
+++ b/src/analyzer/functions.rs
@@ -200,6 +200,16 @@ const KNOWN_FUNCTIONS: &[(&str, usize, usize)] = &[
     ("http_delete", 1, 1),
     ("http_head", 1, 1),
     ("urlencode", 1, 1),
+    // pgvector extension
+    ("l2_distance", 2, 2),
+    ("cosine_distance", 2, 2),
+    ("inner_product", 2, 2),
+    ("l1_distance", 2, 2),
+    ("vector_norm", 1, 1),
+    ("vector_dims", 1, 1),
+    ("vector_to_float4", 1, 1),
+    ("subvector", 3, 3),
+    ("vector_concat", 2, 2),
     // Misc
     ("pg_typeof", 1, 1),
     ("pg_input_is_valid", 2, 2),

--- a/src/executor/exec_expr.rs
+++ b/src/executor/exec_expr.rs
@@ -42,6 +42,7 @@ use crate::utils::adt::misc::{
     compare_values_for_predicate, parse_bool_scalar, parse_f64_numeric_scalar, parse_f64_scalar,
     parse_i64_scalar, parse_nullable_bool, parse_pg_array_literal, truthy,
 };
+use crate::utils::adt::vector::coerce_scalar_to_vector;
 use crate::utils::fmgr::eval_scalar_function;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{JsCast, JsValue};
@@ -2224,6 +2225,10 @@ pub(crate) fn eval_cast_scalar(
             Ok(ScalarValue::Text(format_timestamp(dt)))
         }
         "interval" => eval_interval_cast(&value),
+        "vector" => {
+            let vector = coerce_scalar_to_vector(&value, None, "cannot cast value to vector")?;
+            Ok(ScalarValue::Vector(vector))
+        }
         "json" | "jsonb" => {
             // For JSON/JSONB casts, validate that the input is valid JSON
             let text = value.render();
@@ -2423,6 +2428,12 @@ pub(crate) fn eval_binary(
         Add => eval_add(left, right),
         Sub => eval_sub(left, right),
         Mul => {
+            if matches!(left, ScalarValue::Null) || matches!(right, ScalarValue::Null) {
+                return Ok(ScalarValue::Null);
+            }
+            if let (ScalarValue::Vector(a), ScalarValue::Vector(b)) = (&left, &right) {
+                return eval_vector_elementwise(a, b, "vector multiplication", |x, y| x * y);
+            }
             // interval * numeric or numeric * interval
             let left_is_interval = matches!(&left, ScalarValue::Text(t) if is_interval_text(t));
             let right_is_interval = matches!(&right, ScalarValue::Text(t) if is_interval_text(t));
@@ -2575,6 +2586,9 @@ fn eval_add(left: ScalarValue, right: ScalarValue) -> Result<ScalarValue, Engine
     if matches!(left, ScalarValue::Null) || matches!(right, ScalarValue::Null) {
         return Ok(ScalarValue::Null);
     }
+    if let (ScalarValue::Vector(a), ScalarValue::Vector(b)) = (&left, &right) {
+        return eval_vector_elementwise(a, b, "vector addition", |x, y| x + y);
+    }
 
     if parse_numeric_operand(&left).is_ok() && parse_numeric_operand(&right).is_ok() {
         return numeric_bin(
@@ -2625,6 +2639,9 @@ fn eval_add(left: ScalarValue, right: ScalarValue) -> Result<ScalarValue, Engine
 fn eval_sub(left: ScalarValue, right: ScalarValue) -> Result<ScalarValue, EngineError> {
     if matches!(left, ScalarValue::Null) || matches!(right, ScalarValue::Null) {
         return Ok(ScalarValue::Null);
+    }
+    if let (ScalarValue::Vector(a), ScalarValue::Vector(b)) = (&left, &right) {
+        return eval_vector_elementwise(a, b, "vector subtraction", |x, y| x - y);
     }
 
     if parse_numeric_operand(&left).is_ok() && parse_numeric_operand(&right).is_ok() {
@@ -2691,6 +2708,29 @@ fn eval_sub(left: ScalarValue, right: ScalarValue) -> Result<ScalarValue, Engine
     Err(EngineError {
         message: "numeric operation expects numeric values".to_string(),
     })
+}
+
+fn eval_vector_elementwise(
+    left: &[f32],
+    right: &[f32],
+    context: &str,
+    op: impl Fn(f32, f32) -> f32,
+) -> Result<ScalarValue, EngineError> {
+    if left.len() != right.len() {
+        return Err(EngineError {
+            message: format!(
+                "{context} expects vectors of the same dimension ({} != {})",
+                left.len(),
+                right.len()
+            ),
+        });
+    }
+    Ok(ScalarValue::Vector(
+        left.iter()
+            .zip(right.iter())
+            .map(|(a, b)| op(*a, *b))
+            .collect(),
+    ))
 }
 
 fn eval_logical_or(left: ScalarValue, right: ScalarValue) -> Result<ScalarValue, EngineError> {
@@ -3023,6 +3063,9 @@ async fn eval_function(
                     | "l1_distance"
                     | "vector_dims"
                     | "vector_norm"
+                    | "vector_to_float4"
+                    | "subvector"
+                    | "vector_concat"
             )
         {
             return eval_pgvector_function(fname, &values);

--- a/src/executor/exec_main/aggregation.rs
+++ b/src/executor/exec_main/aggregation.rs
@@ -1188,43 +1188,98 @@ pub async fn eval_aggregate_function(
             let mut int_values = Vec::with_capacity(rows.len());
             let mut float_values = Vec::new();
             let mut decimal_total = rust_decimal::Decimal::ZERO;
-            let mut count = 0u64;
+            let mut numeric_count = 0u64;
             let mut saw_decimal = false;
+            let mut saw_numeric = false;
+            let mut vector_sum: Option<Vec<f64>> = None;
+            let mut vector_count = 0u64;
             for row in rows {
-                match row.args[0] {
+                match &row.args[0] {
                     ScalarValue::Null => {}
                     ScalarValue::Int(v) => {
-                        int_values.push(v);
-                        decimal_total += rust_decimal::Decimal::from(v);
-                        count += 1;
+                        if vector_sum.is_some() {
+                            return Err(EngineError {
+                                message: "avg() cannot mix vector and numeric values".to_string(),
+                            });
+                        }
+                        int_values.push(*v);
+                        decimal_total += rust_decimal::Decimal::from(*v);
+                        numeric_count += 1;
+                        saw_numeric = true;
                     }
                     ScalarValue::Float(v) => {
-                        float_values.push(v);
-                        decimal_total += rust_decimal::Decimal::try_from(v)
+                        if vector_sum.is_some() {
+                            return Err(EngineError {
+                                message: "avg() cannot mix vector and numeric values".to_string(),
+                            });
+                        }
+                        float_values.push(*v);
+                        decimal_total += rust_decimal::Decimal::try_from(*v)
                             .unwrap_or(rust_decimal::Decimal::ZERO);
-                        count += 1;
+                        numeric_count += 1;
+                        saw_numeric = true;
                     }
                     ScalarValue::Numeric(v) => {
+                        if vector_sum.is_some() {
+                            return Err(EngineError {
+                                message: "avg() cannot mix vector and numeric values".to_string(),
+                            });
+                        }
                         float_values.push(v.to_string().parse::<f64>().unwrap_or(0.0));
-                        decimal_total += v;
+                        decimal_total += *v;
                         saw_decimal = true;
-                        count += 1;
+                        numeric_count += 1;
+                        saw_numeric = true;
+                    }
+                    ScalarValue::Vector(v) => {
+                        if saw_numeric {
+                            return Err(EngineError {
+                                message: "avg() cannot mix vector and numeric values".to_string(),
+                            });
+                        }
+                        if let Some(sum) = &mut vector_sum {
+                            if sum.len() != v.len() {
+                                return Err(EngineError {
+                                    message: format!(
+                                        "avg() expects vectors of the same dimension ({} != {})",
+                                        sum.len(),
+                                        v.len()
+                                    ),
+                                });
+                            }
+                            for (total, value) in sum.iter_mut().zip(v.iter()) {
+                                *total += *value as f64;
+                            }
+                        } else {
+                            vector_sum = Some(v.iter().map(|value| *value as f64).collect());
+                        }
+                        vector_count += 1;
                     }
                     _ => {
                         return Err(EngineError {
-                            message: "avg() expects numeric values".to_string(),
+                            message: "avg() expects numeric or vector values".to_string(),
                         });
                     }
                 }
             }
-            if count == 0 {
+            if let Some(sum) = vector_sum {
+                if vector_count == 0 {
+                    return Ok(ScalarValue::Null);
+                }
+                return Ok(ScalarValue::Vector(
+                    sum.into_iter()
+                        .map(|value| (value / vector_count as f64) as f32)
+                        .collect(),
+                ));
+            }
+            if numeric_count == 0 {
                 Ok(ScalarValue::Null)
             } else if saw_decimal {
-                let avg = decimal_total / rust_decimal::Decimal::from(count);
+                let avg = decimal_total / rust_decimal::Decimal::from(numeric_count);
                 Ok(ScalarValue::Numeric(avg))
             } else {
                 let float_total = sum_i64_fast(&int_values) as f64 + sum_f64_fast(&float_values);
-                Ok(ScalarValue::Float(float_total / count as f64))
+                Ok(ScalarValue::Float(float_total / numeric_count as f64))
             }
         }
         "min" | "max" => {

--- a/src/extensions/pgvector.rs
+++ b/src/extensions/pgvector.rs
@@ -1,5 +1,6 @@
 use crate::storage::tuple::ScalarValue;
 use crate::tcop::engine::EngineError;
+use crate::utils::adt::misc::parse_i64_scalar;
 use crate::utils::adt::vector::{
     coerce_scalar_to_vector, cosine_distance, inner_product, l1_distance, l2_distance, vector_dims,
     vector_norm,
@@ -61,6 +62,50 @@ pub(crate) fn eval_pgvector_function(
             }
             let vec = coerce_scalar_to_vector(&args[0], None, "vector_norm()")?;
             Ok(ScalarValue::Float(vector_norm(&vec)))
+        }
+        "vector_to_float4" if args.len() == 1 => {
+            if matches!(args[0], ScalarValue::Null) {
+                return Ok(ScalarValue::Null);
+            }
+            let vec = coerce_scalar_to_vector(&args[0], None, "vector_to_float4()")?;
+            Ok(ScalarValue::Array(
+                vec.into_iter()
+                    .map(|value| ScalarValue::Float(value as f64))
+                    .collect(),
+            ))
+        }
+        "subvector" if args.len() == 3 => {
+            if args.iter().any(|arg| matches!(arg, ScalarValue::Null)) {
+                return Ok(ScalarValue::Null);
+            }
+            let vec = coerce_scalar_to_vector(&args[0], None, "subvector()")?;
+            let start = parse_i64_scalar(&args[1], "subvector() start must be an integer")?;
+            let count = parse_i64_scalar(&args[2], "subvector() count must be an integer")?;
+            if start < 1 {
+                return Err(EngineError {
+                    message: "subvector() start must be >= 1".to_string(),
+                });
+            }
+            if count < 0 {
+                return Err(EngineError {
+                    message: "subvector() count must be >= 0".to_string(),
+                });
+            }
+            let start_idx = (start - 1) as usize;
+            if start_idx >= vec.len() || count == 0 {
+                return Ok(ScalarValue::Vector(Vec::new()));
+            }
+            let end_idx = start_idx.saturating_add(count as usize).min(vec.len());
+            Ok(ScalarValue::Vector(vec[start_idx..end_idx].to_vec()))
+        }
+        "vector_concat" if args.len() == 2 => {
+            if args.iter().any(|arg| matches!(arg, ScalarValue::Null)) {
+                return Ok(ScalarValue::Null);
+            }
+            let mut left = coerce_scalar_to_vector(&args[0], None, "vector_concat()")?;
+            let right = coerce_scalar_to_vector(&args[1], None, "vector_concat()")?;
+            left.extend(right);
+            Ok(ScalarValue::Vector(left))
         }
         _ => Err(EngineError {
             message: format!("function pgvector.{fn_name}() does not exist"),

--- a/src/tcop/engine_tests.rs
+++ b/src/tcop/engine_tests.rs
@@ -6015,27 +6015,190 @@ fn test_pgcrypto_functions() {
 }
 
 #[test]
-fn test_pgvector_functions_and_operators() {
+fn test_pgvector_table_roundtrip_and_nearest_neighbor() {
     with_isolated_state(|| {
         run_statement("CREATE EXTENSION vector", &[]);
+        run_statement(
+            "CREATE TABLE items (id serial, name text, embedding vector(3))",
+            &[],
+        );
+        run_statement(
+            "INSERT INTO items (name, embedding) VALUES ('item1', '[1,2,3]')",
+            &[],
+        );
+        run_statement(
+            "INSERT INTO items (name, embedding) VALUES ('item2', '[4,5,6]')",
+            &[],
+        );
+
+        let all_rows = run_statement("SELECT * FROM items ORDER BY id", &[]);
+        assert_eq!(all_rows.rows.len(), 2);
+        assert_eq!(all_rows.rows[0][0], ScalarValue::Int(1));
+        assert_eq!(all_rows.rows[0][1], ScalarValue::Text("item1".to_string()));
+        assert_eq!(
+            all_rows.rows[0][2],
+            ScalarValue::Vector(vec![1.0_f32, 2.0_f32, 3.0_f32])
+        );
+        assert_eq!(all_rows.rows[1][0], ScalarValue::Int(2));
+        assert_eq!(all_rows.rows[1][1], ScalarValue::Text("item2".to_string()));
+        assert_eq!(
+            all_rows.rows[1][2],
+            ScalarValue::Vector(vec![4.0_f32, 5.0_f32, 6.0_f32])
+        );
+
+        let nearest = run_statement(
+            "SELECT name, embedding <-> '[1,2,3]' AS distance FROM items ORDER BY distance LIMIT 2",
+            &[],
+        );
+        assert_eq!(nearest.rows.len(), 2);
+        assert_eq!(nearest.rows[0][0], ScalarValue::Text("item1".to_string()));
+        assert_eq!(nearest.rows[0][1], ScalarValue::Float(0.0));
+        assert_eq!(nearest.rows[1][0], ScalarValue::Text("item2".to_string()));
+        match &nearest.rows[1][1] {
+            ScalarValue::Float(v) => assert!((*v - 5.196_152_422_706_632).abs() < 1e-9),
+            value => panic!("expected float distance, got {value:?}"),
+        }
+    });
+}
+
+#[test]
+fn test_pgvector_arithmetic_casts_and_distance_functions() {
+    with_isolated_state(|| {
+        run_statement("CREATE EXTENSION vector", &[]);
+
+        let arithmetic = run_statement(
+            "SELECT '[1,2,3]'::vector + '[4,5,6]'::vector, '[4,5,6]'::vector - '[1,2,3]'::vector, '[1,2,3]'::vector * '[4,5,6]'::vector",
+            &[],
+        );
+        assert_eq!(
+            arithmetic.rows[0][0],
+            ScalarValue::Vector(vec![5.0_f32, 7.0_f32, 9.0_f32])
+        );
+        assert_eq!(
+            arithmetic.rows[0][1],
+            ScalarValue::Vector(vec![3.0_f32, 3.0_f32, 3.0_f32])
+        );
+        assert_eq!(
+            arithmetic.rows[0][2],
+            ScalarValue::Vector(vec![4.0_f32, 10.0_f32, 18.0_f32])
+        );
+
+        let casts = run_statement("SELECT '[1,2,3]'::vector, ARRAY[1,2,3]::vector", &[]);
+        assert_eq!(
+            casts.rows[0][0],
+            ScalarValue::Vector(vec![1.0_f32, 2.0_f32, 3.0_f32])
+        );
+        assert_eq!(
+            casts.rows[0][1],
+            ScalarValue::Vector(vec![1.0_f32, 2.0_f32, 3.0_f32])
+        );
+
         let distances = run_statement(
-            "SELECT l2_distance('[1,2]', '[4,6]'), l1_distance('[1,2]', '[4,6]'), cosine_distance('[1,0]', '[0,1]')",
+            "SELECT l2_distance('[1,2]', '[4,6]'), l1_distance('[1,2]', '[4,6]'), cosine_distance('[1,0]', '[0,1]'), inner_product('[1,2,3]', '[4,5,6]'), vector_dims('[1,2,3]'), vector_norm('[3,4]'), '[1,2]' <-> '[4,6]'",
             &[],
         );
         assert_eq!(distances.rows[0][0], ScalarValue::Float(5.0));
         assert_eq!(distances.rows[0][1], ScalarValue::Float(7.0));
         assert_eq!(distances.rows[0][2], ScalarValue::Float(1.0));
+        assert_eq!(distances.rows[0][3], ScalarValue::Float(32.0));
+        assert_eq!(distances.rows[0][4], ScalarValue::Int(3));
+        assert_eq!(distances.rows[0][5], ScalarValue::Float(5.0));
+        assert_eq!(distances.rows[0][6], ScalarValue::Float(5.0));
+    });
+}
 
-        let extras = run_statement(
-            "SELECT inner_product('[1,2,3]', '[4,5,6]'), vector_dims('[1,2,3]'), vector_norm('[3,4]')",
+#[test]
+fn test_pgvector_avg_and_helper_functions() {
+    with_isolated_state(|| {
+        run_statement("CREATE EXTENSION vector", &[]);
+        run_statement("CREATE TABLE embeddings (v vector(3))", &[]);
+        run_statement("INSERT INTO embeddings VALUES ('[1,2,3]')", &[]);
+        run_statement("INSERT INTO embeddings VALUES ('[4,5,6]')", &[]);
+        run_statement("INSERT INTO embeddings VALUES (NULL)", &[]);
+
+        let avg = run_statement("SELECT avg(v) FROM embeddings", &[]);
+        assert_eq!(
+            avg.rows[0][0],
+            ScalarValue::Vector(vec![2.5_f32, 3.5_f32, 4.5_f32])
+        );
+
+        let helpers = run_statement(
+            "SELECT vector_to_float4('[1,2,3]'::vector), subvector('[1,2,3,4]'::vector, 2, 2), vector_concat('[1,2]'::vector, '[3,4]'::vector)",
             &[],
         );
-        assert_eq!(extras.rows[0][0], ScalarValue::Float(32.0));
-        assert_eq!(extras.rows[0][1], ScalarValue::Int(3));
-        assert_eq!(extras.rows[0][2], ScalarValue::Float(5.0));
+        assert_eq!(
+            helpers.rows[0][0],
+            ScalarValue::Array(vec![
+                ScalarValue::Float(1.0),
+                ScalarValue::Float(2.0),
+                ScalarValue::Float(3.0),
+            ])
+        );
+        assert_eq!(
+            helpers.rows[0][1],
+            ScalarValue::Vector(vec![2.0_f32, 3.0_f32])
+        );
+        assert_eq!(
+            helpers.rows[0][2],
+            ScalarValue::Vector(vec![1.0_f32, 2.0_f32, 3.0_f32, 4.0_f32])
+        );
+    });
+}
 
-        let op_result = run_statement("SELECT '[1,2]' <-> '[4,6]' AS dist", &[]);
-        assert_eq!(op_result.rows[0][0], ScalarValue::Float(5.0));
+#[test]
+fn test_pgvector_dimension_mismatch_errors() {
+    with_isolated_state(|| {
+        run_statement("CREATE EXTENSION vector", &[]);
+        run_statement("CREATE TABLE items (embedding vector(3))", &[]);
+
+        let statement = parse_statement("INSERT INTO items VALUES ('[1,2]')").unwrap();
+        let planned = plan_statement(statement).unwrap();
+        let err = block_on(execute_planned_query(&planned, &[]))
+            .expect_err("vector dimension mismatch should fail");
+        assert!(err.message.contains("expects vector dimension 3"));
+
+        let statement = parse_statement("SELECT '[1,2]'::vector + '[1,2,3]'::vector").unwrap();
+        let planned = plan_statement(statement).unwrap();
+        let err = block_on(execute_planned_query(&planned, &[]))
+            .expect_err("vector arithmetic dimension mismatch should fail");
+        assert!(
+            err.message
+                .contains("vector addition expects vectors of the same dimension")
+        );
+
+        run_statement("CREATE TABLE varying_embeddings (v vector)", &[]);
+        run_statement("INSERT INTO varying_embeddings VALUES ('[1,2]')", &[]);
+        run_statement("INSERT INTO varying_embeddings VALUES ('[1,2,3]')", &[]);
+
+        let statement = parse_statement("SELECT avg(v) FROM varying_embeddings").unwrap();
+        let planned = plan_statement(statement).unwrap();
+        let err = block_on(execute_planned_query(&planned, &[]))
+            .expect_err("avg(vector) dimension mismatch should fail");
+        assert!(
+            err.message
+                .contains("avg() expects vectors of the same dimension")
+        );
+    });
+}
+
+#[test]
+fn test_pgvector_null_handling() {
+    with_isolated_state(|| {
+        run_statement("CREATE EXTENSION vector", &[]);
+        let nulls = run_statement(
+            "SELECT NULL::vector + '[1,2]'::vector, NULL::vector - '[1,2]'::vector, NULL::vector * '[1,2]'::vector, vector_concat(NULL::vector, '[1,2]'::vector), subvector(NULL::vector, 1, 1), vector_to_float4(NULL::vector), l2_distance(NULL::vector, '[1,2]'::vector)",
+            &[],
+        );
+        assert!(
+            nulls.rows[0]
+                .iter()
+                .all(|value| matches!(value, ScalarValue::Null))
+        );
+
+        run_statement("CREATE TABLE nullable_vectors (v vector(2))", &[]);
+        run_statement("INSERT INTO nullable_vectors VALUES (NULL), ('[1,2]')", &[]);
+        let avg = run_statement("SELECT avg(v) FROM nullable_vectors", &[]);
+        assert_eq!(avg.rows[0][0], ScalarValue::Vector(vec![1.0_f32, 2.0_f32]));
     });
 }
 
@@ -6656,7 +6819,7 @@ fn json_table_deribit_column_row_width() {
 
 #[test]
 fn json_table_deribit_pgwire() {
-    use crate::tcop::postgres::{FrontendMessage, PostgresSession, BackendMessage};
+    use crate::tcop::postgres::{BackendMessage, FrontendMessage, PostgresSession};
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
         let mut session = PostgresSession::new();
@@ -6665,7 +6828,7 @@ fn json_table_deribit_pgwire() {
                 sql: "SELECT * FROM json_table('https://www.deribit.com/api/v2/public/get_currencies', 'result') ORDER BY currency;".to_string(),
             }
         ]).await;
-        
+
         let mut row_desc_count = 0usize;
         let mut row_count = 0;
         let mut error = None;

--- a/src/tcop/pquery.rs
+++ b/src/tcop/pquery.rs
@@ -21,6 +21,7 @@ const PG_NUMERIC_OID: u32 = 1700;
 const PG_DATE_OID: u32 = 1082;
 const PG_TIMESTAMP_OID: u32 = 1114;
 const PG_VECTOR_OID: u32 = 6000;
+const PG_FLOAT4_ARRAY_OID: u32 = 1021;
 
 pub(crate) fn type_signature_to_oid(ty: TypeSignature) -> u32 {
     match ty {
@@ -178,8 +179,18 @@ fn infer_function_return_oid(
         | "position" | "ascii" | "pg_backend_pid" | "width_bucket" | "scale" | "factorial"
         | "num_nulls" | "num_nonnulls" => PG_INT8_OID,
         "extract" | "date_part" => PG_INT8_OID,
-        "avg" | "stddev" | "stddev_samp" | "stddev_pop" | "variance" | "var_samp" | "var_pop"
-        | "corr" | "covar_pop" | "covar_samp" | "regr_slope" | "regr_intercept" | "regr_r2"
+        "avg" => args
+            .first()
+            .map(|expr| {
+                if infer_expr_type_oid(expr, scope, ctes) == PG_VECTOR_OID {
+                    PG_VECTOR_OID
+                } else {
+                    PG_FLOAT8_OID
+                }
+            })
+            .unwrap_or(PG_FLOAT8_OID),
+        "stddev" | "stddev_samp" | "stddev_pop" | "variance" | "var_samp" | "var_pop" | "corr"
+        | "covar_pop" | "covar_samp" | "regr_slope" | "regr_intercept" | "regr_r2"
         | "regr_avgx" | "regr_avgy" | "regr_sxx" | "regr_sxy" | "regr_syy" | "percentile_cont" => {
             PG_FLOAT8_OID
         }
@@ -237,6 +248,8 @@ fn infer_function_return_oid(
             PG_FLOAT8_OID
         }
         "vector_dims" => PG_INT8_OID,
+        "subvector" | "vector_concat" => PG_VECTOR_OID,
+        "vector_to_float4" => PG_FLOAT4_ARRAY_OID,
         _ => PG_TEXT_OID,
     }
 }
@@ -301,7 +314,9 @@ fn infer_expr_type_oid(
                 | BinaryOp::VectorInnerProduct
                 | BinaryOp::VectorCosineDistance => PG_FLOAT8_OID,
                 BinaryOp::Add => {
-                    if (left_oid == PG_DATE_OID || left_oid == PG_TIMESTAMP_OID)
+                    if left_oid == PG_VECTOR_OID && right_oid == PG_VECTOR_OID {
+                        PG_VECTOR_OID
+                    } else if (left_oid == PG_DATE_OID || left_oid == PG_TIMESTAMP_OID)
                         && right_oid == PG_INT8_OID
                     {
                         left_oid
@@ -314,7 +329,9 @@ fn infer_expr_type_oid(
                     }
                 }
                 BinaryOp::Sub => {
-                    if (left_oid == PG_DATE_OID || left_oid == PG_TIMESTAMP_OID)
+                    if left_oid == PG_VECTOR_OID && right_oid == PG_VECTOR_OID {
+                        PG_VECTOR_OID
+                    } else if (left_oid == PG_DATE_OID || left_oid == PG_TIMESTAMP_OID)
                         && (right_oid == PG_DATE_OID || right_oid == PG_TIMESTAMP_OID)
                     {
                         PG_INT8_OID
@@ -328,8 +345,14 @@ fn infer_expr_type_oid(
                         infer_numeric_result_oid(left_oid, right_oid)
                     }
                 }
-                BinaryOp::Mul
-                | BinaryOp::Div
+                BinaryOp::Mul => {
+                    if left_oid == PG_VECTOR_OID && right_oid == PG_VECTOR_OID {
+                        PG_VECTOR_OID
+                    } else {
+                        infer_numeric_result_oid(left_oid, right_oid)
+                    }
+                }
+                BinaryOp::Div
                 | BinaryOp::Mod
                 | BinaryOp::Pow
                 | BinaryOp::ShiftLeft


### PR DESCRIPTION
## pgvector Extension

Completes issue #90 — full pgvector-compatible extension for AI/ML workflows.

### Features
- **Vector table roundtrip**: CREATE TABLE with vector(N), INSERT, SELECT
- **Nearest neighbor**: ORDER BY embedding <-> '[1,2,3]' LIMIT K
- **Distance operators**: <-> (L2), <=> (cosine), <#> (inner product)  
- **Vector arithmetic**: +, -, * (element-wise)
- **::vector cast**: Text and array to vector coercion
- **avg() aggregate**: Element-wise vector averaging
- **Helper functions**: vector_to_float4, subvector, vector_concat, l1_distance, vector_norm, vector_dims

### Tests
- All 728+ lib tests pass
- Comprehensive pgvector test suite: roundtrip, nearest neighbor, arithmetic, casts, avg, dimension mismatch errors, NULL handling

Closes #90