### PR TITLE
perf: streaming LIMIT — top-N heap avoids full sort

### DIFF
--- a/src/executor/exec_main/mod.rs
+++ b/src/executor/exec_main/mod.rs
@@ -84,7 +84,7 @@ use from_clause::{
     relation_index_offsets_for_predicates, remaining_predicate_from_applied,
 };
 use order_limit::{
-    apply_offset_limit, apply_order_by, augment_select_for_order_by,
+    QueryRowCollector, apply_offset_limit, apply_order_by, augment_select_for_order_by,
     collect_extra_order_by_columns, scalar_cmp,
 };
 use query_pipeline::execute_query_expr_with_outer;

--- a/src/executor/exec_main/order_limit.rs
+++ b/src/executor/exec_main/order_limit.rs
@@ -1,5 +1,271 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use std::collections::BinaryHeap;
+
+pub(super) struct QueryRowCollector {
+    strategy: RowCollectionStrategy,
+}
+
+enum RowCollectionStrategy {
+    All {
+        rows: Vec<CollectedRow>,
+        order_by: Vec<OrderByExpr>,
+        offset: usize,
+        limit: Option<usize>,
+    },
+    LimitOnly {
+        rows: Vec<Vec<ScalarValue>>,
+        offset: usize,
+        limit: usize,
+    },
+    TopN {
+        heap: BinaryHeap<TopNEntry>,
+        order_by: Vec<OrderByExpr>,
+        capacity: usize,
+        offset: usize,
+        limit: usize,
+        sequence: usize,
+    },
+}
+
+struct TopNEntry {
+    keys: Vec<TopNKeyPart>,
+    row: Vec<ScalarValue>,
+    sequence: usize,
+}
+
+struct CollectedRow {
+    keys: Vec<ScalarValue>,
+    row: Vec<ScalarValue>,
+}
+
+struct TopNKeyPart {
+    value: ScalarValue,
+    descending: bool,
+}
+
+impl QueryRowCollector {
+    pub(super) async fn new(query: &Query, params: &[Option<String>]) -> Result<Self, EngineError> {
+        let offset = if let Some(expr) = &query.offset {
+            parse_non_negative_int(
+                &eval_expr(expr, &EvalScope::default(), params).await?,
+                "OFFSET",
+            )?
+        } else {
+            0usize
+        };
+
+        let limit = if let Some(expr) = &query.limit {
+            Some(parse_non_negative_int(
+                &eval_expr(expr, &EvalScope::default(), params).await?,
+                "LIMIT",
+            )?)
+        } else {
+            None
+        };
+
+        let strategy = match limit {
+            Some(limit) if !query.order_by.is_empty() => RowCollectionStrategy::TopN {
+                heap: BinaryHeap::new(),
+                order_by: query.order_by.clone(),
+                capacity: offset.saturating_add(limit),
+                offset,
+                limit,
+                sequence: 0,
+            },
+            Some(limit) => RowCollectionStrategy::LimitOnly {
+                rows: Vec::new(),
+                offset,
+                limit,
+            },
+            None => RowCollectionStrategy::All {
+                rows: Vec::new(),
+                order_by: query.order_by.clone(),
+                offset,
+                limit: None,
+            },
+        };
+
+        Ok(Self { strategy })
+    }
+
+    pub(super) async fn push_row(
+        &mut self,
+        columns: &[String],
+        row: Vec<ScalarValue>,
+        params: &[Option<String>],
+    ) -> Result<bool, EngineError> {
+        match &mut self.strategy {
+            RowCollectionStrategy::All { rows, order_by, .. } => {
+                let keys = if order_by.is_empty() {
+                    Vec::new()
+                } else {
+                    resolve_order_keys(order_by, columns, &row, params).await?
+                };
+                rows.push(CollectedRow { keys, row });
+                Ok(true)
+            }
+            RowCollectionStrategy::LimitOnly {
+                rows,
+                offset,
+                limit,
+            } => {
+                let target = offset.saturating_add(*limit);
+                if rows.len() < target {
+                    rows.push(row);
+                }
+                Ok(rows.len() < target)
+            }
+            RowCollectionStrategy::TopN {
+                heap,
+                order_by,
+                capacity,
+                sequence,
+                ..
+            } => {
+                if *capacity == 0 {
+                    return Ok(true);
+                }
+                let keys = resolve_order_keys(order_by, columns, &row, params).await?;
+                let entry = TopNEntry::new(keys, order_by, row, *sequence);
+                *sequence += 1;
+                if heap.len() < *capacity {
+                    heap.push(entry);
+                } else if heap.peek().is_some_and(|worst| entry < *worst) {
+                    let _ = heap.pop();
+                    heap.push(entry);
+                }
+                Ok(true)
+            }
+        }
+    }
+
+    pub(super) fn finish(self) -> Vec<Vec<ScalarValue>> {
+        match self.strategy {
+            RowCollectionStrategy::All {
+                mut rows,
+                order_by,
+                offset,
+                limit,
+            } => {
+                if !order_by.is_empty() {
+                    rows.sort_by(|left, right| {
+                        compare_order_keys(&left.keys, &right.keys, &order_by)
+                    });
+                }
+                let mut rows = rows.into_iter().map(|row| row.row).collect::<Vec<_>>();
+                apply_offset_limit_to_rows(&mut rows, offset, limit);
+                rows
+            }
+            RowCollectionStrategy::LimitOnly {
+                mut rows,
+                offset,
+                limit,
+            } => {
+                apply_offset_limit_to_rows(&mut rows, offset, Some(limit));
+                rows
+            }
+            RowCollectionStrategy::TopN {
+                heap,
+                offset,
+                limit,
+                ..
+            } => {
+                let mut rows = heap
+                    .into_sorted_vec()
+                    .into_iter()
+                    .map(|entry| entry.row)
+                    .collect::<Vec<_>>();
+                apply_offset_limit_to_rows(&mut rows, offset, Some(limit));
+                rows
+            }
+        }
+    }
+}
+
+impl TopNEntry {
+    fn new(
+        keys: Vec<ScalarValue>,
+        order_by: &[OrderByExpr],
+        row: Vec<ScalarValue>,
+        sequence: usize,
+    ) -> Self {
+        let keys = keys
+            .into_iter()
+            .enumerate()
+            .map(|(idx, value)| TopNKeyPart {
+                value,
+                descending: order_by[idx].ascending == Some(false),
+            })
+            .collect();
+        Self {
+            keys,
+            row,
+            sequence,
+        }
+    }
+}
+
+impl PartialEq for TopNEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for TopNEntry {}
+
+impl PartialOrd for TopNEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TopNEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        for (left, right) in self.keys.iter().zip(&other.keys) {
+            let ord = scalar_cmp(&left.value, &right.value);
+            let ord = if left.descending { ord.reverse() } else { ord };
+            if ord != Ordering::Equal {
+                return ord;
+            }
+        }
+        self.sequence.cmp(&other.sequence)
+    }
+}
+
+async fn resolve_order_keys(
+    order_by: &[OrderByExpr],
+    columns: &[String],
+    row: &[ScalarValue],
+    params: &[Option<String>],
+) -> Result<Vec<ScalarValue>, EngineError> {
+    let scope = EvalScope::from_output_row(columns, row);
+    let mut keys = Vec::with_capacity(order_by.len());
+    for spec in order_by {
+        keys.push(resolve_order_key(&spec.expr, &scope, columns, row, params).await?);
+    }
+    Ok(keys)
+}
+
+fn apply_offset_limit_to_rows(
+    rows: &mut Vec<Vec<ScalarValue>>,
+    offset: usize,
+    limit: Option<usize>,
+) {
+    if offset > 0 {
+        if offset >= rows.len() {
+            rows.clear();
+            return;
+        }
+        rows.drain(0..offset);
+    }
+
+    if let Some(limit) = limit
+        && limit < rows.len()
+    {
+        rows.truncate(limit);
+    }
+}
 
 /// Collect identifiers from ORDER BY that are not present in the SELECT output columns.
 /// These need to be temporarily added to the SELECT for sorting.

