### PR TITLE
perf: Arrow columnar storage backend — Phase 1

### DIFF
--- a/src/commands/alter.rs
+++ b/src/commands/alter.rs
@@ -74,10 +74,15 @@ pub async fn execute_alter_table(
             })?;
 
             with_storage_write(|storage| {
-                let rows = storage.rows_by_table.entry(table.oid()).or_default();
-                for row in rows.iter_mut() {
+                let mut rows = storage
+                    .rows_by_table
+                    .get(&table.oid())
+                    .cloned()
+                    .unwrap_or_default();
+                for row in &mut rows {
                     row.push(default_value.clone().unwrap_or(ScalarValue::Null));
                 }
+                let _ = storage.replace_rows_for_table(table.oid(), rows);
             });
         }
         AlterTableAction::AddConstraint(constraint) => {
@@ -130,12 +135,17 @@ pub async fn execute_alter_table(
             })?;
 
             with_storage_write(|storage| {
-                let rows = storage.rows_by_table.entry(table.oid()).or_default();
-                for row in rows.iter_mut() {
+                let mut rows = storage
+                    .rows_by_table
+                    .get(&table.oid())
+                    .cloned()
+                    .unwrap_or_default();
+                for row in &mut rows {
                     if dropped_index < row.len() {
                         row.remove(dropped_index);
                     }
                 }
+                let _ = storage.replace_rows_for_table(table.oid(), rows);
             });
         }
         AlterTableAction::DropConstraint { name } => {
@@ -211,7 +221,7 @@ pub async fn execute_alter_table(
             }
 
             with_storage_write(|storage| {
-                storage.rows_by_table.insert(table.oid(), rewritten_rows);
+                let _ = storage.replace_rows_for_table(table.oid(), rewritten_rows);
             });
             with_catalog_write(|catalog| {
                 catalog.set_column_type(table.schema_name(), table.name(), name, target_signature)

--- a/src/commands/create_table.rs
+++ b/src/commands/create_table.rs
@@ -107,7 +107,7 @@ pub async fn execute_create_table(
     };
 
     with_storage_write(|storage| {
-        storage.rows_by_table.entry(table_oid).or_default();
+        let _ = storage.ensure_table(table_oid);
     });
     security::set_relation_owner(table_oid, &security::current_role());
     if !identity_sequence_names.is_empty() {
@@ -389,7 +389,7 @@ async fn execute_create_table_as_select(
     };
 
     with_storage_write(|storage| {
-        storage.rows_by_table.entry(table_oid).or_default();
+        let _ = storage.ensure_table(table_oid);
     });
     security::set_relation_owner(table_oid, &security::current_role());
 
@@ -399,10 +399,7 @@ async fn execute_create_table_as_select(
     let row_count = query_result.rows.len() as u64;
 
     with_storage_write(|storage| {
-        let rows = storage.rows_by_table.entry(table_oid).or_default();
-        for row in query_result.rows {
-            rows.push(row);
-        }
+        let _ = storage.replace_rows_for_table(table_oid, query_result.rows);
     });
 
     Ok(QueryResult {

--- a/src/commands/drop.rs
+++ b/src/commands/drop.rs
@@ -20,8 +20,7 @@ pub fn drop_relations_by_oid_order(
                 message: err.message,
             })?;
         with_storage_write(|storage| {
-            storage.rows_by_table.remove(table_oid);
-            storage.drop_all_indexes_for_table(*table_oid);
+            storage.remove_table(*table_oid);
         });
         crate::security::clear_relation_security(*table_oid);
     }

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -109,7 +109,7 @@ pub(crate) async fn execute_create_view_internal(
 
     if create.or_replace {
         with_storage_write(|storage| {
-            storage.rows_by_table.remove(&oid);
+            storage.remove_table(oid);
         });
     }
     if create.materialized {

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -1501,7 +1501,7 @@ pub(super) async fn evaluate_relation_with_predicates(
                 .map(|column| column.name().to_string())
                 .collect::<Vec<_>>();
             let columns = projected_column_names(&all_columns, projected_columns.as_deref());
-            let rows = with_storage_read(|storage| {
+            let rows = crate::tcop::engine::with_storage_write(|storage| {
                 storage.scan_rows_for_table(
                     table.oid(),
                     index_offsets.as_deref(),

--- a/src/replication/apply.rs
+++ b/src/replication/apply.rs
@@ -164,11 +164,7 @@ impl ApplyWorker {
             }
         }
         with_storage_write(|storage| {
-            storage
-                .rows_by_table
-                .entry(relation.local_oid)
-                .or_default()
-                .push(row);
+            let _ = storage.append_row(relation.local_oid, row);
         });
         Ok(())
     }
@@ -210,7 +206,7 @@ impl ApplyWorker {
         }
         rows[row_idx] = updated;
         with_storage_write(|storage| {
-            storage.rows_by_table.insert(relation.local_oid, rows);
+            let _ = storage.replace_rows_for_table(relation.local_oid, rows);
         });
         Ok(())
     }
@@ -239,7 +235,7 @@ impl ApplyWorker {
         };
         rows.remove(row_idx);
         with_storage_write(|storage| {
-            storage.rows_by_table.insert(relation.local_oid, rows);
+            let _ = storage.replace_rows_for_table(relation.local_oid, rows);
         });
         Ok(())
     }
@@ -248,7 +244,7 @@ impl ApplyWorker {
         with_storage_write(|storage| {
             for relation_id in &truncate.relation_ids {
                 if let Some(info) = self.relations.get(relation_id) {
-                    storage.rows_by_table.insert(info.local_oid, Vec::new());
+                    let _ = storage.replace_rows_for_table(info.local_oid, Vec::new());
                 }
             }
         });

--- a/src/replication/initial_sync.rs
+++ b/src/replication/initial_sync.rs
@@ -66,7 +66,7 @@ pub async fn copy_tables(
         }
 
         with_storage_write(|storage| {
-            storage.rows_by_table.insert(local_oid, rows.clone());
+            let _ = storage.replace_rows_for_table(local_oid, rows.clone());
         });
     }
 

--- a/src/replication/schema_sync.rs
+++ b/src/replication/schema_sync.rs
@@ -96,7 +96,7 @@ pub fn ensure_local_table(
     })?;
 
     with_storage_write(|storage| {
-        storage.rows_by_table.entry(oid).or_default();
+        let _ = storage.ensure_table(oid);
     });
 
     Ok(oid)

--- a/src/storage/heap.rs
+++ b/src/storage/heap.rs
@@ -1,13 +1,35 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::sync::{OnceLock, RwLock};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, OnceLock, RwLock};
+
+use arrow::array::{BooleanArray, BooleanBuilder, RecordBatch};
+use arrow::compute::filter_record_batch;
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 
 use crate::catalog::oid::Oid;
+use crate::catalog::{TypeSignature, with_catalog_read};
 use crate::storage::btree::{BTreeIndex, CompositeKey};
-use crate::storage::tuple::ScalarValue;
+use crate::storage::tuple::{
+    ScalarValue, append_scalar_value_to_builder, arrow_value_to_scalar_value, scalar_values_schema,
+};
 use crate::utils::adt::misc::compare_values_for_predicate;
 
 pub(crate) const DEFAULT_BTREE_ORDER: usize = 48;
+pub(crate) const COLUMNAR_BATCH_SIZE: usize = 8_192;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ColumnarBatch {
+    pub(crate) record_batch: RecordBatch,
+    pub(crate) deleted_rows: Vec<bool>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ColumnarTable {
+    pub(crate) column_names: Vec<String>,
+    pub(crate) schema: Option<Arc<Schema>>,
+    pub(crate) batches: Vec<ColumnarBatch>,
+    pub(crate) pending_rows: Vec<Vec<ScalarValue>>,
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct StoredIndex {
@@ -45,31 +67,44 @@ pub(crate) struct ScanPredicate {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct InMemoryStorage {
     pub(crate) rows_by_table: HashMap<Oid, Vec<Vec<ScalarValue>>>,
+    pub(crate) columnar_by_table: HashMap<Oid, ColumnarTable>,
     pub(crate) indexes_by_table: HashMap<(Oid, String), StoredIndex>,
 }
 
 impl InMemoryStorage {
+    pub(crate) fn ensure_table(&mut self, table_oid: Oid) -> Result<(), String> {
+        self.rows_by_table.entry(table_oid).or_default();
+        let columnar = self.columnar_by_table.entry(table_oid).or_default();
+        if columnar.schema.is_none() {
+            let rows = self
+                .rows_by_table
+                .get(&table_oid)
+                .cloned()
+                .unwrap_or_default();
+            let row_hint = rows.first().map(std::vec::Vec::as_slice);
+            self.ensure_columnar_schema(table_oid, row_hint)?;
+            if !rows.is_empty() {
+                self.rebuild_columnar_table(table_oid)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn remove_table(&mut self, table_oid: Oid) {
+        self.rows_by_table.remove(&table_oid);
+        self.columnar_by_table.remove(&table_oid);
+        self.drop_all_indexes_for_table(table_oid);
+    }
+
+    #[allow(dead_code)]
     pub(crate) fn scan_rows(
-        &self,
+        &mut self,
         table_oid: Oid,
         offsets: Option<&[usize]>,
         projected_columns: Option<&[usize]>,
     ) -> Vec<Vec<ScalarValue>> {
-        let Some(all_rows) = self.rows_by_table.get(&table_oid) else {
-            return Vec::new();
-        };
-
-        match offsets {
-            Some(offsets) => offsets
-                .iter()
-                .filter_map(|offset| all_rows.get(*offset))
-                .map(|row| project_row(row, projected_columns))
-                .collect(),
-            None => all_rows
-                .iter()
-                .map(|row| project_row(row, projected_columns))
-                .collect(),
-        }
+        self.scan_rows_for_table(table_oid, offsets, &[], projected_columns)
+            .unwrap_or_default()
     }
 
     pub(crate) fn register_index(
@@ -150,6 +185,7 @@ impl InMemoryStorage {
         rows: Vec<Vec<ScalarValue>>,
     ) -> Result<(), String> {
         self.rows_by_table.insert(table_oid, rows);
+        self.rebuild_columnar_table(table_oid)?;
         self.rebuild_indexes_for_table(table_oid)
     }
 
@@ -158,6 +194,7 @@ impl InMemoryStorage {
         table_oid: Oid,
         row: Vec<ScalarValue>,
     ) -> Result<usize, String> {
+        self.ensure_table(table_oid)?;
         let offset = self
             .rows_by_table
             .get(&table_oid)
@@ -182,22 +219,23 @@ impl InMemoryStorage {
         }
 
         if let Some(rows) = self.rows_by_table.get_mut(&table_oid) {
-            rows.push(row);
+            rows.push(row.clone());
         } else {
-            self.rows_by_table.insert(table_oid, vec![row]);
+            self.rows_by_table.insert(table_oid, vec![row.clone()]);
         }
-        let row_len = self
-            .rows_by_table
-            .get(&table_oid)
-            .map_or(0, std::vec::Vec::len);
-        if row_len != offset + 1 {
+
+        if let Err(err) = self.append_row_to_columnar(table_oid, row) {
+            if let Some(rows) = self.rows_by_table.get_mut(&table_oid) {
+                let _ = rows.pop();
+            }
             for (index_name, composite_key) in inserted_keys {
                 if let Some(index) = self.index_mut_for_table(table_oid, &index_name) {
                     index.btree.delete(&composite_key, offset)?;
                 }
             }
-            return Err("failed to append row to storage".to_string());
+            return Err(err);
         }
+
         Ok(offset)
     }
 
@@ -243,7 +281,7 @@ impl InMemoryStorage {
             && offset < rows.len()
         {
             rows[offset] = row;
-            return Ok(());
+            return self.rebuild_columnar_table(table_oid);
         }
         Err(format!(
             "row offset {offset} does not exist in relation OID {table_oid}"
@@ -258,6 +296,7 @@ impl InMemoryStorage {
         if offsets.is_empty() {
             return Ok(());
         }
+
         let Some(rows) = self.rows_by_table.get(&table_oid) else {
             return Err(format!("relation OID {table_oid} has no row storage"));
         };
@@ -296,6 +335,8 @@ impl InMemoryStorage {
             }
         }
 
+        self.mark_deleted_in_columnar(table_oid, &sorted);
+
         if let Some(rows) = self.rows_by_table.get_mut(&table_oid) {
             for offset in sorted.iter().rev() {
                 rows.remove(*offset);
@@ -306,6 +347,36 @@ impl InMemoryStorage {
                 index.btree.remap_offsets_after_deletions(&sorted);
             }
         }
+        self.rebuild_columnar_table(table_oid)
+    }
+
+    pub(crate) fn flush_pending(&mut self, table_oid: Oid) -> Result<(), String> {
+        let pending_rows = {
+            let Some(table) = self.columnar_by_table.get_mut(&table_oid) else {
+                return Ok(());
+            };
+            if table.pending_rows.is_empty() {
+                return Ok(());
+            }
+            std::mem::take(&mut table.pending_rows)
+        };
+
+        self.ensure_columnar_schema(table_oid, pending_rows.first().map(std::vec::Vec::as_slice))?;
+        let schema = self
+            .columnar_by_table
+            .get(&table_oid)
+            .and_then(|table| table.schema.clone())
+            .ok_or_else(|| format!("relation OID {table_oid} is missing columnar schema"))?;
+        let batch = build_record_batch(&schema, &pending_rows)?;
+        let deleted_rows = vec![false; batch.num_rows()];
+        self.columnar_by_table
+            .entry(table_oid)
+            .or_default()
+            .batches
+            .push(ColumnarBatch {
+                record_batch: batch,
+                deleted_rows,
+            });
         Ok(())
     }
 
@@ -320,35 +391,27 @@ impl InMemoryStorage {
     }
 
     pub(crate) fn scan_rows_for_table(
-        &self,
+        &mut self,
         table_oid: Oid,
         offsets: Option<&[usize]>,
         predicates: &[ScanPredicate],
         projected_columns: Option<&[usize]>,
     ) -> Result<Vec<Vec<ScalarValue>>, String> {
-        let Some(rows) = self.rows_by_table.get(&table_oid) else {
+        self.ensure_table(table_oid)?;
+        self.flush_pending(table_oid)?;
+        let Some(table) = self.columnar_by_table.get(&table_oid) else {
             return Ok(Vec::new());
         };
-        let mut matching_rows = Vec::with_capacity(offsets.map_or(rows.len(), <[usize]>::len));
-
-        if let Some(offsets) = offsets {
-            for offset in offsets {
-                let Some(row) = rows.get(*offset) else {
-                    continue;
-                };
-                if row_matches_scan_predicates(row, predicates)? {
-                    matching_rows.push(project_row(row, projected_columns));
-                }
-            }
-            return Ok(matching_rows);
+        if table.batches.is_empty() {
+            return Ok(Vec::new());
         }
 
-        for row in rows {
-            if row_matches_scan_predicates(row, predicates)? {
-                matching_rows.push(project_row(row, projected_columns));
+        match offsets {
+            Some(offsets) => {
+                self.scan_rows_by_offsets(table, offsets, predicates, projected_columns)
             }
+            None => self.scan_all_rows(table, predicates, projected_columns),
         }
-        Ok(matching_rows)
     }
 
     pub(crate) fn index_for_table(&self, table_oid: Oid, index_name: &str) -> Option<&StoredIndex> {
@@ -403,6 +466,147 @@ impl InMemoryStorage {
         Ok(())
     }
 
+    fn append_row_to_columnar(
+        &mut self,
+        table_oid: Oid,
+        row: Vec<ScalarValue>,
+    ) -> Result<(), String> {
+        self.ensure_columnar_schema(table_oid, Some(&row))?;
+        let table = self.columnar_by_table.entry(table_oid).or_default();
+        table.pending_rows.push(row);
+        if table.pending_rows.len() >= COLUMNAR_BATCH_SIZE {
+            self.flush_pending(table_oid)?;
+        }
+        Ok(())
+    }
+
+    fn rebuild_columnar_table(&mut self, table_oid: Oid) -> Result<(), String> {
+        let rows = self
+            .rows_by_table
+            .get(&table_oid)
+            .cloned()
+            .unwrap_or_default();
+        self.ensure_columnar_schema(table_oid, rows.first().map(std::vec::Vec::as_slice))?;
+        let table = self.columnar_by_table.entry(table_oid).or_default();
+        table.batches.clear();
+        table.pending_rows.clear();
+        for chunk in rows.chunks(COLUMNAR_BATCH_SIZE) {
+            let schema = table
+                .schema
+                .clone()
+                .ok_or_else(|| format!("relation OID {table_oid} is missing columnar schema"))?;
+            let batch = build_record_batch(&schema, chunk)?;
+            table.batches.push(ColumnarBatch {
+                record_batch: batch,
+                deleted_rows: vec![false; chunk.len()],
+            });
+        }
+        Ok(())
+    }
+
+    fn ensure_columnar_schema(
+        &mut self,
+        table_oid: Oid,
+        first_row: Option<&[ScalarValue]>,
+    ) -> Result<(), String> {
+        let table = self.columnar_by_table.entry(table_oid).or_default();
+        if let Some((column_names, schema)) = lookup_catalog_schema(table_oid, first_row)? {
+            table.column_names = column_names;
+            table.schema = Some(Arc::new(schema));
+            return Ok(());
+        }
+
+        if table.schema.is_some() {
+            return Ok(());
+        }
+
+        if let Some(row) = first_row {
+            let columns = row
+                .iter()
+                .enumerate()
+                .map(|(idx, value)| (format!("column_{idx}"), value.clone()))
+                .collect::<Vec<_>>();
+            let schema = scalar_values_schema(&columns);
+            table.column_names = columns.into_iter().map(|(name, _)| name).collect();
+            table.schema = Some(Arc::new(schema));
+        }
+        Ok(())
+    }
+
+    fn mark_deleted_in_columnar(&mut self, table_oid: Oid, offsets: &[usize]) {
+        let Some(table) = self.columnar_by_table.get_mut(&table_oid) else {
+            return;
+        };
+        let deleted: HashSet<usize> = offsets.iter().copied().collect();
+        let mut current_offset = 0usize;
+        for batch in &mut table.batches {
+            for (row_idx, deleted_flag) in batch.deleted_rows.iter_mut().enumerate() {
+                let global_offset = current_offset + row_idx;
+                if deleted.contains(&global_offset) {
+                    *deleted_flag = true;
+                }
+            }
+            current_offset += batch.record_batch.num_rows();
+        }
+    }
+
+    fn scan_all_rows(
+        &self,
+        table: &ColumnarTable,
+        predicates: &[ScanPredicate],
+        projected_columns: Option<&[usize]>,
+    ) -> Result<Vec<Vec<ScalarValue>>, String> {
+        let mut rows = Vec::new();
+        for batch in &table.batches {
+            let (filtered_batch, _) = filter_batch(batch, predicates, None)?;
+            rows.extend(record_batch_to_rows(&filtered_batch, projected_columns));
+        }
+        Ok(rows)
+    }
+
+    fn scan_rows_by_offsets(
+        &self,
+        table: &ColumnarTable,
+        offsets: &[usize],
+        predicates: &[ScanPredicate],
+        projected_columns: Option<&[usize]>,
+    ) -> Result<Vec<Vec<ScalarValue>>, String> {
+        let mut rows_by_offset = HashMap::new();
+        let requested_offsets = offsets.iter().copied().collect::<HashSet<_>>();
+        let mut batch_start = 0usize;
+
+        for batch in &table.batches {
+            let batch_len = batch.record_batch.num_rows();
+            let batch_end = batch_start + batch_len;
+            let relevant = requested_offsets
+                .iter()
+                .copied()
+                .filter(|offset| *offset >= batch_start && *offset < batch_end)
+                .collect::<Vec<_>>();
+            if relevant.is_empty() {
+                batch_start = batch_end;
+                continue;
+            }
+
+            let mut selected_rows = vec![false; batch_len];
+            for offset in &relevant {
+                selected_rows[*offset - batch_start] = true;
+            }
+            let (filtered_batch, surviving_local_offsets) =
+                filter_batch(batch, predicates, Some(&selected_rows))?;
+            let batch_rows = record_batch_to_rows(&filtered_batch, projected_columns);
+            for (local_offset, row) in surviving_local_offsets.into_iter().zip(batch_rows) {
+                rows_by_offset.insert(batch_start + local_offset, row);
+            }
+            batch_start = batch_end;
+        }
+
+        Ok(offsets
+            .iter()
+            .filter_map(|offset| rows_by_offset.get(offset).cloned())
+            .collect())
+    }
+
     fn index_names_for_table(&self, table_oid: Oid) -> Vec<String> {
         let mut names = self
             .indexes_by_table
@@ -420,6 +624,147 @@ impl InMemoryStorage {
     }
 }
 
+fn lookup_catalog_schema(
+    table_oid: Oid,
+    first_row: Option<&[ScalarValue]>,
+) -> Result<Option<(Vec<String>, Schema)>, String> {
+    let maybe_table = with_catalog_read(|catalog| {
+        catalog
+            .schemas()
+            .flat_map(crate::catalog::schema::Schema::tables)
+            .find(|table| table.oid() == table_oid)
+            .cloned()
+    });
+    let Some(table) = maybe_table else {
+        return Ok(None);
+    };
+
+    let fields = table
+        .columns()
+        .iter()
+        .enumerate()
+        .map(|(idx, column)| {
+            let data_type = data_type_for_column(
+                column.type_signature(),
+                first_row.and_then(|row| row.get(idx)),
+            );
+            Field::new(column.name(), data_type, true)
+        })
+        .collect::<Vec<_>>();
+    let column_names = table
+        .columns()
+        .iter()
+        .map(|column| column.name().to_string())
+        .collect::<Vec<_>>();
+    Ok(Some((column_names, Schema::new(fields))))
+}
+
+fn data_type_for_column(type_signature: TypeSignature, _sample: Option<&ScalarValue>) -> DataType {
+    match type_signature {
+        TypeSignature::Bool => DataType::Boolean,
+        TypeSignature::Int8 => DataType::Int64,
+        TypeSignature::Float8 => DataType::Float64,
+        TypeSignature::Numeric => DataType::Utf8,
+        TypeSignature::Text => DataType::Utf8,
+        TypeSignature::Date => DataType::Date32,
+        TypeSignature::Timestamp => DataType::Timestamp(TimeUnit::Microsecond, None),
+        TypeSignature::Vector(Some(len)) => DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Float64, true)),
+            len as i32,
+        ),
+        TypeSignature::Vector(None) => DataType::Utf8,
+    }
+}
+
+fn build_record_batch(
+    schema: &Arc<Schema>,
+    rows: &[Vec<ScalarValue>],
+) -> Result<RecordBatch, String> {
+    if schema.fields().is_empty() {
+        return Ok(RecordBatch::new_empty(schema.clone()));
+    }
+    let mut columns = Vec::with_capacity(schema.fields().len());
+    for (column_idx, field) in schema.fields().iter().enumerate() {
+        let mut builder = arrow::array::builder::make_builder(field.data_type(), rows.len());
+        for row in rows {
+            let value = row.get(column_idx).unwrap_or(&ScalarValue::Null);
+            append_scalar_value_to_builder(value, builder.as_mut())?;
+        }
+        columns.push(builder.finish());
+    }
+    RecordBatch::try_new(schema.clone(), columns).map_err(|err| err.to_string())
+}
+
+fn filter_batch(
+    batch: &ColumnarBatch,
+    predicates: &[ScanPredicate],
+    selected_rows: Option<&[bool]>,
+) -> Result<(RecordBatch, Vec<usize>), String> {
+    let row_count = batch.record_batch.num_rows();
+    let mut mask_builder = BooleanBuilder::with_capacity(row_count);
+    let mut surviving_offsets = Vec::new();
+
+    for row_idx in 0..row_count {
+        let selected = selected_rows.is_none_or(|rows| rows.get(row_idx).copied().unwrap_or(false));
+        let deleted = batch.deleted_rows.get(row_idx).copied().unwrap_or(false);
+        if !selected || deleted {
+            mask_builder.append_value(false);
+            continue;
+        }
+        if record_batch_row_matches_predicates(&batch.record_batch, row_idx, predicates)? {
+            mask_builder.append_value(true);
+            surviving_offsets.push(row_idx);
+        } else {
+            mask_builder.append_value(false);
+        }
+    }
+
+    let mask: BooleanArray = mask_builder.finish();
+    let filtered =
+        filter_record_batch(&batch.record_batch, &mask).map_err(|err| err.to_string())?;
+    Ok((filtered, surviving_offsets))
+}
+
+fn record_batch_to_rows(
+    batch: &RecordBatch,
+    projected_columns: Option<&[usize]>,
+) -> Vec<Vec<ScalarValue>> {
+    let projected = projected_columns
+        .map(<[usize]>::to_vec)
+        .unwrap_or_else(|| (0..batch.num_columns()).collect());
+    let mut rows = Vec::with_capacity(batch.num_rows());
+    for row_idx in 0..batch.num_rows() {
+        let mut row = Vec::with_capacity(projected.len());
+        for column_idx in &projected {
+            if let Some(column) = batch.columns().get(*column_idx) {
+                row.push(arrow_value_to_scalar_value(column.as_ref(), row_idx));
+            }
+        }
+        rows.push(row);
+    }
+    rows
+}
+
+fn record_batch_row_matches_predicates(
+    batch: &RecordBatch,
+    row_idx: usize,
+    predicates: &[ScanPredicate],
+) -> Result<bool, String> {
+    for predicate in predicates {
+        let Some(column) = batch.columns().get(predicate.column_index) else {
+            return Err(format!(
+                "row does not have predicate column offset {}",
+                predicate.column_index
+            ));
+        };
+        let value = arrow_value_to_scalar_value(column.as_ref(), row_idx);
+        if !scan_predicate_matches(&value, predicate)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 fn composite_key_from_row(row: &[ScalarValue], indexes: &[usize]) -> Result<CompositeKey, String> {
     let mut out = Vec::with_capacity(indexes.len());
     for idx in indexes {
@@ -432,36 +777,8 @@ fn composite_key_from_row(row: &[ScalarValue], indexes: &[usize]) -> Result<Comp
     Ok(out)
 }
 
-fn project_row(row: &[ScalarValue], projected_columns: Option<&[usize]>) -> Vec<ScalarValue> {
-    match projected_columns {
-        Some(columns) => columns
-            .iter()
-            .filter_map(|idx| row.get(*idx).cloned())
-            .collect(),
-        None => row.to_vec(),
-    }
-}
-
 fn composite_key_contains_nulls(key: &[ScalarValue]) -> bool {
     key.iter().any(|value| matches!(value, ScalarValue::Null))
-}
-
-fn row_matches_scan_predicates(
-    row: &[ScalarValue],
-    predicates: &[ScanPredicate],
-) -> Result<bool, String> {
-    for predicate in predicates {
-        let value = row.get(predicate.column_index).ok_or_else(|| {
-            format!(
-                "row does not have predicate column offset {}",
-                predicate.column_index
-            )
-        })?;
-        if !scan_predicate_matches(value, predicate)? {
-            return Ok(false);
-        }
-    }
-    Ok(true)
 }
 
 fn scan_predicate_matches(left: &ScalarValue, predicate: &ScanPredicate) -> Result<bool, String> {
@@ -481,20 +798,22 @@ fn scan_predicate_matches(left: &ScalarValue, predicate: &ScanPredicate) -> Resu
 
 #[cfg(test)]
 mod tests {
-    use super::{InMemoryStorage, ScanPredicate, ScanPredicateOp};
+    use super::{COLUMNAR_BATCH_SIZE, InMemoryStorage, ScanPredicate, ScanPredicateOp};
     use crate::storage::tuple::ScalarValue;
 
     #[test]
     fn scan_rows_for_table_filters_without_cloning_non_matches() {
         let mut storage = InMemoryStorage::default();
-        storage.rows_by_table.insert(
-            42,
-            vec![
-                vec![ScalarValue::Int(1), ScalarValue::Text("a".to_string())],
-                vec![ScalarValue::Int(2), ScalarValue::Text("b".to_string())],
-                vec![ScalarValue::Int(3), ScalarValue::Text("c".to_string())],
-            ],
-        );
+        storage
+            .replace_rows_for_table(
+                42,
+                vec![
+                    vec![ScalarValue::Int(1), ScalarValue::Text("a".to_string())],
+                    vec![ScalarValue::Int(2), ScalarValue::Text("b".to_string())],
+                    vec![ScalarValue::Int(3), ScalarValue::Text("c".to_string())],
+                ],
+            )
+            .expect("replace rows");
 
         let rows = storage
             .scan_rows_for_table(
@@ -521,19 +840,21 @@ mod tests {
     #[test]
     fn scan_rows_for_table_honors_offsets() {
         let mut storage = InMemoryStorage::default();
-        storage.rows_by_table.insert(
-            42,
-            vec![
-                vec![ScalarValue::Int(1)],
-                vec![ScalarValue::Int(2)],
-                vec![ScalarValue::Int(3)],
-            ],
-        );
+        storage
+            .replace_rows_for_table(
+                42,
+                vec![
+                    vec![ScalarValue::Int(1)],
+                    vec![ScalarValue::Int(2)],
+                    vec![ScalarValue::Int(3)],
+                ],
+            )
+            .expect("replace rows");
 
         let rows = storage
             .scan_rows_for_table(
                 42,
-                Some(&[2, 0]),
+                Some(&[2, 0, 2]),
                 &[ScanPredicate {
                     column_index: 0,
                     op: ScanPredicateOp::NotEq,
@@ -543,7 +864,55 @@ mod tests {
             )
             .expect("scan should succeed");
 
-        assert_eq!(rows, vec![vec![ScalarValue::Int(3)]]);
+        assert_eq!(
+            rows,
+            vec![vec![ScalarValue::Int(3)], vec![ScalarValue::Int(3)]]
+        );
+    }
+
+    #[test]
+    fn append_flushes_pending_rows_into_record_batches() {
+        let mut storage = InMemoryStorage::default();
+        storage.rows_by_table.insert(7, Vec::new());
+        for idx in 0..=COLUMNAR_BATCH_SIZE {
+            storage
+                .append_row(7, vec![ScalarValue::Int(idx as i64)])
+                .expect("append row");
+        }
+
+        let table = storage
+            .columnar_by_table
+            .get(&7)
+            .expect("columnar table should exist");
+        assert_eq!(table.batches.len(), 1);
+        assert_eq!(table.pending_rows.len(), 1);
+    }
+
+    #[test]
+    fn delete_marks_rows_and_rebuilds_columnar_storage() {
+        let mut storage = InMemoryStorage::default();
+        storage
+            .replace_rows_for_table(
+                9,
+                vec![
+                    vec![ScalarValue::Int(1)],
+                    vec![ScalarValue::Int(2)],
+                    vec![ScalarValue::Int(3)],
+                ],
+            )
+            .expect("replace rows");
+
+        storage
+            .delete_rows_by_offsets(9, &[1])
+            .expect("delete should succeed");
+
+        let rows = storage
+            .scan_rows_for_table(9, None, &[], None)
+            .expect("scan should succeed");
+        assert_eq!(
+            rows,
+            vec![vec![ScalarValue::Int(1)], vec![ScalarValue::Int(3)]]
+        );
     }
 }
 

--- a/src/storage/tuple.rs
+++ b/src/storage/tuple.rs
@@ -1,3 +1,20 @@
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayBuilder, BinaryArray, BinaryBuilder, BooleanArray, BooleanBuilder, Date32Array,
+    Date32Builder, FixedSizeListArray, FixedSizeListBuilder, Float64Array, Float64Builder,
+    Int64Array, Int64Builder, NullArray, NullBuilder, StringArray, StringBuilder,
+    TimestampMicrosecondArray, TimestampMicrosecondBuilder,
+};
+use arrow::datatypes::{DataType, Field, Schema};
+use serde_json::{Value as JsonValue, json};
+
+use crate::utils::adt::datetime::{
+    DateValue, datetime_to_epoch_seconds, format_date, format_timestamp, parse_datetime_text,
+};
+
+const ENCODED_SCALAR_PREFIX: &str = "__openassay__:";
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScalarValue {
     Null,
@@ -39,6 +56,83 @@ impl ScalarValue {
             Self::Vector(values) => render_vector_literal(values),
         }
     }
+}
+
+pub fn scalar_value_to_arrow_value(val: &ScalarValue, builder: &mut dyn ArrayBuilder) {
+    append_scalar_value_to_builder(val, builder)
+        .expect("Arrow builder type should match inferred storage schema");
+}
+
+pub fn arrow_value_to_scalar_value(array: &dyn Array, index: usize) -> ScalarValue {
+    if array.is_null(index) {
+        return ScalarValue::Null;
+    }
+
+    if let Some(array) = array.as_any().downcast_ref::<NullArray>() {
+        let _ = array;
+        return ScalarValue::Null;
+    }
+    if let Some(array) = array.as_any().downcast_ref::<BooleanArray>() {
+        return ScalarValue::Bool(array.value(index));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<Int64Array>() {
+        return ScalarValue::Int(array.value(index));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<Float64Array>() {
+        return ScalarValue::Float(array.value(index));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
+        return decode_string_scalar(array.value(index));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<BinaryArray>() {
+        return ScalarValue::Text(String::from_utf8_lossy(array.value(index)).into_owned());
+    }
+    if let Some(array) = array.as_any().downcast_ref::<Date32Array>() {
+        let days = array.value(index) as i64;
+        let epoch_seconds = days.saturating_mul(86_400);
+        let date = crate::utils::adt::datetime::datetime_from_epoch_seconds(epoch_seconds).date;
+        return ScalarValue::Text(format_date(date));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<TimestampMicrosecondArray>() {
+        let value = array.value(index);
+        if value == i64::MAX {
+            return ScalarValue::Text("infinity".to_string());
+        }
+        if value == i64::MIN {
+            return ScalarValue::Text("-infinity".to_string());
+        }
+        let seconds = value.div_euclid(1_000_000);
+        let micros = value.rem_euclid(1_000_000) as u32;
+        let mut datetime = crate::utils::adt::datetime::datetime_from_epoch_seconds(seconds);
+        datetime.microsecond = micros;
+        return ScalarValue::Text(format_timestamp(datetime));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<FixedSizeListArray>() {
+        let values = array.value(index);
+        let float_values = values
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("vector storage should use Float64 child arrays");
+        let mut out = Vec::with_capacity(float_values.len());
+        for idx in 0..float_values.len() {
+            if float_values.is_null(idx) {
+                out.push(0.0);
+            } else {
+                out.push(float_values.value(idx) as f32);
+            }
+        }
+        return ScalarValue::Vector(out);
+    }
+
+    ScalarValue::Text(array_value_to_string(array, index))
+}
+
+pub fn scalar_values_schema(columns: &[(String, ScalarValue)]) -> Schema {
+    let fields: Vec<Field> = columns
+        .iter()
+        .map(|(name, value)| Field::new(name, infer_data_type(value), true))
+        .collect();
+    Schema::new(fields)
 }
 
 /// Render a float8 (f64) value matching PostgreSQL's output format.
@@ -96,6 +190,372 @@ fn render_vector_literal(values: &[f32]) -> String {
     format!("[{}]", parts.join(","))
 }
 
+pub(crate) fn append_scalar_value_to_builder(
+    val: &ScalarValue,
+    builder: &mut dyn ArrayBuilder,
+) -> Result<(), String> {
+    if matches!(val, ScalarValue::Null) {
+        append_null_to_builder(builder)?;
+        return Ok(());
+    }
+
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<NullBuilder>() {
+        let _ = builder;
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<BooleanBuilder>() {
+        match val {
+            ScalarValue::Bool(v) => builder.append_value(*v),
+            _ => builder.append_null(),
+        }
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<Int64Builder>() {
+        match val {
+            ScalarValue::Int(v) => builder.append_value(*v),
+            _ => builder.append_null(),
+        }
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<Float64Builder>() {
+        match val {
+            ScalarValue::Float(v) => builder.append_value(*v),
+            _ => builder.append_null(),
+        }
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<StringBuilder>() {
+        match val {
+            ScalarValue::Text(v) => builder.append_value(encode_text_scalar(v)),
+            _ => builder.append_value(encode_tagged_scalar(val)),
+        }
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<BinaryBuilder>() {
+        builder.append_value(val.render().into_bytes());
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<Date32Builder>() {
+        match val {
+            ScalarValue::Text(text) => {
+                let days = date_text_to_date32(text)?;
+                builder.append_value(days);
+            }
+            _ => builder.append_null(),
+        }
+        return Ok(());
+    }
+    if let Some(builder) = builder
+        .as_any_mut()
+        .downcast_mut::<TimestampMicrosecondBuilder>()
+    {
+        match val {
+            ScalarValue::Text(text) => {
+                let micros = timestamp_text_to_microseconds(text)?;
+                builder.append_value(micros);
+            }
+            _ => builder.append_null(),
+        }
+        return Ok(());
+    }
+    if let Some(builder) = builder
+        .as_any_mut()
+        .downcast_mut::<FixedSizeListBuilder<Box<dyn ArrayBuilder>>>()
+    {
+        match val {
+            ScalarValue::Vector(values) => {
+                let expected_len = builder.value_length() as usize;
+                if values.len() != expected_len {
+                    return Err(format!(
+                        "vector length {} does not match schema length {expected_len}",
+                        values.len()
+                    ));
+                }
+                for value in values {
+                    append_scalar_value_to_builder(
+                        &ScalarValue::Float(f64::from(*value)),
+                        builder.values().as_mut(),
+                    )?;
+                }
+                builder.append(true);
+            }
+            _ => {
+                for _ in 0..builder.value_length() {
+                    append_null_to_builder(builder.values().as_mut())?;
+                }
+                builder.append(false);
+            }
+        }
+        return Ok(());
+    }
+
+    Err("unsupported Arrow builder type".to_string())
+}
+
+fn append_null_to_builder(builder: &mut dyn ArrayBuilder) -> Result<(), String> {
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<NullBuilder>() {
+        builder.append_null();
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<BooleanBuilder>() {
+        builder.append_null();
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<Int64Builder>() {
+        builder.append_null();
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<Float64Builder>() {
+        builder.append_null();
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<StringBuilder>() {
+        builder.append_null();
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<BinaryBuilder>() {
+        builder.append_null();
+        return Ok(());
+    }
+    if let Some(builder) = builder.as_any_mut().downcast_mut::<Date32Builder>() {
+        builder.append_null();
+        return Ok(());
+    }
+    if let Some(builder) = builder
+        .as_any_mut()
+        .downcast_mut::<TimestampMicrosecondBuilder>()
+    {
+        builder.append_null();
+        return Ok(());
+    }
+    if let Some(builder) = builder
+        .as_any_mut()
+        .downcast_mut::<FixedSizeListBuilder<Box<dyn ArrayBuilder>>>()
+    {
+        for _ in 0..builder.value_length() {
+            append_null_to_builder(builder.values().as_mut())?;
+        }
+        builder.append(false);
+        return Ok(());
+    }
+
+    Err("unsupported Arrow builder type".to_string())
+}
+
+fn infer_data_type(value: &ScalarValue) -> DataType {
+    match value {
+        ScalarValue::Null => DataType::Utf8,
+        ScalarValue::Bool(_) => DataType::Boolean,
+        ScalarValue::Int(_) => DataType::Int64,
+        ScalarValue::Float(_) => DataType::Float64,
+        ScalarValue::Numeric(_) => DataType::Utf8,
+        ScalarValue::Text(_) => DataType::Utf8,
+        ScalarValue::Array(_) => DataType::Utf8,
+        ScalarValue::Record(_) => DataType::Utf8,
+        ScalarValue::Vector(values) => DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Float64, true)),
+            values.len() as i32,
+        ),
+    }
+}
+
+fn encode_text_scalar(value: &str) -> String {
+    if value.starts_with(ENCODED_SCALAR_PREFIX) {
+        format!("{ENCODED_SCALAR_PREFIX}text:{value}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn encode_tagged_scalar(value: &ScalarValue) -> String {
+    format!("{ENCODED_SCALAR_PREFIX}{}", scalar_to_json(value))
+}
+
+fn decode_string_scalar(value: &str) -> ScalarValue {
+    if let Some(encoded) = value.strip_prefix(ENCODED_SCALAR_PREFIX) {
+        if let Some(text) = encoded.strip_prefix("text:") {
+            return ScalarValue::Text(text.to_string());
+        }
+        return json_to_scalar(encoded).unwrap_or_else(|| ScalarValue::Text(value.to_string()));
+    }
+    ScalarValue::Text(value.to_string())
+}
+
+fn scalar_to_json(value: &ScalarValue) -> String {
+    json_scalar_value(value).to_string()
+}
+
+fn json_to_scalar(value: &str) -> Option<ScalarValue> {
+    let json: JsonValue = serde_json::from_str(value).ok()?;
+    scalar_from_json_value(&json).ok()
+}
+
+fn json_scalar_value(value: &ScalarValue) -> JsonValue {
+    match value {
+        ScalarValue::Null => json!({ "type": "null" }),
+        ScalarValue::Bool(v) => json!({ "type": "bool", "value": v }),
+        ScalarValue::Int(v) => json!({ "type": "int", "value": v }),
+        ScalarValue::Float(v) => json!({ "type": "float", "value": v }),
+        ScalarValue::Numeric(v) => json!({ "type": "numeric", "value": v.to_string() }),
+        ScalarValue::Text(v) => json!({ "type": "text", "value": v }),
+        ScalarValue::Array(values) => json!({
+            "type": "array",
+            "value": values.iter().map(json_scalar_value).collect::<Vec<_>>()
+        }),
+        ScalarValue::Record(values) => json!({
+            "type": "record",
+            "value": values.iter().map(json_scalar_value).collect::<Vec<_>>()
+        }),
+        ScalarValue::Vector(values) => json!({ "type": "vector", "value": values }),
+    }
+}
+
+fn scalar_from_json_value(value: &JsonValue) -> Result<ScalarValue, String> {
+    let tag = value
+        .get("type")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| "encoded scalar type is missing".to_string())?;
+    match tag {
+        "null" => Ok(ScalarValue::Null),
+        "bool" => value
+            .get("value")
+            .and_then(JsonValue::as_bool)
+            .map(ScalarValue::Bool)
+            .ok_or_else(|| "encoded bool value is missing".to_string()),
+        "int" => value
+            .get("value")
+            .and_then(JsonValue::as_i64)
+            .map(ScalarValue::Int)
+            .ok_or_else(|| "encoded int value is missing".to_string()),
+        "float" => value
+            .get("value")
+            .and_then(JsonValue::as_f64)
+            .map(ScalarValue::Float)
+            .ok_or_else(|| "encoded float value is missing".to_string()),
+        "numeric" => value
+            .get("value")
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| "encoded numeric value is missing".to_string())?
+            .parse()
+            .map(ScalarValue::Numeric)
+            .map_err(|_| "encoded numeric value is invalid".to_string()),
+        "text" => value
+            .get("value")
+            .and_then(JsonValue::as_str)
+            .map(|v| ScalarValue::Text(v.to_string()))
+            .ok_or_else(|| "encoded text value is missing".to_string()),
+        "array" => decode_json_sequence(value, ScalarValue::Array),
+        "record" => decode_json_sequence(value, ScalarValue::Record),
+        "vector" => {
+            let values = value
+                .get("value")
+                .and_then(JsonValue::as_array)
+                .ok_or_else(|| "encoded vector is missing".to_string())?
+                .iter()
+                .map(|item| {
+                    item.as_f64()
+                        .map(|v| v as f32)
+                        .ok_or_else(|| "encoded vector element is invalid".to_string())
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(ScalarValue::Vector(values))
+        }
+        _ => Err("unsupported encoded scalar type".to_string()),
+    }
+}
+
+fn decode_json_sequence(
+    value: &JsonValue,
+    wrap: fn(Vec<ScalarValue>) -> ScalarValue,
+) -> Result<ScalarValue, String> {
+    let items = value
+        .get("value")
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| "encoded sequence is missing".to_string())?
+        .iter()
+        .map(scalar_from_json_value)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(wrap(items))
+}
+
+fn date_text_to_date32(text: &str) -> Result<i32, String> {
+    let text = text.trim();
+    if text.eq_ignore_ascii_case("infinity") {
+        return Ok(days_since_epoch(DateValue {
+            year: 294_276,
+            month: 12,
+            day: 31,
+        }));
+    }
+    if text.eq_ignore_ascii_case("-infinity") {
+        return Ok(days_since_epoch(DateValue {
+            year: -4_713,
+            month: 1,
+            day: 1,
+        }));
+    }
+    let datetime = parse_datetime_text(text).map_err(|err| err.message)?;
+    Ok(days_since_epoch(datetime.date))
+}
+
+fn timestamp_text_to_microseconds(text: &str) -> Result<i64, String> {
+    let text = text.trim();
+    if text.eq_ignore_ascii_case("infinity") {
+        return Ok(i64::MAX);
+    }
+    if text.eq_ignore_ascii_case("-infinity") {
+        return Ok(i64::MIN);
+    }
+    let datetime = parse_datetime_text(text).map_err(|err| err.message)?;
+    let seconds = datetime_to_epoch_seconds(datetime);
+    Ok(seconds
+        .saturating_mul(1_000_000)
+        .saturating_add(i64::from(datetime.microsecond)))
+}
+
+fn days_since_epoch(date: DateValue) -> i32 {
+    let epoch = parse_datetime_text("1970-01-01")
+        .expect("1970-01-01 should parse")
+        .date;
+    let target = parse_datetime_text(&format_date(date))
+        .expect("formatted date should parse")
+        .date;
+    let epoch_seconds = datetime_to_epoch_seconds(crate::utils::adt::datetime::DateTimeValue {
+        date: epoch,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        microsecond: 0,
+    });
+    let target_seconds = datetime_to_epoch_seconds(crate::utils::adt::datetime::DateTimeValue {
+        date: target,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        microsecond: 0,
+    });
+    ((target_seconds - epoch_seconds) / 86_400) as i32
+}
+
+fn array_value_to_string(array: &dyn Array, index: usize) -> String {
+    if array.is_null(index) {
+        return "NULL".to_string();
+    }
+    if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
+        return array.value(index).to_string();
+    }
+    if let Some(array) = array.as_any().downcast_ref::<BooleanArray>() {
+        return if array.value(index) { "t" } else { "f" }.to_string();
+    }
+    if let Some(array) = array.as_any().downcast_ref::<Int64Array>() {
+        return array.value(index).to_string();
+    }
+    if let Some(array) = array.as_any().downcast_ref::<Float64Array>() {
+        return render_float8(array.value(index));
+    }
+    "NULL".to_string()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CopyBinaryColumn {
     pub name: String,
@@ -107,4 +567,65 @@ pub struct CopyBinarySnapshot {
     pub qualified_name: String,
     pub columns: Vec<CopyBinaryColumn>,
     pub rows: Vec<Vec<ScalarValue>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::builder::make_builder;
+
+    use super::{
+        ScalarValue, arrow_value_to_scalar_value, scalar_value_to_arrow_value, scalar_values_schema,
+    };
+
+    #[test]
+    fn scalar_value_arrow_roundtrip_preserves_supported_variants() {
+        let columns = vec![
+            ("flag".to_string(), ScalarValue::Bool(true)),
+            ("count".to_string(), ScalarValue::Int(7)),
+            ("ratio".to_string(), ScalarValue::Float(3.5)),
+            (
+                "amount".to_string(),
+                ScalarValue::Numeric("42.125".parse().expect("numeric")),
+            ),
+            ("name".to_string(), ScalarValue::Text("alpha".to_string())),
+            (
+                "items".to_string(),
+                ScalarValue::Array(vec![
+                    ScalarValue::Int(1),
+                    ScalarValue::Text("x".to_string()),
+                ]),
+            ),
+            (
+                "record".to_string(),
+                ScalarValue::Record(vec![ScalarValue::Bool(false), ScalarValue::Int(9)]),
+            ),
+            (
+                "embedding".to_string(),
+                ScalarValue::Vector(vec![1.0, 2.5, 3.0]),
+            ),
+        ];
+        let schema = scalar_values_schema(&columns);
+
+        for (idx, (_, value)) in columns.iter().enumerate() {
+            let mut builder = make_builder(schema.field(idx).data_type(), 1);
+            scalar_value_to_arrow_value(value, builder.as_mut());
+            let array = builder.finish();
+            let actual = arrow_value_to_scalar_value(array.as_ref(), 0);
+            assert_eq!(&actual, value);
+        }
+    }
+
+    #[test]
+    fn utf8_escape_roundtrip_preserves_user_text_prefixes() {
+        let columns = vec![(
+            "text".to_string(),
+            ScalarValue::Text("__openassay__:literal".to_string()),
+        )];
+        let schema = scalar_values_schema(&columns);
+        let mut builder = make_builder(schema.field(0).data_type(), 1);
+        scalar_value_to_arrow_value(&columns[0].1, builder.as_mut());
+        let array = builder.finish();
+        let actual = arrow_value_to_scalar_value(array.as_ref(), 0);
+        assert_eq!(actual, columns[0].1);
+    }
 }

--- a/src/tcop/engine.rs
+++ b/src/tcop/engine.rs
@@ -865,6 +865,7 @@ pub(crate) fn with_ext_write<T>(f: impl FnOnce(&mut ExtensionState) -> T) -> T {
 pub struct EngineStateSnapshot {
     catalog: crate::catalog::Catalog,
     rows_by_table: HashMap<Oid, Vec<Vec<ScalarValue>>>,
+    columnar_by_table: HashMap<Oid, crate::storage::heap::ColumnarTable>,
     indexes_by_table: HashMap<(Oid, String), crate::storage::heap::StoredIndex>,
     pub(crate) sequences: HashMap<String, SequenceState>,
     security: crate::security::SecurityState,
@@ -874,6 +875,7 @@ pub fn snapshot_state() -> EngineStateSnapshot {
     EngineStateSnapshot {
         catalog: with_catalog_read(|catalog| catalog.clone()),
         rows_by_table: with_storage_read(|storage| storage.rows_by_table.clone()),
+        columnar_by_table: with_storage_read(|storage| storage.columnar_by_table.clone()),
         indexes_by_table: with_storage_read(|storage| storage.indexes_by_table.clone()),
         sequences: with_sequences_read(|sequences| sequences.clone()),
         security: security::snapshot_state(),
@@ -884,6 +886,7 @@ pub fn restore_state(snapshot: EngineStateSnapshot) {
     let EngineStateSnapshot {
         catalog: next_catalog,
         rows_by_table: next_rows,
+        columnar_by_table: next_columnar,
         indexes_by_table: next_indexes,
         sequences: next_sequences,
         security: next_security,
@@ -893,6 +896,7 @@ pub fn restore_state(snapshot: EngineStateSnapshot) {
     });
     with_storage_write(|storage| {
         storage.rows_by_table = next_rows;
+        storage.columnar_by_table = next_columnar;
         storage.indexes_by_table = next_indexes;
     });
     with_sequences_write(|sequences| {
@@ -905,6 +909,7 @@ pub fn restore_state(snapshot: EngineStateSnapshot) {
 pub fn reset_global_storage_for_tests() {
     with_storage_write(|storage| {
         storage.rows_by_table.clear();
+        storage.columnar_by_table.clear();
         storage.indexes_by_table.clear();
     });
     with_sequences_write(|sequences| {


### PR DESCRIPTION
Replaces row-oriented Vec<Vec<ScalarValue>> with Arrow RecordBatch columnar storage. INSERT buffers rows, flushes to RecordBatch. Scans convert back to ScalarValue at boundary. Foundation for 10-50x query speedups.