### PR TITLE
feat: Iceberg scan tests with crypto market data fixtures

### DIFF
--- a/src/analyzer/functions.rs
+++ b/src/analyzer/functions.rs
@@ -190,8 +190,9 @@ const KNOWN_FUNCTIONS: &[(&str, usize, usize)] = &[
     ("jsonb_exists_any", 2, 2),
     ("jsonb_exists_all", 2, 2),
     // Convenience table functions
-    ("json_table", 1, 255), // url + optional variadic path segments
-    ("iceberg_scan", 1, 1), // table root directory or metadata file path
+    ("json_table", 1, 255),     // url + optional variadic path segments
+    ("iceberg_scan", 1, 1),     // table root directory or metadata file path
+    ("iceberg_metadata", 1, 1), // table root directory or metadata file path
     // HTTP extension functions
     ("http_get", 1, 2),
     ("http_post", 2, 3),

--- a/src/bin/tui.rs
+++ b/src/bin/tui.rs
@@ -813,6 +813,8 @@ const BUILTIN_FUNCTIONS: &[&str] = &[
     "jsonb_exists_all",
     // Table functions
     "json_table",
+    "iceberg_scan",
+    "iceberg_metadata",
     "http_get",
     "http_post",
     "http_put",

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -111,6 +111,7 @@ pub(super) async fn evaluate_set_returning_function(
         "pg_input_error_info" => eval_pg_input_error_info_set_function(args, &fn_name),
         "json_table" => eval_json_table_function(args, &fn_name).await,
         "iceberg_scan" => eval_iceberg_scan_function(args, &fn_name).await,
+        "iceberg_metadata" => eval_iceberg_metadata_function(args, &fn_name),
         "pg_get_keywords" => eval_pg_get_keywords(),
         "messages" if function.name.len() == 2 && function.name[0].eq_ignore_ascii_case("ws") => {
             execute_ws_messages(args).await
@@ -583,6 +584,114 @@ pub(super) async fn eval_iceberg_scan_function(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+pub(super) fn eval_iceberg_metadata_function(
+    args: &[ScalarValue],
+    fn_name: &str,
+) -> Result<(Vec<String>, Vec<Vec<ScalarValue>>), EngineError> {
+    const OUTPUT_COLUMNS: [&str; 7] = [
+        "table_uuid",
+        "format_version",
+        "last_updated",
+        "current_schema_id",
+        "partition_spec",
+        "snapshot_count",
+        "total_data_files",
+    ];
+
+    if args.len() != 1 {
+        return Err(EngineError {
+            message: format!("{fn_name}() expects exactly one argument (table path)"),
+        });
+    }
+    if matches!(args[0], ScalarValue::Null) {
+        return Ok((
+            OUTPUT_COLUMNS.iter().map(std::string::ToString::to_string).collect(),
+            Vec::new(),
+        ));
+    }
+
+    let input_path = match &args[0] {
+        ScalarValue::Text(text) => text.trim().to_string(),
+        other => other.render(),
+    };
+    if input_path.is_empty() {
+        return Err(EngineError {
+            message: format!("{fn_name}() path argument cannot be empty"),
+        });
+    }
+
+    let input = Path::new(&input_path);
+    let metadata_file = resolve_iceberg_metadata_file(input).ok_or_else(|| EngineError {
+        message: format!(
+            "{fn_name}(): could not resolve Iceberg metadata file for {}",
+            input.display()
+        ),
+    })?;
+    let metadata_text = fs::read_to_string(&metadata_file).map_err(|err| EngineError {
+        message: format!(
+            "{fn_name}(): failed to read metadata file {}: {err}",
+            metadata_file.display()
+        ),
+    })?;
+    let metadata_json =
+        serde_json::from_str::<JsonValue>(&metadata_text).map_err(|err| EngineError {
+            message: format!(
+                "{fn_name}(): failed to parse metadata file {}: {err}",
+                metadata_file.display()
+            ),
+        })?;
+
+    let parquet_files = discover_iceberg_parquet_files(input, fn_name)?;
+    let snapshots = metadata_json
+        .get("snapshots")
+        .and_then(JsonValue::as_array)
+        .map_or(0_i64, |items| {
+            i64::try_from(items.len()).unwrap_or(i64::MAX)
+        });
+    let partition_spec = metadata_json
+        .get("partition-specs")
+        .cloned()
+        .unwrap_or_else(|| JsonValue::Array(Vec::new()));
+
+    let row = vec![
+        metadata_json
+            .get("table-uuid")
+            .and_then(JsonValue::as_str)
+            .map_or(ScalarValue::Null, |value| ScalarValue::Text(value.to_string())),
+        metadata_json
+            .get("format-version")
+            .and_then(JsonValue::as_i64)
+            .map_or(ScalarValue::Null, ScalarValue::Int),
+        metadata_json
+            .get("last-updated-ms")
+            .and_then(JsonValue::as_i64)
+            .map_or(ScalarValue::Null, ScalarValue::Int),
+        metadata_json
+            .get("current-schema-id")
+            .and_then(JsonValue::as_i64)
+            .map_or(ScalarValue::Null, ScalarValue::Int),
+        ScalarValue::Text(partition_spec.to_string()),
+        ScalarValue::Int(snapshots),
+        ScalarValue::Int(i64::try_from(parquet_files.len()).unwrap_or(i64::MAX)),
+    ];
+
+    Ok((
+        OUTPUT_COLUMNS.iter().map(std::string::ToString::to_string).collect(),
+        vec![row],
+    ))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(super) fn eval_iceberg_metadata_function(
+    _args: &[ScalarValue],
+    fn_name: &str,
+) -> Result<(Vec<String>, Vec<Vec<ScalarValue>>), EngineError> {
+    Err(EngineError {
+        message: format!("{fn_name}() is not supported on wasm targets"),
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub(super) fn scan_iceberg_parquet_files(
     parquet_files: &[PathBuf],
     mut columns: Vec<String>,
@@ -699,7 +808,7 @@ pub(super) fn parquet_field_to_scalar(field: &ParquetField) -> ScalarValue {
         ParquetField::Float16(value) => ScalarValue::Float(f64::from(*value)),
         ParquetField::Float(value) => ScalarValue::Float(f64::from(*value)),
         ParquetField::Double(value) => ScalarValue::Float(*value),
-        ParquetField::Decimal(value) => ScalarValue::Text(format!("{value:?}")),
+        ParquetField::Decimal(value) => ScalarValue::Text(parquet_decimal_to_text(value)),
         ParquetField::Str(value) => ScalarValue::Text(value.clone()),
         ParquetField::Bytes(value) => {
             if let Ok(text) = String::from_utf8(value.data().to_vec()) {
@@ -718,6 +827,45 @@ pub(super) fn parquet_field_to_scalar(field: &ParquetField) -> ScalarValue {
             ScalarValue::Text(field.to_string())
         }
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) fn parquet_decimal_to_text(value: &parquet::data_type::Decimal) -> String {
+    let bytes = value.data();
+    let scale = value.scale();
+    if bytes.len() > 16 {
+        return format!("{value:?}");
+    }
+
+    let sign_extension = if bytes.first().is_some_and(|byte| byte & 0x80 != 0) {
+        0xFF
+    } else {
+        0x00
+    };
+    let mut padded = [sign_extension; 16];
+    let start = 16 - bytes.len();
+    padded[start..].copy_from_slice(bytes);
+    let unscaled = i128::from_be_bytes(padded);
+    format_scaled_i128(unscaled, scale)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) fn format_scaled_i128(value: i128, scale: i32) -> String {
+    if scale <= 0 {
+        return value.to_string();
+    }
+
+    let sign = if value < 0 { "-" } else { "" };
+    let abs = value.unsigned_abs().to_string();
+    let scale_usize = usize::try_from(scale).unwrap_or(0);
+
+    if abs.len() <= scale_usize {
+        let zeros = "0".repeat(scale_usize.saturating_sub(abs.len()));
+        return format!("{sign}0.{zeros}{abs}");
+    }
+
+    let split = abs.len() - scale_usize;
+    format!("{sign}{}.{}", &abs[..split], &abs[split..])
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/tcop/pquery.rs
+++ b/src/tcop/pquery.rs
@@ -1696,6 +1696,15 @@ fn table_function_output_columns(function: &TableFunctionRef) -> Vec<String> {
             "catcode".to_string(),
             "catdesc".to_string(),
         ],
+        "iceberg_metadata" => vec![
+            "table_uuid".to_string(),
+            "format_version".to_string(),
+            "last_updated".to_string(),
+            "current_schema_id".to_string(),
+            "partition_spec".to_string(),
+            "snapshot_count".to_string(),
+            "total_data_files".to_string(),
+        ],
         "pg_input_error_info" => vec![
             "message".to_string(),
             "detail".to_string(),
@@ -1735,6 +1744,15 @@ fn table_function_output_type_oids(function: &TableFunctionRef, count: usize) ->
         | "jsonb_populate_record"
         | "json_populate_recordset"
         | "jsonb_populate_recordset" => Vec::new(),
+        "iceberg_metadata" => vec![
+            PG_TEXT_OID, // table_uuid
+            20,          // format_version (int8)
+            20,          // last_updated (int8)
+            20,          // current_schema_id (int8)
+            PG_TEXT_OID, // partition_spec
+            20,          // snapshot_count (int8)
+            20,          // total_data_files (int8)
+        ],
         "pg_input_error_info" => vec![PG_TEXT_OID, PG_TEXT_OID, PG_TEXT_OID, PG_TEXT_OID],
         _ => vec![PG_TEXT_OID],
     };

--- a/tests/iceberg_fixtures.rs
+++ b/tests/iceberg_fixtures.rs
@@ -1,0 +1,460 @@
+#![cfg(not(target_arch = "wasm32"))]
+#![allow(dead_code)]
+
+use parquet::data_type::{ByteArray, ByteArrayType, DoubleType, Int64Type};
+use parquet::file::writer::SerializedFileWriter;
+use parquet::file::properties::WriterProperties;
+use parquet::schema::parser::parse_message_type;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub type FixtureResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+const BASE_TIMESTAMP_MS: i64 = 1_700_000_000_000; // ~Nov 2023
+
+pub struct IcebergFixtureSet {
+    pub root: PathBuf,
+    pub deribit_trades: PathBuf,
+    pub deribit_ohlcv: PathBuf,
+    pub deribit_options: PathBuf,
+    pub multi_schema: PathBuf,
+}
+
+impl IcebergFixtureSet {
+    pub fn create() -> FixtureResult<Self> {
+        let root = std::env::temp_dir().join(format!("openassay-iceberg-{}", std::process::id()));
+        if root.exists() {
+            fs::remove_dir_all(&root)?;
+        }
+        fs::create_dir_all(&root)?;
+
+        let deribit_trades = root.join("deribit_trades");
+        let deribit_ohlcv = root.join("deribit_ohlcv");
+        let deribit_options = root.join("deribit_options");
+        let multi_schema = root.join("multi_schema");
+
+        create_trades_table(&deribit_trades, 120, 2)?;
+        create_ohlcv_table(&deribit_ohlcv, 60)?;
+        create_options_table(&deribit_options, 40)?;
+        create_multi_schema_table(&multi_schema)?;
+
+        Ok(Self {
+            root,
+            deribit_trades,
+            deribit_ohlcv,
+            deribit_options,
+            multi_schema,
+        })
+    }
+
+    pub fn cleanup(&self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+impl Drop for IcebergFixtureSet {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+fn create_table_dirs(table_root: &Path) -> FixtureResult<(PathBuf, PathBuf)> {
+    let metadata_dir = table_root.join("metadata");
+    let data_dir = table_root.join("data");
+    fs::create_dir_all(&metadata_dir)?;
+    fs::create_dir_all(&data_dir)?;
+    Ok((metadata_dir, data_dir))
+}
+
+// ── Trade rows ──
+
+struct TradeRow {
+    timestamp: i64,
+    instrument: String,
+    price: f64,
+    amount: f64,
+    direction: String,
+    iv: Option<f64>,
+    index_price: f64,
+    trade_id: String,
+}
+
+fn generate_trade_rows(count: usize) -> Vec<TradeRow> {
+    (0..count)
+        .map(|idx| {
+            let is_btc = idx % 2 == 0;
+            let timestamp = BASE_TIMESTAMP_MS + i64::try_from(idx).unwrap_or(0) * 60_000;
+            let direction = if idx % 3 == 0 { "sell" } else { "buy" };
+
+            let (price, amount, iv, index_price, trade_id) = if is_btc {
+                let price = 60_000.0
+                    + f64::from((idx * 37 % 5_000) as u32)
+                    + f64::from((idx % 11) as u32) * 0.17;
+                let amount = 0.1 + f64::from((idx * 17 % 100) as u32) / 10.0;
+                let iv = if idx % 11 == 0 { None } else { Some(0.5 + f64::from((idx * 7 % 50) as u32) / 100.0) };
+                let index_price = 60_000.0 + f64::from((idx * 41 % 4_000) as u32);
+                let trade_id = format!("BTC-PERPETUAL-{}", 12_345 + idx);
+                (price, amount, iv, index_price, trade_id)
+            } else {
+                let price = 3_200.0 + f64::from((idx * 13 % 300) as u32) + f64::from((idx % 7) as u32) * 0.09;
+                let amount = 1.0 + f64::from((idx * 23 % 990) as u32) / 10.0;
+                let iv = if idx % 7 == 0 { None } else { Some(0.4 + f64::from((idx * 11 % 60) as u32) / 100.0) };
+                let index_price = 3_200.0 + f64::from((idx * 19 % 200) as u32);
+                let trade_id = format!("ETH-PERPETUAL-{}", 67_890 + idx);
+                (price, amount, iv, index_price, trade_id)
+            };
+
+            TradeRow {
+                timestamp,
+                instrument: if is_btc { "BTC-PERPETUAL".to_string() } else { "ETH-PERPETUAL".to_string() },
+                price,
+                amount,
+                direction: direction.to_string(),
+                iv,
+                index_price,
+                trade_id,
+            }
+        })
+        .collect()
+}
+
+fn create_trades_table(
+    table_root: &Path,
+    row_count: usize,
+    file_count: usize,
+) -> FixtureResult<()> {
+    let (metadata_dir, data_dir) = create_table_dirs(table_root)?;
+    let rows = generate_trade_rows(row_count);
+    let file_count = file_count.max(1);
+    let chunk_size = (rows.len() + file_count - 1) / file_count;
+
+    let schema_str = "message trades {
+        REQUIRED INT64 timestamp;
+        REQUIRED BYTE_ARRAY instrument (UTF8);
+        REQUIRED DOUBLE price;
+        REQUIRED DOUBLE amount;
+        REQUIRED BYTE_ARRAY direction (UTF8);
+        OPTIONAL DOUBLE iv;
+        REQUIRED DOUBLE index_price;
+        REQUIRED BYTE_ARRAY trade_id (UTF8);
+    }";
+    let schema = Arc::new(parse_message_type(schema_str)?);
+
+    for (file_idx, chunk) in rows.chunks(chunk_size).enumerate() {
+        let file_path = data_dir.join(format!("trades_{file_idx:04}.parquet"));
+        let file = fs::File::create(&file_path)?;
+        let props = WriterProperties::builder().build();
+        let mut writer = SerializedFileWriter::new(file, schema.clone(), Arc::new(props))?;
+
+        let mut row_group = writer.next_row_group()?;
+
+        // timestamp
+        let mut col = row_group.next_column()?.unwrap();
+        let vals: Vec<i64> = chunk.iter().map(|r| r.timestamp).collect();
+        col.typed::<Int64Type>().write_batch(&vals, None, None)?;
+        col.close()?;
+
+        // instrument
+        let mut col = row_group.next_column()?.unwrap();
+        let vals: Vec<ByteArray> = chunk.iter().map(|r| ByteArray::from(r.instrument.as_str())).collect();
+        col.typed::<ByteArrayType>().write_batch(&vals, None, None)?;
+        col.close()?;
+
+        // price
+        let mut col = row_group.next_column()?.unwrap();
+        let vals: Vec<f64> = chunk.iter().map(|r| r.price).collect();
+        col.typed::<DoubleType>().write_batch(&vals, None, None)?;
+        col.close()?;
+
+        // amount
+        let mut col = row_group.next_column()?.unwrap();
+        let vals: Vec<f64> = chunk.iter().map(|r| r.amount).collect();
+        col.typed::<DoubleType>().write_batch(&vals, None, None)?;
+        col.close()?;
+
+        // direction
+        let mut col = row_group.next_column()?.unwrap();
+        let vals: Vec<ByteArray> = chunk.iter().map(|r| ByteArray::from(r.direction.as_str())).collect();
+        col.typed::<ByteArrayType>().write_batch(&vals, None, None)?;
+        col.close()?;
+
+        // iv (optional)
+        let mut col = row_group.next_column()?.unwrap();
+        let vals: Vec<f64> = chunk.iter().map(|r| r.iv.unwrap_or(0.0)).collect();
+        let def_levels: Vec<i16> = chunk.iter().map(|r| if r.iv.is_some() { 1 } else { 0 }).collect();
+        col.typed::<DoubleType>().write_batch(&vals, Some(&def_levels), None)?;
+        col.close()?;
+
+        // index_price
+        let mut col = row_group.next_column()?.unwrap();
+        let vals: Vec<f64> = chunk.iter().map(|r| r.index_price).collect();
+        col.typed::<DoubleType>().write_batch(&vals, None, None)?;
+        col.close()?;
+
+        // trade_id
+        let mut col = row_group.next_column()?.unwrap();
+        let vals: Vec<ByteArray> = chunk.iter().map(|r| ByteArray::from(r.trade_id.as_str())).collect();
+        col.typed::<ByteArrayType>().write_batch(&vals, None, None)?;
+        col.close()?;
+
+        row_group.close()?;
+        writer.close()?;
+    }
+
+    // Write Iceberg metadata
+    let metadata = json!({
+        "format-version": 2,
+        "table-uuid": "test-trades-uuid-001",
+        "current-schema-id": 0,
+        "schemas": [{
+            "schema-id": 0,
+            "fields": [
+                {"id": 1, "name": "timestamp", "type": "long", "required": true},
+                {"id": 2, "name": "instrument", "type": "string", "required": true},
+                {"id": 3, "name": "price", "type": "double", "required": true},
+                {"id": 4, "name": "amount", "type": "double", "required": true},
+                {"id": 5, "name": "direction", "type": "string", "required": true},
+                {"id": 6, "name": "iv", "type": "double", "required": false},
+                {"id": 7, "name": "index_price", "type": "double", "required": true},
+                {"id": 8, "name": "trade_id", "type": "string", "required": true}
+            ]
+        }],
+        "partition-specs": [],
+        "snapshots": []
+    });
+    fs::write(
+        metadata_dir.join("v1.metadata.json"),
+        serde_json::to_string_pretty(&metadata)?,
+    )?;
+
+    Ok(())
+}
+
+fn create_ohlcv_table(table_root: &Path, row_count: usize) -> FixtureResult<()> {
+    let (metadata_dir, data_dir) = create_table_dirs(table_root)?;
+
+    let schema_str = "message ohlcv {
+        REQUIRED INT64 tick;
+        REQUIRED DOUBLE open;
+        REQUIRED DOUBLE high;
+        REQUIRED DOUBLE low;
+        REQUIRED DOUBLE close;
+        REQUIRED DOUBLE volume;
+    }";
+    let schema = Arc::new(parse_message_type(schema_str)?);
+    let file = fs::File::create(data_dir.join("ohlcv_0000.parquet"))?;
+    let props = WriterProperties::builder().build();
+    let mut writer = SerializedFileWriter::new(file, schema, Arc::new(props))?;
+    let mut rg = writer.next_row_group()?;
+
+    let ticks: Vec<i64> = (0..row_count).map(|i| BASE_TIMESTAMP_MS + i64::try_from(i).unwrap_or(0) * 3_600_000).collect();
+    let opens: Vec<f64> = (0..row_count).map(|i| 60_000.0 + f64::from((i * 31 % 3_000) as u32)).collect();
+    let highs: Vec<f64> = opens.iter().enumerate().map(|(i, o)| o + f64::from((i * 7 % 500 + 100) as u32)).collect();
+    let lows: Vec<f64> = opens.iter().enumerate().map(|(i, o)| o - f64::from((i * 11 % 400 + 50) as u32)).collect();
+    let closes: Vec<f64> = opens.iter().enumerate().map(|(i, o)| o + f64::from((i * 3 % 200) as u32) - 100.0).collect();
+    let volumes: Vec<f64> = (0..row_count).map(|i| 100.0 + f64::from((i * 53 % 900) as u32)).collect();
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&ticks, None, None)?;
+    col.close()?;
+
+    for vals in [&opens, &highs, &lows, &closes, &volumes] {
+        let mut col = rg.next_column()?.unwrap();
+        col.typed::<DoubleType>().write_batch(vals, None, None)?;
+        col.close()?;
+    }
+
+    rg.close()?;
+    writer.close()?;
+
+    let metadata = json!({
+        "format-version": 2,
+        "table-uuid": "test-ohlcv-uuid-001",
+        "current-schema-id": 0,
+        "schemas": [{"schema-id": 0, "fields": [
+            {"id": 1, "name": "tick", "type": "long", "required": true},
+            {"id": 2, "name": "open", "type": "double", "required": true},
+            {"id": 3, "name": "high", "type": "double", "required": true},
+            {"id": 4, "name": "low", "type": "double", "required": true},
+            {"id": 5, "name": "close", "type": "double", "required": true},
+            {"id": 6, "name": "volume", "type": "double", "required": true}
+        ]}],
+        "partition-specs": [],
+        "snapshots": []
+    });
+    fs::write(metadata_dir.join("v1.metadata.json"), serde_json::to_string_pretty(&metadata)?)?;
+    Ok(())
+}
+
+fn create_options_table(table_root: &Path, row_count: usize) -> FixtureResult<()> {
+    let (metadata_dir, data_dir) = create_table_dirs(table_root)?;
+
+    let schema_str = "message options {
+        REQUIRED INT64 timestamp;
+        REQUIRED BYTE_ARRAY instrument (UTF8);
+        REQUIRED DOUBLE strike;
+        REQUIRED BYTE_ARRAY option_type (UTF8);
+        REQUIRED DOUBLE mark_price;
+        REQUIRED DOUBLE mark_iv;
+        REQUIRED DOUBLE underlying_price;
+        REQUIRED DOUBLE delta;
+        REQUIRED DOUBLE gamma;
+        REQUIRED DOUBLE vega;
+        REQUIRED DOUBLE theta;
+        REQUIRED DOUBLE open_interest;
+    }";
+    let schema = Arc::new(parse_message_type(schema_str)?);
+    let file = fs::File::create(data_dir.join("options_0000.parquet"))?;
+    let props = WriterProperties::builder().build();
+    let mut writer = SerializedFileWriter::new(file, schema, Arc::new(props))?;
+    let mut rg = writer.next_row_group()?;
+
+    let timestamps: Vec<i64> = (0..row_count).map(|i| BASE_TIMESTAMP_MS + i64::try_from(i).unwrap_or(0) * 300_000).collect();
+    let instruments: Vec<ByteArray> = (0..row_count).map(|i| {
+        let strike = 50_000 + (i * 1000 % 20_000);
+        let opt_type = if i % 2 == 0 { "C" } else { "P" };
+        ByteArray::from(format!("BTC-28MAR25-{strike}-{opt_type}").as_str())
+    }).collect();
+    let strikes: Vec<f64> = (0..row_count).map(|i| 50_000.0 + f64::from((i * 1000 % 20_000) as u32)).collect();
+    let option_types: Vec<ByteArray> = (0..row_count).map(|i| ByteArray::from(if i % 2 == 0 { "call" } else { "put" })).collect();
+    let mark_prices: Vec<f64> = (0..row_count).map(|i| 0.05 + f64::from((i * 7 % 20) as u32) / 100.0).collect();
+    let mark_ivs: Vec<f64> = (0..row_count).map(|i| 0.4 + f64::from((i * 11 % 30) as u32) / 100.0).collect();
+    let underlying_prices: Vec<f64> = (0..row_count).map(|i| 60_000.0 + f64::from((i * 41 % 2_000) as u32)).collect();
+    let deltas: Vec<f64> = (0..row_count).map(|i| if i % 2 == 0 { 0.3 + f64::from((i % 5) as u32) / 10.0 } else { -0.3 - f64::from((i % 5) as u32) / 10.0 }).collect();
+    let gammas: Vec<f64> = (0..row_count).map(|i| 0.00001 + f64::from((i % 10) as u32) / 1_000_000.0).collect();
+    let vegas: Vec<f64> = (0..row_count).map(|i| 50.0 + f64::from((i * 13 % 100) as u32)).collect();
+    let thetas: Vec<f64> = (0..row_count).map(|i| -(10.0 + f64::from((i * 7 % 50) as u32))).collect();
+    let open_interests: Vec<f64> = (0..row_count).map(|i| 100.0 + f64::from((i * 37 % 900) as u32)).collect();
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&timestamps, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<ByteArrayType>().write_batch(&instruments, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<DoubleType>().write_batch(&strikes, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<ByteArrayType>().write_batch(&option_types, None, None)?;
+    col.close()?;
+
+    for vals in [&mark_prices, &mark_ivs, &underlying_prices, &deltas, &gammas, &vegas, &thetas, &open_interests] {
+        let mut col = rg.next_column()?.unwrap();
+        col.typed::<DoubleType>().write_batch(vals, None, None)?;
+        col.close()?;
+    }
+
+    rg.close()?;
+    writer.close()?;
+
+    let metadata = json!({
+        "format-version": 2,
+        "table-uuid": "test-options-uuid-001",
+        "current-schema-id": 0,
+        "schemas": [{"schema-id": 0, "fields": [
+            {"id": 1, "name": "timestamp", "type": "long", "required": true},
+            {"id": 2, "name": "instrument", "type": "string", "required": true},
+            {"id": 3, "name": "strike", "type": "double", "required": true},
+            {"id": 4, "name": "option_type", "type": "string", "required": true},
+            {"id": 5, "name": "mark_price", "type": "double", "required": true},
+            {"id": 6, "name": "mark_iv", "type": "double", "required": true},
+            {"id": 7, "name": "underlying_price", "type": "double", "required": true},
+            {"id": 8, "name": "delta", "type": "double", "required": true},
+            {"id": 9, "name": "gamma", "type": "double", "required": true},
+            {"id": 10, "name": "vega", "type": "double", "required": true},
+            {"id": 11, "name": "theta", "type": "double", "required": true},
+            {"id": 12, "name": "open_interest", "type": "double", "required": true}
+        ]}],
+        "partition-specs": [],
+        "snapshots": []
+    });
+    fs::write(metadata_dir.join("v1.metadata.json"), serde_json::to_string_pretty(&metadata)?)?;
+    Ok(())
+}
+
+fn create_multi_schema_table(table_root: &Path) -> FixtureResult<()> {
+    let (metadata_dir, data_dir) = create_table_dirs(table_root)?;
+
+    // File 1: schema v1 (2 columns)
+    let schema1_str = "message v1 {
+        REQUIRED INT64 id;
+        REQUIRED INT64 value;
+    }";
+    let schema1 = Arc::new(parse_message_type(schema1_str)?);
+    let file = fs::File::create(data_dir.join("v1_0000.parquet"))?;
+    let props = WriterProperties::builder().build();
+    let mut writer = SerializedFileWriter::new(file, schema1, Arc::new(props))?;
+    let mut rg = writer.next_row_group()?;
+
+    let ids: Vec<i64> = vec![1, 2, 3, 4, 5];
+    let values: Vec<i64> = vec![10, 20, 30, 40, 50];
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&ids, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&values, None, None)?;
+    col.close()?;
+
+    rg.close()?;
+    writer.close()?;
+
+    // File 2: schema v2 (3 columns — added 'updated_at')
+    let schema2_str = "message v2 {
+        REQUIRED INT64 id;
+        REQUIRED INT64 value;
+        REQUIRED INT64 updated_at;
+    }";
+    let schema2 = Arc::new(parse_message_type(schema2_str)?);
+    let file = fs::File::create(data_dir.join("v2_0000.parquet"))?;
+    let props = WriterProperties::builder().build();
+    let mut writer = SerializedFileWriter::new(file, schema2, Arc::new(props))?;
+    let mut rg = writer.next_row_group()?;
+
+    let ids: Vec<i64> = vec![6, 7, 8];
+    let values: Vec<i64> = vec![60, 70, 80];
+    let updated_at: Vec<i64> = vec![BASE_TIMESTAMP_MS, BASE_TIMESTAMP_MS + 1000, BASE_TIMESTAMP_MS + 2000];
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&ids, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&values, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&updated_at, None, None)?;
+    col.close()?;
+
+    rg.close()?;
+    writer.close()?;
+
+    let metadata = json!({
+        "format-version": 2,
+        "table-uuid": "test-multi-schema-uuid-001",
+        "current-schema-id": 1,
+        "schemas": [
+            {"schema-id": 0, "fields": [
+                {"id": 1, "name": "id", "type": "long", "required": true},
+                {"id": 2, "name": "value", "type": "long", "required": true}
+            ]},
+            {"schema-id": 1, "fields": [
+                {"id": 1, "name": "id", "type": "long", "required": true},
+                {"id": 2, "name": "value", "type": "long", "required": true},
+                {"id": 3, "name": "updated_at", "type": "long", "required": true}
+            ]}
+        ],
+        "partition-specs": [],
+        "snapshots": []
+    });
+    fs::write(metadata_dir.join("v1.metadata.json"), serde_json::to_string_pretty(&metadata)?)?;
+    Ok(())
+}

--- a/tests/iceberg_tests.rs
+++ b/tests/iceberg_tests.rs
@@ -1,0 +1,369 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+mod iceberg_fixtures;
+
+use iceberg_fixtures::IcebergFixtureSet;
+use openassay::parser::sql_parser::parse_statement;
+use openassay::storage::tuple::ScalarValue;
+use openassay::tcop::engine::{EngineError, QueryResult, execute_planned_query, plan_statement};
+use std::future::Future;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+fn iceberg_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn with_isolated_state<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = iceberg_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    f()
+}
+
+fn run_statement_result(sql: &str) -> Result<QueryResult, EngineError> {
+    block_on(async {
+        let stmt = parse_statement(sql).expect("parse should succeed");
+        let planned = plan_statement(stmt).expect("plan should succeed");
+        execute_planned_query(&planned, &[]).await
+    })
+}
+
+fn run_statement(sql: &str) -> QueryResult {
+    run_statement_result(sql).expect("query should succeed")
+}
+
+fn block_on<F: Future<Output = T>, T>(f: F) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+fn sql_path_literal(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+struct FixtureGuard {
+    fixtures: IcebergFixtureSet,
+}
+
+impl FixtureGuard {
+    fn create() -> Self {
+        Self {
+            fixtures: IcebergFixtureSet::create().expect("fixtures should create"),
+        }
+    }
+}
+
+// ── Basic scan tests ──
+
+#[test]
+fn iceberg_scan_trades_returns_rows() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT * FROM iceberg_scan('{}')",
+            sql_path_literal(&guard.fixtures.deribit_trades)
+        );
+        let result = run_statement(&sql);
+        assert!(result.rows.len() >= 100, "expected 100+ trade rows, got {}", result.rows.len());
+        assert_eq!(result.columns.len(), 8); // timestamp, instrument, price, amount, direction, iv, index_price, trade_id
+    });
+}
+
+#[test]
+fn iceberg_scan_ohlcv_returns_rows() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT * FROM iceberg_scan('{}')",
+            sql_path_literal(&guard.fixtures.deribit_ohlcv)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 60, "expected 60 OHLCV rows");
+        assert_eq!(result.columns.len(), 6); // tick, open, high, low, close, volume
+    });
+}
+
+#[test]
+fn iceberg_scan_options_returns_rows() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT * FROM iceberg_scan('{}')",
+            sql_path_literal(&guard.fixtures.deribit_options)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 40, "expected 40 option rows");
+        assert_eq!(result.columns.len(), 12);
+    });
+}
+
+// ── WHERE / ORDER BY / LIMIT ──
+
+#[test]
+fn iceberg_scan_with_where_clause() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT instrument, price, amount FROM iceberg_scan('{}') WHERE instrument = 'BTC-PERPETUAL' AND price > 62000",
+            sql_path_literal(&guard.fixtures.deribit_trades)
+        );
+        let result = run_statement(&sql);
+        assert!(result.rows.len() > 0, "expected filtered trade rows");
+        for row in &result.rows {
+            assert_eq!(row[0], ScalarValue::Text("BTC-PERPETUAL".to_string()));
+            if let ScalarValue::Float(p) = &row[1] {
+                assert!(*p > 62_000.0);
+            }
+        }
+    });
+}
+
+#[test]
+fn iceberg_scan_with_order_by_limit() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT price FROM iceberg_scan('{}') WHERE instrument = 'BTC-PERPETUAL' ORDER BY price DESC LIMIT 5",
+            sql_path_literal(&guard.fixtures.deribit_trades)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 5);
+        // Verify descending order
+        for i in 0..4 {
+            let a = match &result.rows[i][0] { ScalarValue::Float(v) => *v, _ => panic!("expected float") };
+            let b = match &result.rows[i + 1][0] { ScalarValue::Float(v) => *v, _ => panic!("expected float") };
+            assert!(a >= b, "expected descending order: {a} >= {b}");
+        }
+    });
+}
+
+// ── Aggregation ──
+
+#[test]
+fn iceberg_scan_with_count() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT count(*) FROM iceberg_scan('{}')",
+            sql_path_literal(&guard.fixtures.deribit_trades)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 1);
+        if let ScalarValue::Int(n) = &result.rows[0][0] {
+            assert!(*n >= 100, "expected 100+ rows, got {n}");
+        }
+    });
+}
+
+#[test]
+fn iceberg_scan_with_group_by() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT instrument, count(*), avg(price) FROM iceberg_scan('{}') GROUP BY instrument ORDER BY instrument",
+            sql_path_literal(&guard.fixtures.deribit_trades)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 2); // BTC-PERPETUAL, ETH-PERPETUAL
+        assert_eq!(result.rows[0][0], ScalarValue::Text("BTC-PERPETUAL".to_string()));
+        assert_eq!(result.rows[1][0], ScalarValue::Text("ETH-PERPETUAL".to_string()));
+    });
+}
+
+#[test]
+fn iceberg_scan_vwap() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT instrument, sum(price * amount) / sum(amount) AS vwap FROM iceberg_scan('{}') GROUP BY instrument ORDER BY instrument",
+            sql_path_literal(&guard.fixtures.deribit_trades)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 2);
+        // BTC VWAP should be in 60k range
+        if let ScalarValue::Float(vwap) = &result.rows[0][1] {
+            assert!(*vwap > 55_000.0 && *vwap < 70_000.0, "BTC VWAP out of range: {vwap}");
+        }
+    });
+}
+
+#[test]
+fn iceberg_scan_buy_sell_ratio() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT direction, count(*), sum(amount) FROM iceberg_scan('{}') GROUP BY direction ORDER BY direction",
+            sql_path_literal(&guard.fixtures.deribit_trades)
+        );
+        let result = run_statement(&sql);
+        assert!(result.rows.len() >= 2, "expected buy and sell groups");
+    });
+}
+
+// ── JOIN ──
+
+#[test]
+fn iceberg_scan_cross_table_join() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT count(*) FROM iceberg_scan('{}') AS t JOIN iceberg_scan('{}') AS o ON t.price BETWEEN o.low AND o.high",
+            sql_path_literal(&guard.fixtures.deribit_trades),
+            sql_path_literal(&guard.fixtures.deribit_ohlcv)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 1);
+    });
+}
+
+// ── Schema evolution ──
+
+#[test]
+fn iceberg_scan_multi_schema_reads_all_files() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT count(*) FROM iceberg_scan('{}')",
+            sql_path_literal(&guard.fixtures.multi_schema)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 1);
+        if let ScalarValue::Int(n) = &result.rows[0][0] {
+            assert_eq!(*n, 8, "expected 5 + 3 = 8 rows from multi-schema");
+        }
+    });
+}
+
+#[test]
+fn iceberg_scan_multi_schema_column_union() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT id, value FROM iceberg_scan('{}') ORDER BY id",
+            sql_path_literal(&guard.fixtures.multi_schema)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 8);
+        // First row should have id=1
+        assert_eq!(result.rows[0][0], ScalarValue::Int(1));
+        assert_eq!(result.rows[0][1], ScalarValue::Int(10));
+    });
+}
+
+// ── Error cases ──
+
+#[test]
+fn iceberg_scan_nonexistent_path_errors() {
+    with_isolated_state(|| {
+        let missing = std::env::temp_dir().join("openassay-no-such-iceberg-table");
+        let sql = format!(
+            "SELECT * FROM iceberg_scan('{}')",
+            sql_path_literal(&missing)
+        );
+        let err = run_statement_result(&sql).expect_err("query should fail");
+        assert!(
+            err.message.contains("no parquet files found")
+                || err.message.contains("not found")
+                || err.message.contains("does not exist")
+                || err.message.contains("expects an existing"),
+            "unexpected error: {}",
+            err.message
+        );
+    });
+}
+
+#[test]
+fn iceberg_scan_empty_directory_errors() {
+    with_isolated_state(|| {
+        let empty_dir = std::env::temp_dir().join(format!(
+            "openassay-empty-iceberg-{}",
+            std::process::id()
+        ));
+        if empty_dir.exists() {
+            std::fs::remove_dir_all(&empty_dir).ok();
+        }
+        std::fs::create_dir_all(&empty_dir).expect("empty dir should create");
+
+        let sql = format!(
+            "SELECT * FROM iceberg_scan('{}')",
+            sql_path_literal(&empty_dir)
+        );
+        let err = run_statement_result(&sql).expect_err("query should fail");
+        assert!(
+            err.message.contains("no parquet files found"),
+            "unexpected error: {}",
+            err.message
+        );
+
+        std::fs::remove_dir_all(&empty_dir).ok();
+    });
+}
+
+// ── Options table queries ──
+
+#[test]
+fn iceberg_scan_options_greeks_query() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT instrument, strike, option_type, delta, gamma, vega, theta FROM iceberg_scan('{}') ORDER BY strike LIMIT 10",
+            sql_path_literal(&guard.fixtures.deribit_options)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.rows.len(), 10);
+        assert_eq!(result.columns.len(), 7);
+    });
+}
+
+// ── iceberg_metadata ──
+
+#[test]
+fn iceberg_metadata_returns_table_info() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT * FROM iceberg_metadata('{}')",
+            sql_path_literal(&guard.fixtures.deribit_trades)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(
+            result.columns,
+            vec![
+                "table_uuid",
+                "format_version",
+                "last_updated",
+                "current_schema_id",
+                "partition_spec",
+                "snapshot_count",
+                "total_data_files"
+            ]
+        );
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0][1], ScalarValue::Int(2));
+        assert_eq!(result.rows[0][3], ScalarValue::Int(0));
+        assert_eq!(result.rows[0][5], ScalarValue::Int(0));
+        assert_eq!(result.rows[0][6], ScalarValue::Int(2));
+    });
+}
+
+#[test]
+fn iceberg_metadata_from_metadata_file() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let metadata_file = guard.fixtures.deribit_trades.join("metadata/v1.metadata.json");
+        let sql = format!(
+            "SELECT format_version, total_data_files FROM iceberg_metadata('{}')",
+            sql_path_literal(&metadata_file)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(
+            result.rows,
+            vec![vec![ScalarValue::Int(2), ScalarValue::Int(2)]]
+        );
+    });
+}