--- a/src/executor/exec_main/query_pipeline.rs
+++ b/src/executor/exec_main/query_pipeline.rs
@@ -78,10 +78,13 @@ pub fn execute_query_with_outer<'a>(
                 offset: None,
             };
             let mut result = with_scan_projection_hints(&execution_query, async {
-                execute_query_expr_with_outer(&body, params, outer_scope).await
+                if let QueryExpr::Select(select) = &body {
+                    execute_select_with_query(select, query, params, outer_scope).await
+                } else {
+                    execute_query_expr_with_outer(&body, params, outer_scope).await
+                }
             })
             .await?;
-            apply_order_by(&mut result, query, params).await?;
 
             // Strip hidden ORDER BY columns
             if num_hidden > 0 {
@@ -92,7 +95,10 @@ pub fn execute_query_with_outer<'a>(
                 }
             }
 
-            apply_offset_limit(&mut result, query, params).await?;
+            if !matches!(body, QueryExpr::Select(_)) {
+                apply_order_by(&mut result, query, params).await?;
+                apply_offset_limit(&mut result, query, params).await?;
+            }
             Ok(result)
         })
         .await
@@ -329,6 +335,24 @@ pub(super) async fn execute_select(
     params: &[Option<String>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<QueryResult, EngineError> {
+    execute_select_internal(select, None, params, outer_scope).await
+}
+
+async fn execute_select_with_query(
+    select: &SelectStatement,
+    query: &Query,
+    params: &[Option<String>],
+    outer_scope: Option<&EvalScope>,
+) -> Result<QueryResult, EngineError> {
+    execute_select_internal(select, Some(query), params, outer_scope).await
+}
+
+async fn execute_select_internal(
+    select: &SelectStatement,
+    query: Option<&Query>,
+    params: &[Option<String>],
+    outer_scope: Option<&EvalScope>,
+) -> Result<QueryResult, EngineError> {
     let cte_columns = active_cte_context()
         .into_iter()
         .map(|(name, binding)| (name, binding.columns))
@@ -347,6 +371,11 @@ pub(super) async fn execute_select(
         Vec::new()
     } else {
         derive_select_columns(select, &cte_columns)?
+    };
+    let mut row_collector = if let Some(query) = query {
+        Some(QueryRowCollector::new(query, params).await?)
+    } else {
+        None
     };
     let mut rows = Vec::new();
 
@@ -518,6 +547,41 @@ pub(super) async fn execute_select(
         }
     }
 
+    let supports_direct_streaming =
+        row_collector.is_some() && !has_aggregate && !has_window && select.quantifier.is_none();
+    let emit_directly_to_collector = row_collector.is_some() && select.quantifier.is_none();
+    if supports_direct_streaming {
+        for scope in source_rows {
+            if let Some(predicate) = &remaining_predicate
+                && !truthy(&eval_expr(predicate, &scope, params).await?)
+            {
+                continue;
+            }
+            let row =
+                project_select_row(&select.targets, &scope, params, wildcard_columns.as_deref())
+                    .await?;
+            if !row_collector
+                .as_mut()
+                .expect("streaming collector must be initialized")
+                .push_row(&columns, row, params)
+                .await?
+            {
+                break;
+            }
+        }
+
+        let rows = row_collector
+            .take()
+            .expect("streaming collector must be present")
+            .finish();
+        return Ok(QueryResult {
+            columns,
+            rows_affected: rows.len() as u64,
+            rows,
+            command_tag: "SELECT".to_string(),
+        });
+    }
+
     let filtered_rows = if let Some(predicate) = &remaining_predicate {
         let mut rows = Vec::with_capacity(source_rows.len());
         for scope in source_rows {
@@ -643,7 +707,18 @@ pub(super) async fn execute_select(
                         .await?,
                     );
                 }
-                rows.push(row);
+                if emit_directly_to_collector {
+                    if !row_collector
+                        .as_mut()
+                        .expect("collector must be present when emitting directly")
+                        .push_row(&columns, row, params)
+                        .await?
+                    {
+                        break;
+                    }
+                } else {
+                    rows.push(row);
+                }
             }
         }
     } else if has_window {
@@ -658,14 +733,36 @@ pub(super) async fn execute_select(
                 wildcard_columns.as_deref(),
             )
             .await?;
-            rows.push(row);
+            if emit_directly_to_collector {
+                if !row_collector
+                    .as_mut()
+                    .expect("collector must be present when emitting directly")
+                    .push_row(&columns, row, params)
+                    .await?
+                {
+                    break;
+                }
+            } else {
+                rows.push(row);
+            }
         }
     } else {
         for scope in filtered_rows {
             let row =
                 project_select_row(&select.targets, &scope, params, wildcard_columns.as_deref())
                     .await?;
-            rows.push(row);
+            if emit_directly_to_collector {
+                if !row_collector
+                    .as_mut()
+                    .expect("collector must be present when emitting directly")
+                    .push_row(&columns, row, params)
+                    .await?
+                {
+                    break;
+                }
+            } else {
+                rows.push(row);
+            }
         }
     }
 
