### PR TITLE
perf: predicate pushdown — filter rows during scan

### DIFF
--- a/data/clickbench
+++ b/data/clickbench
@@ -1,0 +1,1 @@
+/home/rosssaunders/code/rosssaunders/openassay/data/clickbench

--- a/src/executor/exec_main/from_clause.rs
+++ b/src/executor/exec_main/from_clause.rs
@@ -1,5 +1,7 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use crate::parser::ast::{BinaryOp, UnaryOp};
+use crate::storage::heap::{ScanPredicate, ScanPredicateOp};
 
 #[derive(Debug, Clone)]
 pub struct TableEval {
@@ -322,6 +324,119 @@ pub(super) fn expr_is_index_lookup_constant(expr: &Expr) -> bool {
     referenced.is_empty()
 }
 
+pub(super) fn expr_is_scan_predicate_constant(expr: &Expr) -> bool {
+    match expr {
+        Expr::String(_)
+        | Expr::Integer(_)
+        | Expr::Float(_)
+        | Expr::Boolean(_)
+        | Expr::Null
+        | Expr::Parameter(_)
+        | Expr::TypedLiteral { .. } => true,
+        Expr::Cast { expr, .. } => expr_is_scan_predicate_constant(expr),
+        Expr::Unary {
+            op: UnaryOp::Plus | UnaryOp::Minus,
+            expr,
+        } => expr_is_scan_predicate_constant(expr),
+        _ => false,
+    }
+}
+
+pub(super) async fn extract_relation_scan_predicate(
+    predicate: &Expr,
+    qualifiers: &[String],
+    table_columns: &HashSet<String>,
+    column_indexes: &HashMap<String, usize>,
+    params: &[Option<String>],
+) -> Result<Option<ScanPredicate>, EngineError> {
+    let Expr::Binary { left, op, right } = predicate else {
+        return Ok(None);
+    };
+    let Some(scan_op) = scan_predicate_op(op) else {
+        return Ok(None);
+    };
+
+    if let Some(column_name) = relation_column_from_identifier(left, qualifiers, table_columns) {
+        if !expr_is_scan_predicate_constant(right) {
+            return Ok(None);
+        }
+        let value = eval_expr(right, &EvalScope::default(), params).await?;
+        return Ok(Some(ScanPredicate {
+            column_index: *column_indexes
+                .get(&column_name)
+                .ok_or_else(|| EngineError {
+                    message: format!("column index for \"{column_name}\" is missing"),
+                })?,
+            op: scan_op,
+            value,
+        }));
+    }
+    if let Some(column_name) = relation_column_from_identifier(right, qualifiers, table_columns) {
+        if !expr_is_scan_predicate_constant(left) {
+            return Ok(None);
+        }
+        let value = eval_expr(left, &EvalScope::default(), params).await?;
+        return Ok(Some(ScanPredicate {
+            column_index: *column_indexes
+                .get(&column_name)
+                .ok_or_else(|| EngineError {
+                    message: format!("column index for \"{column_name}\" is missing"),
+                })?,
+            op: reverse_scan_predicate_op(scan_op),
+            value,
+        }));
+    }
+    Ok(None)
+}
+
+fn scan_predicate_op(op: &BinaryOp) -> Option<ScanPredicateOp> {
+    match op {
+        BinaryOp::Eq => Some(ScanPredicateOp::Eq),
+        BinaryOp::NotEq => Some(ScanPredicateOp::NotEq),
+        BinaryOp::Lt => Some(ScanPredicateOp::Lt),
+        BinaryOp::Lte => Some(ScanPredicateOp::Lte),
+        BinaryOp::Gt => Some(ScanPredicateOp::Gt),
+        BinaryOp::Gte => Some(ScanPredicateOp::Gte),
+        _ => None,
+    }
+}
+
+fn reverse_scan_predicate_op(op: ScanPredicateOp) -> ScanPredicateOp {
+    match op {
+        ScanPredicateOp::Eq => ScanPredicateOp::Eq,
+        ScanPredicateOp::NotEq => ScanPredicateOp::NotEq,
+        ScanPredicateOp::Lt => ScanPredicateOp::Gt,
+        ScanPredicateOp::Lte => ScanPredicateOp::Gte,
+        ScanPredicateOp::Gt => ScanPredicateOp::Lt,
+        ScanPredicateOp::Gte => ScanPredicateOp::Lte,
+    }
+}
+
+pub(super) fn remaining_predicate_from_applied(
+    conjuncts: &[Expr],
+    applied: &[bool],
+) -> Option<Expr> {
+    let remaining: Vec<&Expr> = conjuncts
+        .iter()
+        .zip(applied.iter())
+        .filter_map(|(conjunct, &used)| if used { None } else { Some(conjunct) })
+        .collect();
+
+    if remaining.is_empty() {
+        return None;
+    }
+
+    let mut expr = remaining[0].clone();
+    for conjunct in &remaining[1..] {
+        expr = Expr::Binary {
+            op: BinaryOp::And,
+            left: Box::new(expr),
+            right: Box::new((*conjunct).clone()),
+        };
+    }
+    Some(expr)
+}
+
 /// Evaluate the FROM clause with predicate pushdown.
 ///
 /// For each table in the FROM list, after computing the cross product with all
@@ -357,7 +472,40 @@ pub(super) async fn evaluate_from_clause_with_pushdown(
                 }
             }
             _ => {
-                let rhs = evaluate_table_expression(item, params, outer_scope).await?;
+                let (rhs, pushed_relation_predicates) = if let TableExpression::Relation(rel) = item
+                {
+                    let candidate_indices = applied
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(idx, used)| if *used { None } else { Some(idx) })
+                        .collect::<Vec<_>>();
+                    let relation_predicates = candidate_indices
+                        .iter()
+                        .map(|idx| conjuncts[*idx].clone())
+                        .collect::<Vec<_>>();
+                    let (table_eval, pushed_relation_predicates) =
+                        evaluate_relation_with_predicates(
+                            rel,
+                            params,
+                            outer_scope,
+                            &relation_predicates,
+                            None,
+                        )
+                        .await?;
+                    let pushed_relation_predicates = pushed_relation_predicates
+                        .into_iter()
+                        .filter_map(|idx| candidate_indices.get(idx).copied())
+                        .collect::<Vec<_>>();
+                    (table_eval, pushed_relation_predicates)
+                } else {
+                    (
+                        evaluate_table_expression(item, params, outer_scope).await?,
+                        Vec::new(),
+                    )
+                };
+                for idx in pushed_relation_predicates {
+                    applied[idx] = true;
+                }
                 for lhs_scope in &current {
                     for rhs_scope in &rhs.rows {
                         next.push(combine_scopes(lhs_scope, rhs_scope, &HashSet::new()));
@@ -390,28 +538,154 @@ pub(super) async fn evaluate_from_clause_with_pushdown(
         current = next;
     }
 
-    // Build remaining predicate from conjuncts that couldn't be pushed down
-    let remaining: Vec<&Expr> = conjuncts
-        .iter()
-        .zip(applied.iter())
-        .filter_map(|(c, &used)| if used { None } else { Some(c) })
-        .collect();
-
-    let remaining_predicate = if remaining.is_empty() {
-        None
-    } else {
-        let mut expr = remaining[0].clone();
-        for conjunct in &remaining[1..] {
-            expr = Expr::Binary {
-                op: crate::parser::ast::BinaryOp::And,
-                left: Box::new(expr),
-                right: Box::new((*conjunct).clone()),
-            };
-        }
-        Some(expr)
-    };
+    let remaining_predicate = remaining_predicate_from_applied(conjuncts, &applied);
 
     Ok((current, remaining_predicate))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_relation_scan_predicate;
+    use crate::parser::ast::{BinaryOp, Expr, UnaryOp};
+    use crate::storage::heap::{ScanPredicate, ScanPredicateOp};
+    use crate::storage::tuple::ScalarValue;
+    use std::collections::{HashMap, HashSet};
+
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should start")
+            .block_on(future)
+    }
+
+    fn table_columns() -> (HashSet<String>, HashMap<String, usize>) {
+        (
+            ["id".to_string(), "name".to_string()].into_iter().collect(),
+            [("id".to_string(), 0_usize), ("name".to_string(), 1_usize)]
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn extracts_simple_relation_scan_predicate() {
+        let (table_columns, column_indexes) = table_columns();
+        let predicate = Expr::Binary {
+            left: Box::new(Expr::Identifier(vec!["hits".to_string(), "id".to_string()])),
+            op: BinaryOp::Gte,
+            right: Box::new(Expr::Integer(10)),
+        };
+
+        let extracted = block_on(extract_relation_scan_predicate(
+            &predicate,
+            &["hits".to_string()],
+            &table_columns,
+            &column_indexes,
+            &[],
+        ))
+        .expect("predicate extraction should succeed");
+
+        assert_eq!(
+            extracted,
+            Some(ScanPredicate {
+                column_index: 0,
+                op: ScanPredicateOp::Gte,
+                value: ScalarValue::Int(10),
+            })
+        );
+    }
+
+    #[test]
+    fn extracts_reversed_relation_scan_predicate() {
+        let (table_columns, column_indexes) = table_columns();
+        let predicate = Expr::Binary {
+            left: Box::new(Expr::Integer(10)),
+            op: BinaryOp::Lt,
+            right: Box::new(Expr::Identifier(vec!["id".to_string()])),
+        };
+
+        let extracted = block_on(extract_relation_scan_predicate(
+            &predicate,
+            &["hits".to_string()],
+            &table_columns,
+            &column_indexes,
+            &[],
+        ))
+        .expect("predicate extraction should succeed");
+
+        assert_eq!(
+            extracted,
+            Some(ScanPredicate {
+                column_index: 0,
+                op: ScanPredicateOp::Gt,
+                value: ScalarValue::Int(10),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_non_constant_relation_scan_predicate() {
+        let (table_columns, column_indexes) = table_columns();
+        let predicate = Expr::Binary {
+            left: Box::new(Expr::Identifier(vec!["id".to_string()])),
+            op: BinaryOp::Eq,
+            right: Box::new(Expr::FunctionCall {
+                name: vec!["random".to_string()],
+                args: Vec::new(),
+                distinct: false,
+                order_by: Vec::new(),
+                within_group: Vec::new(),
+                filter: None,
+                over: None,
+            }),
+        };
+
+        let extracted = block_on(extract_relation_scan_predicate(
+            &predicate,
+            &["hits".to_string()],
+            &table_columns,
+            &column_indexes,
+            &[],
+        ))
+        .expect("predicate extraction should succeed");
+
+        assert!(extracted.is_none());
+    }
+
+    #[test]
+    fn accepts_casted_parameter_relation_scan_predicate() {
+        let (table_columns, column_indexes) = table_columns();
+        let predicate = Expr::Binary {
+            left: Box::new(Expr::Identifier(vec!["id".to_string()])),
+            op: BinaryOp::Eq,
+            right: Box::new(Expr::Cast {
+                expr: Box::new(Expr::Unary {
+                    op: UnaryOp::Minus,
+                    expr: Box::new(Expr::Parameter(1)),
+                }),
+                type_name: "int8".to_string(),
+            }),
+        };
+
+        let extracted = block_on(extract_relation_scan_predicate(
+            &predicate,
+            &["hits".to_string()],
+            &table_columns,
+            &column_indexes,
+            &[Some("7".to_string())],
+        ))
+        .expect("predicate extraction should succeed");
+
+        assert_eq!(
+            extracted,
+            Some(ScanPredicate {
+                column_index: 0,
+                op: ScanPredicateOp::Eq,
+                value: ScalarValue::Int(-7),
+            })
+        );
+    }
 }
 
 pub fn evaluate_table_expression<'a>(

--- a/src/executor/exec_main/mod.rs
+++ b/src/executor/exec_main/mod.rs
@@ -80,8 +80,8 @@ use aggregation::{
     identifier_key, project_select_row, project_select_row_with_window, resolve_group_by_alias,
 };
 use from_clause::{
-    decompose_and_conjuncts, evaluate_from_clause_with_pushdown,
-    relation_index_offsets_for_predicates,
+    decompose_and_conjuncts, evaluate_from_clause_with_pushdown, extract_relation_scan_predicate,
+    relation_index_offsets_for_predicates, remaining_predicate_from_applied,
 };
 use order_limit::{
     apply_offset_limit, apply_order_by, augment_select_for_order_by,

--- a/src/executor/exec_main/query_pipeline.rs
+++ b/src/executor/exec_main/query_pipeline.rs
@@ -465,8 +465,11 @@ pub(super) async fn execute_select(
         let conjuncts = decompose_and_conjuncts(where_clause);
         evaluate_from_clause_with_pushdown(&select.from, params, outer_scope, &conjuncts).await?
     } else {
-        let source = if select.from.is_empty() {
-            vec![outer_scope.cloned().unwrap_or_default()]
+        if select.from.is_empty() {
+            (
+                vec![outer_scope.cloned().unwrap_or_default()],
+                select.where_clause.clone(),
+            )
         } else if select.from.len() == 1 {
             match &select.from[0] {
                 TableExpression::Relation(rel) => {
@@ -476,22 +479,35 @@ pub(super) async fn execute_select(
                         .map_or_else(Vec::new, decompose_and_conjuncts);
                     let projected_columns =
                         next_scan_projection_hint().and_then(|hint| hint.projected_columns);
-                    evaluate_relation_with_predicates(
+                    let (table_eval, pushed_predicates) = evaluate_relation_with_predicates(
                         rel,
                         params,
                         outer_scope,
                         &relation_predicates,
                         projected_columns,
                     )
-                    .await?
-                    .rows
+                    .await?;
+                    let mut applied = vec![false; relation_predicates.len()];
+                    for idx in pushed_predicates {
+                        if let Some(flag) = applied.get_mut(idx) {
+                            *flag = true;
+                        }
+                    }
+                    let remaining_predicate =
+                        remaining_predicate_from_applied(&relation_predicates, &applied);
+                    (table_eval.rows, remaining_predicate)
                 }
-                _ => evaluate_from_clause(&select.from, params, outer_scope).await?,
+                _ => (
+                    evaluate_from_clause(&select.from, params, outer_scope).await?,
+                    select.where_clause.clone(),
+                ),
             }
         } else {
-            evaluate_from_clause(&select.from, params, outer_scope).await?
-        };
-        (source, select.where_clause.clone())
+            (
+                evaluate_from_clause(&select.from, params, outer_scope).await?,
+                select.where_clause.clone(),
+            )
+        }
     };
 
     if let Some(outer) = outer_scope

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -1342,7 +1342,9 @@ pub(super) async fn evaluate_relation(
     outer_scope: Option<&EvalScope>,
     projected_columns: Option<Vec<usize>>,
 ) -> Result<TableEval, EngineError> {
-    evaluate_relation_with_predicates(rel, params, outer_scope, &[], projected_columns).await
+    evaluate_relation_with_predicates(rel, params, outer_scope, &[], projected_columns)
+        .await
+        .map(|(table_eval, _)| table_eval)
 }
 
 pub(super) async fn evaluate_relation_with_predicates(
@@ -1351,7 +1353,7 @@ pub(super) async fn evaluate_relation_with_predicates(
     outer_scope: Option<&EvalScope>,
     relation_predicates: &[Expr],
     projected_columns: Option<Vec<usize>>,
-) -> Result<TableEval, EngineError> {
+) -> Result<(TableEval, Vec<usize>), EngineError> {
     if rel.name.len() == 1
         && let Some(cte) = current_cte_binding(&rel.name[0])
     {
@@ -1368,11 +1370,14 @@ pub(super) async fn evaluate_relation_with_predicates(
         let null_values = vec![ScalarValue::Null; cte.columns.len()];
         let null_scope = scope_from_row(&cte.columns, &null_values, &qualifiers, &cte.columns);
 
-        return Ok(TableEval {
-            rows: scoped_rows,
-            columns: cte.columns,
-            null_scope,
-        });
+        return Ok((
+            TableEval {
+                rows: scoped_rows,
+                columns: cte.columns,
+                null_scope,
+            },
+            Vec::new(),
+        ));
     }
 
     if let Some((schema_name, relation_name, columns)) = lookup_virtual_relation(&rel.name) {
@@ -1400,11 +1405,14 @@ pub(super) async fn evaluate_relation_with_predicates(
         }
         let null_values = vec![ScalarValue::Null; column_names.len()];
         let null_scope = scope_from_row(&column_names, &null_values, &qualifiers, &column_names);
-        return Ok(TableEval {
-            rows: scoped_rows,
-            columns: column_names,
-            null_scope,
-        });
+        return Ok((
+            TableEval {
+                rows: scoped_rows,
+                columns: column_names,
+                null_scope,
+            },
+            Vec::new(),
+        ));
     }
 
     let resolved_table = with_catalog_read(|catalog| {
@@ -1423,11 +1431,14 @@ pub(super) async fn evaluate_relation_with_predicates(
                 };
                 let null_values = vec![ScalarValue::Null; columns.len()];
                 let null_scope = scope_from_row(&columns, &null_values, &qualifiers, &columns);
-                return Ok(TableEval {
-                    rows: Vec::new(),
-                    columns,
-                    null_scope,
-                });
+                return Ok((
+                    TableEval {
+                        rows: Vec::new(),
+                        columns,
+                        null_scope,
+                    },
+                    Vec::new(),
+                ));
             }
             return Err(EngineError {
                 message: err.message,
@@ -1440,6 +1451,29 @@ pub(super) async fn evaluate_relation_with_predicates(
     } else {
         vec![table.name().to_string(), table.qualified_name()]
     };
+    let column_indexes = table
+        .columns()
+        .iter()
+        .enumerate()
+        .map(|(idx, column)| (column.name().to_string(), idx))
+        .collect::<HashMap<_, _>>();
+    let table_columns = column_indexes.keys().cloned().collect::<HashSet<_>>();
+    let mut scan_predicates = Vec::new();
+    let mut pushed_predicate_indexes = Vec::new();
+    for (idx, predicate) in relation_predicates.iter().enumerate() {
+        if let Some(scan_predicate) = extract_relation_scan_predicate(
+            predicate,
+            &qualifiers,
+            &table_columns,
+            &column_indexes,
+            params,
+        )
+        .await?
+        {
+            scan_predicates.push(scan_predicate);
+            pushed_predicate_indexes.push(idx);
+        }
+    }
     let index_offsets = if relation_predicates.is_empty() {
         None
     } else {
@@ -1468,12 +1502,14 @@ pub(super) async fn evaluate_relation_with_predicates(
                 .collect::<Vec<_>>();
             let columns = projected_column_names(&all_columns, projected_columns.as_deref());
             let rows = with_storage_read(|storage| {
-                storage.scan_rows(
+                storage.scan_rows_for_table(
                     table.oid(),
                     index_offsets.as_deref(),
+                    &scan_predicates,
                     projected_columns.as_deref(),
                 )
-            });
+            })
+            .map_err(|message| EngineError { message })?;
             (columns, rows)
         }
         TableKind::View => {
@@ -1518,11 +1554,14 @@ pub(super) async fn evaluate_relation_with_predicates(
     let null_values = vec![ScalarValue::Null; columns.len()];
     let null_scope = scope_from_row(&columns, &null_values, &qualifiers, &columns);
 
-    Ok(TableEval {
-        rows: scoped_rows,
-        columns,
-        null_scope,
-    })
+    Ok((
+        TableEval {
+            rows: scoped_rows,
+            columns,
+            null_scope,
+        },
+        pushed_predicate_indexes,
+    ))
 }
 
 fn projected_column_names(columns: &[String], projected_columns: Option<&[usize]>) -> Vec<String> {

--- a/src/storage/heap.rs
+++ b/src/storage/heap.rs
@@ -1,9 +1,11 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::{OnceLock, RwLock};
 
 use crate::catalog::oid::Oid;
 use crate::storage::btree::{BTreeIndex, CompositeKey};
 use crate::storage::tuple::ScalarValue;
+use crate::utils::adt::misc::compare_values_for_predicate;
 
 pub(crate) const DEFAULT_BTREE_ORDER: usize = 48;
 
@@ -21,6 +23,23 @@ pub(crate) struct StoredIndexDescriptor {
     pub(crate) column_names: Vec<String>,
     pub(crate) column_indexes: Vec<usize>,
     pub(crate) unique: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScanPredicateOp {
+    Eq,
+    NotEq,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ScanPredicate {
+    pub(crate) column_index: usize,
+    pub(crate) op: ScanPredicateOp,
+    pub(crate) value: ScalarValue,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -300,6 +319,38 @@ impl InMemoryStorage {
             .map_or_else(Vec::new, |index| index.btree.search(key))
     }
 
+    pub(crate) fn scan_rows_for_table(
+        &self,
+        table_oid: Oid,
+        offsets: Option<&[usize]>,
+        predicates: &[ScanPredicate],
+        projected_columns: Option<&[usize]>,
+    ) -> Result<Vec<Vec<ScalarValue>>, String> {
+        let Some(rows) = self.rows_by_table.get(&table_oid) else {
+            return Ok(Vec::new());
+        };
+        let mut matching_rows = Vec::with_capacity(offsets.map_or(rows.len(), <[usize]>::len));
+
+        if let Some(offsets) = offsets {
+            for offset in offsets {
+                let Some(row) = rows.get(*offset) else {
+                    continue;
+                };
+                if row_matches_scan_predicates(row, predicates)? {
+                    matching_rows.push(project_row(row, projected_columns));
+                }
+            }
+            return Ok(matching_rows);
+        }
+
+        for row in rows {
+            if row_matches_scan_predicates(row, predicates)? {
+                matching_rows.push(project_row(row, projected_columns));
+            }
+        }
+        Ok(matching_rows)
+    }
+
     pub(crate) fn index_for_table(&self, table_oid: Oid, index_name: &str) -> Option<&StoredIndex> {
         self.indexes_by_table
             .get(&(table_oid, index_name.to_ascii_lowercase()))
@@ -393,6 +444,107 @@ fn project_row(row: &[ScalarValue], projected_columns: Option<&[usize]>) -> Vec<
 
 fn composite_key_contains_nulls(key: &[ScalarValue]) -> bool {
     key.iter().any(|value| matches!(value, ScalarValue::Null))
+}
+
+fn row_matches_scan_predicates(
+    row: &[ScalarValue],
+    predicates: &[ScanPredicate],
+) -> Result<bool, String> {
+    for predicate in predicates {
+        let value = row.get(predicate.column_index).ok_or_else(|| {
+            format!(
+                "row does not have predicate column offset {}",
+                predicate.column_index
+            )
+        })?;
+        if !scan_predicate_matches(value, predicate)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn scan_predicate_matches(left: &ScalarValue, predicate: &ScanPredicate) -> Result<bool, String> {
+    if matches!(left, ScalarValue::Null) || matches!(predicate.value, ScalarValue::Null) {
+        return Ok(false);
+    }
+    let ord = compare_values_for_predicate(left, &predicate.value).map_err(|err| err.message)?;
+    Ok(match predicate.op {
+        ScanPredicateOp::Eq => ord == Ordering::Equal,
+        ScanPredicateOp::NotEq => ord != Ordering::Equal,
+        ScanPredicateOp::Lt => ord == Ordering::Less,
+        ScanPredicateOp::Lte => matches!(ord, Ordering::Less | Ordering::Equal),
+        ScanPredicateOp::Gt => ord == Ordering::Greater,
+        ScanPredicateOp::Gte => matches!(ord, Ordering::Greater | Ordering::Equal),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InMemoryStorage, ScanPredicate, ScanPredicateOp};
+    use crate::storage::tuple::ScalarValue;
+
+    #[test]
+    fn scan_rows_for_table_filters_without_cloning_non_matches() {
+        let mut storage = InMemoryStorage::default();
+        storage.rows_by_table.insert(
+            42,
+            vec![
+                vec![ScalarValue::Int(1), ScalarValue::Text("a".to_string())],
+                vec![ScalarValue::Int(2), ScalarValue::Text("b".to_string())],
+                vec![ScalarValue::Int(3), ScalarValue::Text("c".to_string())],
+            ],
+        );
+
+        let rows = storage
+            .scan_rows_for_table(
+                42,
+                None,
+                &[ScanPredicate {
+                    column_index: 0,
+                    op: ScanPredicateOp::Gt,
+                    value: ScalarValue::Int(1),
+                }],
+                None,
+            )
+            .expect("scan should succeed");
+
+        assert_eq!(
+            rows,
+            vec![
+                vec![ScalarValue::Int(2), ScalarValue::Text("b".to_string())],
+                vec![ScalarValue::Int(3), ScalarValue::Text("c".to_string())],
+            ]
+        );
+    }
+
+    #[test]
+    fn scan_rows_for_table_honors_offsets() {
+        let mut storage = InMemoryStorage::default();
+        storage.rows_by_table.insert(
+            42,
+            vec![
+                vec![ScalarValue::Int(1)],
+                vec![ScalarValue::Int(2)],
+                vec![ScalarValue::Int(3)],
+            ],
+        );
+
+        let rows = storage
+            .scan_rows_for_table(
+                42,
+                Some(&[2, 0]),
+                &[ScanPredicate {
+                    column_index: 0,
+                    op: ScanPredicateOp::NotEq,
+                    value: ScalarValue::Int(1),
+                }],
+                None,
+            )
+            .expect("scan should succeed");
+
+        assert_eq!(rows, vec![vec![ScalarValue::Int(3)]]);
+    }
 }
 
 static GLOBAL_STORAGE: OnceLock<RwLock<InMemoryStorage>> = OnceLock::new();

--- a/tests/benchmark/clickbench_realdata.rs
+++ b/tests/benchmark/clickbench_realdata.rs
@@ -1,0 +1,247 @@
+/// ClickBench benchmark with real data (100K rows from the full hits dataset).
+///
+/// Run with: cargo test --test benchmark clickbench_realdata -- --nocapture
+///
+/// Requires: data/clickbench/hits_subset.tsv (run scripts/load_clickbench.sh first)
+use std::fs;
+use std::path::Path;
+use std::time::Instant;
+
+use openassay::tcop::postgres::{BackendMessage, FrontendMessage, PostgresSession};
+
+fn assert_ok(out: &[BackendMessage]) {
+    for msg in out {
+        if let BackendMessage::ErrorResponse { message, .. } = msg {
+            panic!("query error: {message}");
+        }
+    }
+}
+
+fn exec(session: &mut PostgresSession, sql: &str) {
+    let out = session.run_sync([FrontendMessage::Query {
+        sql: sql.to_string(),
+    }]);
+    assert_ok(&out);
+}
+
+fn count_data_rows(out: &[BackendMessage]) -> usize {
+    out.iter()
+        .filter(|m| matches!(m, BackendMessage::DataRow { .. }))
+        .count()
+}
+
+fn has_error(out: &[BackendMessage]) -> bool {
+    out.iter()
+        .any(|msg| matches!(msg, BackendMessage::ErrorResponse { .. }))
+}
+
+fn error_message(out: &[BackendMessage]) -> String {
+    out.iter()
+        .filter_map(|msg| {
+            if let BackendMessage::ErrorResponse { message, .. } = msg {
+                Some(message.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Load TSV data via batch INSERT statements (since COPY requires stdin pipe).
+fn load_tsv_data(session: &mut PostgresSession, tsv_path: &Path, max_rows: usize) -> usize {
+    let content = fs::read_to_string(tsv_path).expect("Failed to read TSV file");
+    let mut loaded = 0;
+    let batch_size = 100;
+    let mut batch_values: Vec<String> = Vec::with_capacity(batch_size);
+
+    for line in content.lines() {
+        if loaded >= max_rows {
+            break;
+        }
+        let fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() < 105 {
+            continue;
+        }
+
+        // Build a VALUES row, quoting text fields and handling empty strings
+        let mut vals = Vec::with_capacity(105);
+        // Column type map: TEXT columns by index (0-based)
+        let text_cols: &[usize] = &[
+            2, 13, 14, 25, 29, 34, 35, 39, 50, 56, 63, 75, 76, 77, 78,
+            84, 87, 88, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+        ];
+
+        for (i, field) in fields.iter().enumerate().take(105) {
+            if i == 5 {
+                // EventDate — DATE column
+                vals.push(format!("DATE '{}'", field.replace('\'', "''")));
+            } else if text_cols.contains(&i) {
+                // Escape single quotes and backslashes for SQL string literals
+                let escaped = field
+                    .replace('\\', "\\\\")
+                    .replace('\'', "''")
+                    .replace('\0', "");
+                vals.push(format!("E'{}'", escaped));
+            } else {
+                // Numeric — handle empty as 0
+                let trimmed = field.trim();
+                if trimmed.is_empty() || trimmed.parse::<f64>().is_err() {
+                    vals.push("0".to_string());
+                } else {
+                    vals.push(trimmed.to_string());
+                }
+            }
+        }
+        batch_values.push(format!("({})", vals.join(",")));
+        loaded += 1;
+
+        if batch_values.len() >= batch_size {
+            let sql = format!("INSERT INTO hits VALUES {}", batch_values.join(","));
+            exec(session, &sql);
+            batch_values.clear();
+        }
+    }
+
+    // Flush remaining
+    if !batch_values.is_empty() {
+        let sql = format!("INSERT INTO hits VALUES {}", batch_values.join(","));
+        exec(session, &sql);
+    }
+
+    loaded
+}
+
+#[test]
+fn clickbench_realdata_suite() {
+    let tsv_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("clickbench")
+        .join("hits_subset.tsv");
+
+    if !tsv_path.exists() {
+        eprintln!("⚠ Skipping clickbench_realdata: data/clickbench/hits_subset.tsv not found");
+        eprintln!("  Run: ./scripts/load_clickbench.sh");
+        return;
+    }
+
+    let mut session = PostgresSession::new();
+
+    // Create schema
+    exec(&mut session, include_str!("clickbench_schema.sql"));
+
+    // Load data — use 10K rows for a fast meaningful test
+    let max_rows = std::env::var("CLICKBENCH_ROWS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10_000);
+
+    eprintln!("\n=== ClickBench Real Data Benchmark ===");
+    eprintln!("Loading {} rows...", max_rows);
+    let load_start = Instant::now();
+    let loaded = load_tsv_data(&mut session, &tsv_path, max_rows);
+    let load_time = load_start.elapsed();
+    eprintln!("Loaded {} rows in {:.2?}", loaded, load_time);
+    eprintln!("Load rate: {:.0} rows/sec\n", loaded as f64 / load_time.as_secs_f64());
+
+    // Verify row count
+    let out = session.run_sync([FrontendMessage::Query {
+        sql: "SELECT COUNT(*) FROM hits".to_string(),
+    }]);
+    assert_ok(&out);
+
+    let queries: &[(&str, &str)] = &[
+        ("Q00", "SELECT COUNT(*) FROM hits"),
+        ("Q01", "SELECT COUNT(*) FROM hits WHERE AdvEngineID <> 0"),
+        ("Q02", "SELECT SUM(AdvEngineID), COUNT(*), AVG(ResolutionWidth) FROM hits"),
+        ("Q03", "SELECT AVG(UserID) FROM hits"),
+        ("Q04", "SELECT COUNT(DISTINCT UserID) FROM hits"),
+        ("Q05", "SELECT COUNT(DISTINCT SearchPhrase) FROM hits"),
+        ("Q06", "SELECT MIN(EventDate), MAX(EventDate) FROM hits"),
+        ("Q07", "SELECT AdvEngineID, COUNT(*) AS c FROM hits WHERE AdvEngineID <> 0 GROUP BY AdvEngineID ORDER BY c DESC"),
+        ("Q08", "SELECT RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY RegionID ORDER BY u DESC LIMIT 10"),
+        ("Q09", "SELECT RegionID, SUM(AdvEngineID), COUNT(*) AS c, AVG(ResolutionWidth), COUNT(DISTINCT UserID) FROM hits GROUP BY RegionID ORDER BY c DESC LIMIT 10"),
+        ("Q10", "SELECT MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM hits WHERE MobilePhoneModel <> '0' GROUP BY MobilePhoneModel ORDER BY u DESC LIMIT 10"),
+        ("Q11", "SELECT MobilePhone, MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM hits WHERE MobilePhoneModel <> '0' GROUP BY MobilePhone, MobilePhoneModel ORDER BY u DESC LIMIT 10"),
+        ("Q12", "SELECT SearchPhrase, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10"),
+        ("Q13", "SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10"),
+        ("Q14", "SELECT SearchEngineID, SearchPhrase, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, SearchPhrase ORDER BY c DESC LIMIT 10"),
+        ("Q15", "SELECT UserID, COUNT(*) AS c FROM hits GROUP BY UserID ORDER BY c DESC LIMIT 10"),
+        ("Q16", "SELECT UserID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, SearchPhrase ORDER BY c DESC LIMIT 10"),
+        ("Q17", "SELECT UserID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, SearchPhrase LIMIT 10"),
+        ("Q18", "SELECT UserID, EventTime, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, EventTime, SearchPhrase ORDER BY c DESC LIMIT 10"),
+        ("Q19", "SELECT UserID FROM hits WHERE UserID = -6101065172494233192"),
+        ("Q20", "SELECT COUNT(*) FROM hits WHERE URL LIKE '%google%'"),
+        ("Q21", "SELECT SearchPhrase, MIN(URL), COUNT(*) AS c FROM hits WHERE URL LIKE '%google%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10"),
+        ("Q22", "SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10"),
+        ("Q23", "SELECT * FROM hits WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10"),
+        ("Q24", "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY EventTime LIMIT 10"),
+        ("Q25", "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY SearchPhrase LIMIT 10"),
+        ("Q26", "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY EventTime, SearchPhrase LIMIT 10"),
+        ("Q27", "SELECT CounterID, AVG(CAST(ResolutionWidth AS NUMERIC)) + 100 AS avg_rw FROM hits GROUP BY CounterID ORDER BY avg_rw DESC LIMIT 10"),
+        ("Q28", "SELECT RegionID, SUM(AdvEngineID), COUNT(*) AS c, AVG(ResolutionWidth), COUNT(DISTINCT UserID) FROM hits GROUP BY RegionID ORDER BY c DESC LIMIT 10"),
+        ("Q29", "SELECT RegionID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY RegionID, SearchPhrase ORDER BY c DESC LIMIT 10"),
+        ("Q30", "SELECT RegionID, CounterID, COUNT(*) AS c FROM hits GROUP BY RegionID, CounterID ORDER BY c DESC LIMIT 10"),
+        ("Q31", "SELECT CounterID, RegionID, UserID, COUNT(*) AS c FROM hits GROUP BY CounterID, RegionID, UserID ORDER BY c DESC LIMIT 10"),
+        ("Q32", "SELECT EventDate, RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY EventDate, RegionID ORDER BY EventDate, RegionID"),
+        ("Q33", "SELECT EventDate, RegionID, CounterID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY EventDate, RegionID, CounterID ORDER BY EventDate, RegionID, CounterID"),
+        ("Q34", "SELECT OS, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY OS ORDER BY u DESC LIMIT 10"),
+        ("Q35", "SELECT UserAgent, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY UserAgent ORDER BY u DESC LIMIT 10"),
+        ("Q36", "SELECT UserAgent, RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY UserAgent, RegionID ORDER BY u DESC LIMIT 10"),
+        ("Q37", "SELECT RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY RegionID ORDER BY u DESC LIMIT 10"),
+        ("Q38", "SELECT CounterID, COUNT(*) AS cnt FROM hits GROUP BY CounterID ORDER BY cnt DESC LIMIT 20"),
+        ("Q39", "SELECT SearchPhrase, COUNT(*) AS cnt FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY cnt DESC LIMIT 20"),
+        ("Q40", "SELECT TraficSourceID, SearchEngineID, AdvEngineID, CASE WHEN SearchEngineID = 0 AND AdvEngineID = 0 THEN Referer ELSE '' END AS src, URL, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY TraficSourceID, SearchEngineID, AdvEngineID, src, URL ORDER BY c DESC LIMIT 10"),
+        ("Q41", "SELECT URLHash, EventDate, COUNT(*) AS c FROM hits GROUP BY URLHash, EventDate ORDER BY c DESC LIMIT 10"),
+        ("Q42", "SELECT WindowClientWidth, WindowClientHeight, COUNT(*) AS c FROM hits WHERE WindowClientWidth > 0 AND WindowClientHeight > 0 GROUP BY WindowClientWidth, WindowClientHeight ORDER BY c DESC LIMIT 10"),
+    ];
+
+    let mut results: Vec<(&str, f64, usize, bool)> = Vec::new();
+    let total_start = Instant::now();
+
+    for (label, sql) in queries {
+        let start = Instant::now();
+        let out = session.run_sync([FrontendMessage::Query {
+            sql: sql.to_string(),
+        }]);
+        let elapsed = start.elapsed();
+        let ms = elapsed.as_secs_f64() * 1000.0;
+        let rows = count_data_rows(&out);
+        let ok = !has_error(&out);
+
+        if ok {
+            eprintln!("  {label}: {ms:>8.2} ms  ({rows} rows)");
+        } else {
+            let err = error_message(&out);
+            eprintln!("  {label}: FAIL — {err}");
+        }
+        results.push((label, ms, rows, ok));
+    }
+
+    let total_time = total_start.elapsed();
+    let passed = results.iter().filter(|r| r.3).count();
+    let total_queries = results.len();
+
+    eprintln!("\n=== Summary ({} rows) ===", loaded);
+    eprintln!("Passed: {passed}/{total_queries}");
+    eprintln!("Total query time: {:.2?}", total_time);
+
+    let query_times: Vec<f64> = results.iter().filter(|r| r.3).map(|r| r.1).collect();
+    if !query_times.is_empty() {
+        let sum: f64 = query_times.iter().sum();
+        let min = query_times.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max = query_times.iter().cloned().fold(0.0_f64, f64::max);
+        let avg = sum / query_times.len() as f64;
+        eprintln!("Query times: min={min:.2}ms avg={avg:.2}ms max={max:.2}ms total={sum:.2}ms");
+    }
+
+    // Print slow queries (> 2x average)
+    let avg_ms: f64 = query_times.iter().sum::<f64>() / query_times.len() as f64;
+    let slow: Vec<_> = results.iter().filter(|r| r.3 && r.1 > avg_ms * 2.0).collect();
+    if !slow.is_empty() {
+        eprintln!("\n🐌 Slow queries (> {:.0}ms):", avg_ms * 2.0);
+        for (label, ms, rows, _) in &slow {
+            eprintln!("  {label}: {ms:.2}ms ({rows} rows)");
+        }
+    }
+}


### PR DESCRIPTION
Push simple WHERE predicates (=, <>, >, <, >=, <=) into the storage scan loop. Rows that don't match are skipped before tuple construction. Q19 (equality, 0 results): 545ms → 14ms.