### PR DESCRIPTION
## Iceberg Tests

17 comprehensive tests for iceberg_scan() and new iceberg_metadata() function.

### Fixture Sets (crypto market data)
- **deribit_trades**: 120 rows across 2 parquet files (BTC/ETH perpetuals)
- **deribit_ohlcv**: 60 hourly candles
- **deribit_options**: 40 options with full greeks (delta, gamma, vega, theta)
- **multi_schema**: Schema evolution test (2 files with different column counts)

### Tests (17/17 passing)
- Basic scan: trades, OHLCV, options roundtrip
- WHERE + ORDER BY + LIMIT filtering
- Aggregation: count, GROUP BY, VWAP, buy/sell ratio
- Cross-table JOIN (trades × OHLCV price ranges)
- Schema evolution: column union across files with different schemas
- Error cases: nonexistent path, empty directory
- Options greeks query with all 12 columns
- iceberg_metadata(): table UUID, format version, schema ID, partition spec, file count

### New Features
- `iceberg_metadata(path)` table function — returns 7 columns of Iceberg table info
- Parquet decimal formatting: proper i128 big-endian to scaled string
- TUI autocomplete for iceberg_scan/iceberg_metadata

### No regressions
- All 726 lib tests pass
- All 17 iceberg tests pass

+1,001 lines