@@ -691,6 +788,21 @@ pub(super) async fn execute_select(
         } else {
             rows = dedupe_rows(rows);
         }
+    }
+
+    if let Some(mut collector) = row_collector {
+        for row in rows {
+            if !collector.push_row(&columns, row, params).await? {
+                break;
+            }
+        }
+        let rows = collector.finish();
+        return Ok(QueryResult {
+            columns,
+            rows_affected: rows.len() as u64,
+            rows,
+            command_tag: "SELECT".to_string(),
+        });
     }
 
     Ok(QueryResult {

--- a/src/tcop/engine_tests.rs
+++ b/src/tcop/engine_tests.rs
@@ -137,6 +137,37 @@ fn executes_set_operations_and_order_limit() {
 }
 
 #[test]
+fn executes_multi_column_order_limit_with_mixed_directions_and_nulls() {
+    let results = run_batch(&[
+        "CREATE TABLE t (a int8, b int8)",
+        "INSERT INTO t VALUES (1, NULL), (1, 2), (1, 1), (2, NULL), (2, 3), (2, 1)",
+        "SELECT a, b FROM t ORDER BY a DESC, b ASC LIMIT 4",
+    ]);
+    assert_eq!(
+        results[2].rows,
+        vec![
+            vec![ScalarValue::Int(2), ScalarValue::Null],
+            vec![ScalarValue::Int(2), ScalarValue::Int(1)],
+            vec![ScalarValue::Int(2), ScalarValue::Int(3)],
+            vec![ScalarValue::Int(1), ScalarValue::Null],
+        ]
+    );
+}
+
+#[test]
+fn order_limit_with_offset_preserves_input_order_for_equal_keys() {
+    let results = run_batch(&[
+        "CREATE TABLE t (id int8, grp int8)",
+        "INSERT INTO t VALUES (10, 1), (20, 1), (30, 1), (40, 2)",
+        "SELECT id FROM t ORDER BY grp LIMIT 2 OFFSET 1",
+    ]);
+    assert_eq!(
+        results[2].rows,
+        vec![vec![ScalarValue::Int(20)], vec![ScalarValue::Int(30)]]
+    );
+}
+
+#[test]
 fn executes_parameterized_expression() {
     let result = with_isolated_state(|| run_statement("SELECT $1 + 5", &[Some("7".to_string())]));
     assert_eq!(result.rows[0], vec![ScalarValue::Int(12)]);

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -1,3 +1,5 @@
+use std::sync::{Mutex, OnceLock};
+
 #[path = "benchmark/tpch_queries.rs"]
 mod tpch_queries;
 
@@ -6,3 +8,8 @@ mod clickbench_queries;
 
 #[path = "benchmark/clickbench_realdata.rs"]
 mod clickbench_realdata;
+
+fn benchmark_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}

--- a/tests/benchmark/clickbench_queries.rs
+++ b/tests/benchmark/clickbench_queries.rs
@@ -58,7 +58,11 @@ fn try_query(session: &mut PostgresSession, label: &str, sql: &str) -> bool {
 
 #[test]
 fn clickbench_query_suite() {
+    let _guard = super::benchmark_lock()
+        .lock()
+        .expect("benchmark lock should not be poisoned");
     let mut session = PostgresSession::new();
+    exec(&mut session, "DROP TABLE IF EXISTS hits");
     exec(&mut session, include_str!("clickbench_schema.sql"));
     exec(&mut session, include_str!("clickbench_data.sql"));
 

--- a/tests/benchmark/clickbench_realdata.rs
+++ b/tests/benchmark/clickbench_realdata.rs
@@ -68,8 +68,8 @@ fn load_tsv_data(session: &mut PostgresSession, tsv_path: &Path, max_rows: usize
         let mut vals = Vec::with_capacity(105);
         // Column type map: TEXT columns by index (0-based)
         let text_cols: &[usize] = &[
-            2, 13, 14, 25, 29, 34, 35, 39, 50, 56, 63, 75, 76, 77, 78,
-            84, 87, 88, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+            2, 13, 14, 25, 29, 34, 35, 39, 50, 56, 63, 75, 76, 77, 78, 84, 87, 88, 91, 92, 93, 94,
+            95, 96, 97, 98, 99, 100,
         ];
 
         for (i, field) in fields.iter().enumerate().take(105) {
@@ -114,6 +114,9 @@ fn load_tsv_data(session: &mut PostgresSession, tsv_path: &Path, max_rows: usize
 
 #[test]
 fn clickbench_realdata_suite() {
+    let _guard = super::benchmark_lock()
+        .lock()
+        .expect("benchmark lock should not be poisoned");
     let tsv_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("clickbench")
@@ -128,6 +131,7 @@ fn clickbench_realdata_suite() {
     let mut session = PostgresSession::new();
 
     // Create schema
+    exec(&mut session, "DROP TABLE IF EXISTS hits");
     exec(&mut session, include_str!("clickbench_schema.sql"));
 
     // Load data — use 10K rows for a fast meaningful test
@@ -142,7 +146,10 @@ fn clickbench_realdata_suite() {
     let loaded = load_tsv_data(&mut session, &tsv_path, max_rows);
     let load_time = load_start.elapsed();
     eprintln!("Loaded {} rows in {:.2?}", loaded, load_time);
-    eprintln!("Load rate: {:.0} rows/sec\n", loaded as f64 / load_time.as_secs_f64());
+    eprintln!(
+        "Load rate: {:.0} rows/sec\n",
+        loaded as f64 / load_time.as_secs_f64()
+    );
 
     // Verify row count
     let out = session.run_sync([FrontendMessage::Query {
@@ -153,47 +160,155 @@ fn clickbench_realdata_suite() {
     let queries: &[(&str, &str)] = &[
         ("Q00", "SELECT COUNT(*) FROM hits"),
         ("Q01", "SELECT COUNT(*) FROM hits WHERE AdvEngineID <> 0"),
-        ("Q02", "SELECT SUM(AdvEngineID), COUNT(*), AVG(ResolutionWidth) FROM hits"),
+        (
+            "Q02",
+            "SELECT SUM(AdvEngineID), COUNT(*), AVG(ResolutionWidth) FROM hits",
+        ),
         ("Q03", "SELECT AVG(UserID) FROM hits"),
         ("Q04", "SELECT COUNT(DISTINCT UserID) FROM hits"),
         ("Q05", "SELECT COUNT(DISTINCT SearchPhrase) FROM hits"),
         ("Q06", "SELECT MIN(EventDate), MAX(EventDate) FROM hits"),
-        ("Q07", "SELECT AdvEngineID, COUNT(*) AS c FROM hits WHERE AdvEngineID <> 0 GROUP BY AdvEngineID ORDER BY c DESC"),
-        ("Q08", "SELECT RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY RegionID ORDER BY u DESC LIMIT 10"),
-        ("Q09", "SELECT RegionID, SUM(AdvEngineID), COUNT(*) AS c, AVG(ResolutionWidth), COUNT(DISTINCT UserID) FROM hits GROUP BY RegionID ORDER BY c DESC LIMIT 10"),
-        ("Q10", "SELECT MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM hits WHERE MobilePhoneModel <> '0' GROUP BY MobilePhoneModel ORDER BY u DESC LIMIT 10"),
-        ("Q11", "SELECT MobilePhone, MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM hits WHERE MobilePhoneModel <> '0' GROUP BY MobilePhone, MobilePhoneModel ORDER BY u DESC LIMIT 10"),
-        ("Q12", "SELECT SearchPhrase, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10"),
-        ("Q13", "SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10"),
-        ("Q14", "SELECT SearchEngineID, SearchPhrase, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, SearchPhrase ORDER BY c DESC LIMIT 10"),
-        ("Q15", "SELECT UserID, COUNT(*) AS c FROM hits GROUP BY UserID ORDER BY c DESC LIMIT 10"),
-        ("Q16", "SELECT UserID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, SearchPhrase ORDER BY c DESC LIMIT 10"),
-        ("Q17", "SELECT UserID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, SearchPhrase LIMIT 10"),
-        ("Q18", "SELECT UserID, EventTime, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, EventTime, SearchPhrase ORDER BY c DESC LIMIT 10"),
-        ("Q19", "SELECT UserID FROM hits WHERE UserID = -6101065172494233192"),
+        (
+            "Q07",
+            "SELECT AdvEngineID, COUNT(*) AS c FROM hits WHERE AdvEngineID <> 0 GROUP BY AdvEngineID ORDER BY c DESC",
+        ),
+        (
+            "Q08",
+            "SELECT RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY RegionID ORDER BY u DESC LIMIT 10",
+        ),
+        (
+            "Q09",
+            "SELECT RegionID, SUM(AdvEngineID), COUNT(*) AS c, AVG(ResolutionWidth), COUNT(DISTINCT UserID) FROM hits GROUP BY RegionID ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q10",
+            "SELECT MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM hits WHERE MobilePhoneModel <> '0' GROUP BY MobilePhoneModel ORDER BY u DESC LIMIT 10",
+        ),
+        (
+            "Q11",
+            "SELECT MobilePhone, MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM hits WHERE MobilePhoneModel <> '0' GROUP BY MobilePhone, MobilePhoneModel ORDER BY u DESC LIMIT 10",
+        ),
+        (
+            "Q12",
+            "SELECT SearchPhrase, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q13",
+            "SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10",
+        ),
+        (
+            "Q14",
+            "SELECT SearchEngineID, SearchPhrase, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, SearchPhrase ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q15",
+            "SELECT UserID, COUNT(*) AS c FROM hits GROUP BY UserID ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q16",
+            "SELECT UserID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, SearchPhrase ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q17",
+            "SELECT UserID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, SearchPhrase LIMIT 10",
+        ),
+        (
+            "Q18",
+            "SELECT UserID, EventTime, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY UserID, EventTime, SearchPhrase ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q19",
+            "SELECT UserID FROM hits WHERE UserID = -6101065172494233192",
+        ),
         ("Q20", "SELECT COUNT(*) FROM hits WHERE URL LIKE '%google%'"),
-        ("Q21", "SELECT SearchPhrase, MIN(URL), COUNT(*) AS c FROM hits WHERE URL LIKE '%google%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10"),
-        ("Q22", "SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10"),
-        ("Q23", "SELECT * FROM hits WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10"),
-        ("Q24", "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY EventTime LIMIT 10"),
-        ("Q25", "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY SearchPhrase LIMIT 10"),
-        ("Q26", "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY EventTime, SearchPhrase LIMIT 10"),
-        ("Q27", "SELECT CounterID, AVG(CAST(ResolutionWidth AS NUMERIC)) + 100 AS avg_rw FROM hits GROUP BY CounterID ORDER BY avg_rw DESC LIMIT 10"),
-        ("Q28", "SELECT RegionID, SUM(AdvEngineID), COUNT(*) AS c, AVG(ResolutionWidth), COUNT(DISTINCT UserID) FROM hits GROUP BY RegionID ORDER BY c DESC LIMIT 10"),
-        ("Q29", "SELECT RegionID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY RegionID, SearchPhrase ORDER BY c DESC LIMIT 10"),
-        ("Q30", "SELECT RegionID, CounterID, COUNT(*) AS c FROM hits GROUP BY RegionID, CounterID ORDER BY c DESC LIMIT 10"),
-        ("Q31", "SELECT CounterID, RegionID, UserID, COUNT(*) AS c FROM hits GROUP BY CounterID, RegionID, UserID ORDER BY c DESC LIMIT 10"),
-        ("Q32", "SELECT EventDate, RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY EventDate, RegionID ORDER BY EventDate, RegionID"),
-        ("Q33", "SELECT EventDate, RegionID, CounterID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY EventDate, RegionID, CounterID ORDER BY EventDate, RegionID, CounterID"),
-        ("Q34", "SELECT OS, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY OS ORDER BY u DESC LIMIT 10"),
-        ("Q35", "SELECT UserAgent, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY UserAgent ORDER BY u DESC LIMIT 10"),
-        ("Q36", "SELECT UserAgent, RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY UserAgent, RegionID ORDER BY u DESC LIMIT 10"),
-        ("Q37", "SELECT RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY RegionID ORDER BY u DESC LIMIT 10"),
-        ("Q38", "SELECT CounterID, COUNT(*) AS cnt FROM hits GROUP BY CounterID ORDER BY cnt DESC LIMIT 20"),
-        ("Q39", "SELECT SearchPhrase, COUNT(*) AS cnt FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY cnt DESC LIMIT 20"),
-        ("Q40", "SELECT TraficSourceID, SearchEngineID, AdvEngineID, CASE WHEN SearchEngineID = 0 AND AdvEngineID = 0 THEN Referer ELSE '' END AS src, URL, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY TraficSourceID, SearchEngineID, AdvEngineID, src, URL ORDER BY c DESC LIMIT 10"),
-        ("Q41", "SELECT URLHash, EventDate, COUNT(*) AS c FROM hits GROUP BY URLHash, EventDate ORDER BY c DESC LIMIT 10"),
-        ("Q42", "SELECT WindowClientWidth, WindowClientHeight, COUNT(*) AS c FROM hits WHERE WindowClientWidth > 0 AND WindowClientHeight > 0 GROUP BY WindowClientWidth, WindowClientHeight ORDER BY c DESC LIMIT 10"),
+        (
+            "Q21",
+            "SELECT SearchPhrase, MIN(URL), COUNT(*) AS c FROM hits WHERE URL LIKE '%google%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q22",
+            "SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q23",
+            "SELECT * FROM hits WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10",
+        ),
+        (
+            "Q24",
+            "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY EventTime LIMIT 10",
+        ),
+        (
+            "Q25",
+            "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY SearchPhrase LIMIT 10",
+        ),
+        (
+            "Q26",
+            "SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY EventTime, SearchPhrase LIMIT 10",
+        ),
+        (
+            "Q27",
+            "SELECT CounterID, AVG(CAST(ResolutionWidth AS NUMERIC)) + 100 AS avg_rw FROM hits GROUP BY CounterID ORDER BY avg_rw DESC LIMIT 10",
+        ),
+        (
+            "Q28",
+            "SELECT RegionID, SUM(AdvEngineID), COUNT(*) AS c, AVG(ResolutionWidth), COUNT(DISTINCT UserID) FROM hits GROUP BY RegionID ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q29",
+            "SELECT RegionID, SearchPhrase, COUNT(*) AS c FROM hits GROUP BY RegionID, SearchPhrase ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q30",
+            "SELECT RegionID, CounterID, COUNT(*) AS c FROM hits GROUP BY RegionID, CounterID ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q31",
+            "SELECT CounterID, RegionID, UserID, COUNT(*) AS c FROM hits GROUP BY CounterID, RegionID, UserID ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q32",
+            "SELECT EventDate, RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY EventDate, RegionID ORDER BY EventDate, RegionID",
+        ),
+        (
+            "Q33",
+            "SELECT EventDate, RegionID, CounterID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY EventDate, RegionID, CounterID ORDER BY EventDate, RegionID, CounterID",
+        ),
+        (
+            "Q34",
+            "SELECT OS, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY OS ORDER BY u DESC LIMIT 10",
+        ),
+        (
+            "Q35",
+            "SELECT UserAgent, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY UserAgent ORDER BY u DESC LIMIT 10",
+        ),
+        (
+            "Q36",
+            "SELECT UserAgent, RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY UserAgent, RegionID ORDER BY u DESC LIMIT 10",
+        ),
+        (
+            "Q37",
+            "SELECT RegionID, COUNT(DISTINCT UserID) AS u FROM hits GROUP BY RegionID ORDER BY u DESC LIMIT 10",
+        ),
+        (
+            "Q38",
+            "SELECT CounterID, COUNT(*) AS cnt FROM hits GROUP BY CounterID ORDER BY cnt DESC LIMIT 20",
+        ),
+        (
+            "Q39",
+            "SELECT SearchPhrase, COUNT(*) AS cnt FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY cnt DESC LIMIT 20",
+        ),
+        (
+            "Q40",
+            "SELECT TraficSourceID, SearchEngineID, AdvEngineID, CASE WHEN SearchEngineID = 0 AND AdvEngineID = 0 THEN Referer ELSE '' END AS src, URL, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY TraficSourceID, SearchEngineID, AdvEngineID, src, URL ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q41",
+            "SELECT URLHash, EventDate, COUNT(*) AS c FROM hits GROUP BY URLHash, EventDate ORDER BY c DESC LIMIT 10",
+        ),
+        (
+            "Q42",
+            "SELECT WindowClientWidth, WindowClientHeight, COUNT(*) AS c FROM hits WHERE WindowClientWidth > 0 AND WindowClientHeight > 0 GROUP BY WindowClientWidth, WindowClientHeight ORDER BY c DESC LIMIT 10",
+        ),
     ];
 
     let mut results: Vec<(&str, f64, usize, bool)> = Vec::new();
@@ -237,7 +352,10 @@ fn clickbench_realdata_suite() {
 
     // Print slow queries (> 2x average)
     let avg_ms: f64 = query_times.iter().sum::<f64>() / query_times.len() as f64;
-    let slow: Vec<_> = results.iter().filter(|r| r.3 && r.1 > avg_ms * 2.0).collect();
+    let slow: Vec<_> = results
+        .iter()
+        .filter(|r| r.3 && r.1 > avg_ms * 2.0)
+        .collect();
     if !slow.is_empty() {
         eprintln!("\n🐌 Slow queries (> {:.0}ms):", avg_ms * 2.0);
         for (label, ms, rows, _) in &slow {

--- a/tests/benchmark/tpch_queries.rs
+++ b/tests/benchmark/tpch_queries.rs
@@ -62,6 +62,9 @@ fn try_query(session: &mut PostgresSession, label: &str, sql: &str) -> bool {
 
 #[test]
 fn tpch_query_suite() {
+    let _guard = super::benchmark_lock()
+        .lock()
+        .expect("benchmark lock should not be poisoned");
     let mut session = PostgresSession::new();
     exec(&mut session, include_str!("tpch_schema.sql"));
     exec(&mut session, include_str!("tpch_data.sql"));


### PR DESCRIPTION
ORDER BY x LIMIT N now uses a BinaryHeap instead of sorting all rows. Q23 (SELECT * ORDER BY LIMIT 10): should drop from 717ms.