### PR TITLE
feat(iceberg): catalog browsing, schema evolution, partition pruning, cloud storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -1366,6 +1367,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1502,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1497,6 +1524,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2160,6 +2188,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "ring",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2261,7 @@ dependencies = [
  "hmac",
  "js-sys",
  "md-5",
+ "object_store",
  "parquet",
  "pbkdf2",
  "postgres-protocol",
@@ -2202,7 +2269,7 @@ dependencies = [
  "ratatui",
  "rcgen",
  "regex",
- "reqwest",
+ "reqwest 0.13.2",
  "rust_decimal",
  "rustls",
  "serde_json",
@@ -2680,6 +2747,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3069,48 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3130,6 +3249,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3146,6 +3266,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3327,6 +3456,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3907,7 +4048,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4242,6 +4395,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.3.32"
 hmac = "0.12.1"
 js-sys = "0.3.91"
 md-5 = "0.10.6"
+object_store = "0.12.4"
 parquet = "58.0.0"
 pbkdf2 = "0.12.2"
 postgres-protocol = "0.6.10"
@@ -55,6 +56,7 @@ serde_json.workspace = true
 sha2.workspace = true
 sha1.workspace = true
 uuid = { workspace = true, features = ["v1", "v4", "v5"] }
+object_store = { workspace = true, features = ["fs"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen.workspace = true
@@ -77,6 +79,7 @@ rcgen.workspace = true
 rustls.workspace = true
 reqwest = { workspace = true, features = ["rustls"] }
 tungstenite = { workspace = true, features = ["native-tls"] }
+object_store = { workspace = true, features = ["aws", "azure", "gcp", "fs"] }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -32,6 +32,16 @@ struct BrowserQueryResult {
     rows_affected: u64,
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = browse_catalog_json))]
+pub async fn browse_catalog_json(path: &str) -> String {
+    browse_catalog_json_internal(path).await
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = browse_catalog))]
+pub async fn browse_catalog(path: &str) -> String {
+    browse_catalog_json(path).await
+}
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub async fn execute_sql(sql: &str) -> String {
     execute_sql_internal(sql, true).await
@@ -403,6 +413,93 @@ fn render_results_json_payload(results: &[BrowserQueryResult]) -> String {
         "results": result_rows,
     })
     .to_string()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn browse_catalog_json_internal(path: &str) -> String {
+    match crate::catalog::iceberg::browse_iceberg_catalogs(path).await {
+        Ok(catalogs) => {
+            let payload = catalogs
+                .into_iter()
+                .map(|catalog| {
+                    json!({
+                        "name": catalog.name,
+                        "kind": "iceberg",
+                        "location": catalog.location,
+                        "namespaces": catalog.namespaces.into_iter().map(|namespace| {
+                            json!({
+                                "name": namespace.schema.name(),
+                                "namespace_path": namespace.namespace_path,
+                                "tables": namespace.tables.into_iter().map(|table| {
+                                    json!({
+                                        "name": table.table.name(),
+                                        "schema_name": table.table.schema_name(),
+                                        "kind": "BASE TABLE",
+                                        "location": table.location,
+                                        "columns": table.table.columns().iter().map(|column| {
+                                            json!({
+                                                "name": column.name(),
+                                                "ordinal": column.ordinal() + 1,
+                                                "nullable": column.nullable(),
+                                                "data_type": browser_type_name(column.type_signature()),
+                                            })
+                                        }).collect::<Vec<_>>(),
+                                        "metadata": {
+                                            "table_root": table.metadata.table_root,
+                                            "metadata_file": table.metadata.metadata_file,
+                                            "table_uuid": table.metadata.table_uuid,
+                                            "format_version": table.metadata.format_version,
+                                            "last_updated_ms": table.metadata.last_updated_ms,
+                                            "current_schema_id": table.metadata.current_schema_id,
+                                            "partition_spec": table.metadata.partition_spec_json,
+                                            "snapshot_count": table.metadata.snapshot_count,
+                                            "total_data_files": table.metadata.total_data_files,
+                                            "partition_columns": table.metadata.partition_columns,
+                                            "column_aliases": table.metadata.column_aliases,
+                                        }
+                                    })
+                                }).collect::<Vec<_>>(),
+                            })
+                        }).collect::<Vec<_>>(),
+                    })
+                })
+                .collect::<Vec<_>>();
+            json!({
+                "ok": true,
+                "catalogs": payload,
+            })
+            .to_string()
+        }
+        Err(error) => json!({
+            "ok": false,
+            "error": error.message,
+            "catalogs": [],
+        })
+        .to_string(),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn browse_catalog_json_internal(_path: &str) -> String {
+    json!({
+        "ok": false,
+        "error": "catalog browsing is not supported on wasm targets",
+        "catalogs": [],
+    })
+    .to_string()
+}
+
+fn browser_type_name(signature: crate::catalog::TypeSignature) -> &'static str {
+    match signature {
+        crate::catalog::TypeSignature::Bool => "boolean",
+        crate::catalog::TypeSignature::Int8 => "bigint",
+        crate::catalog::TypeSignature::Float8 => "double precision",
+        crate::catalog::TypeSignature::Numeric => "numeric",
+        crate::catalog::TypeSignature::Text => "text",
+        crate::catalog::TypeSignature::Date => "date",
+        crate::catalog::TypeSignature::Timestamp => "timestamp without time zone",
+        crate::catalog::TypeSignature::Vector(_) => "vector",
+    }
 }
 
 #[cfg(test)]

--- a/src/catalog/iceberg.rs
+++ b/src/catalog/iceberg.rs
@@ -1,0 +1,1620 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use base64::Engine;
+use bytes::Bytes;
+use futures::TryStreamExt;
+use object_store::local::LocalFileSystem;
+use object_store::path::Path as ObjectPath;
+use object_store::{
+    DynObjectStore, ObjectMeta, ObjectStore, aws::AmazonS3Builder, azure::MicrosoftAzureBuilder,
+    gcp::GoogleCloudStorageBuilder,
+};
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::record::Field as ParquetField;
+use serde_json::Value as JsonValue;
+
+use super::{CatalogError, Column, Schema, Table, TableKind, TypeSignature};
+use crate::parser::ast::{BinaryOp, Expr, UnaryOp};
+use crate::storage::tuple::ScalarValue;
+use crate::tcop::engine::EngineError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IcebergStorageKind {
+    Local,
+    S3,
+    Gcs,
+    AzureBlob,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IcebergObjectLocation {
+    raw: String,
+    store_kind: IcebergStorageKind,
+    bucket: Option<String>,
+    path: String,
+}
+
+impl IcebergObjectLocation {
+    pub fn parse(input: &str) -> Result<Self, CatalogError> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(catalog_error("Iceberg path cannot be empty"));
+        }
+
+        if let Some((scheme, rest)) = trimmed.split_once("://") {
+            let store_kind = match scheme.to_ascii_lowercase().as_str() {
+                "s3" => IcebergStorageKind::S3,
+                "gs" | "gcs" => IcebergStorageKind::Gcs,
+                "az" | "azure" | "abfs" | "abfss" => IcebergStorageKind::AzureBlob,
+                "file" => IcebergStorageKind::Local,
+                _ => {
+                    return Err(catalog_error(format!(
+                        "unsupported Iceberg storage URI scheme \"{scheme}\""
+                    )));
+                }
+            };
+
+            if store_kind == IcebergStorageKind::Local {
+                let normalized = rest.trim_start_matches('/');
+                let local_path = format!("/{}", normalized);
+                return Ok(Self {
+                    raw: trimmed.to_string(),
+                    store_kind,
+                    bucket: None,
+                    path: normalize_object_path(&local_path),
+                });
+            }
+
+            let (bucket, suffix) = rest.split_once('/').map_or((rest, ""), |(bucket, suffix)| {
+                (bucket, suffix)
+            });
+            if bucket.is_empty() {
+                return Err(catalog_error(format!(
+                    "storage URI \"{trimmed}\" is missing a bucket or container"
+                )));
+            }
+            return Ok(Self {
+                raw: trimmed.to_string(),
+                store_kind,
+                bucket: Some(bucket.to_string()),
+                path: normalize_object_path(suffix),
+            });
+        }
+
+        Ok(Self {
+            raw: trimmed.to_string(),
+            store_kind: IcebergStorageKind::Local,
+            bucket: None,
+            path: normalize_object_path(trimmed),
+        })
+    }
+
+    pub fn store_kind(&self) -> IcebergStorageKind {
+        self.store_kind
+    }
+
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn bucket(&self) -> Option<&str> {
+        self.bucket.as_deref()
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn file_name(&self) -> Option<&str> {
+        self.path
+            .trim_end_matches('/')
+            .rsplit('/')
+            .find(|part| !part.is_empty())
+    }
+
+    pub fn extension(&self) -> Option<&str> {
+        self.file_name()
+            .and_then(|name| name.rsplit_once('.').map(|(_, ext)| ext))
+    }
+
+    pub fn is_directory_hint(&self) -> bool {
+        self.raw.ends_with('/') || self.path.is_empty()
+    }
+
+    pub fn join(&self, segment: &str) -> Self {
+        let base = self.path.trim_end_matches('/');
+        let suffix = segment.trim_start_matches('/');
+        let path = if base.is_empty() {
+            suffix.to_string()
+        } else if suffix.is_empty() {
+            base.to_string()
+        } else {
+            format!("{base}/{suffix}")
+        };
+        Self {
+            raw: render_location(self.store_kind, self.bucket(), &path),
+            store_kind: self.store_kind,
+            bucket: self.bucket.clone(),
+            path,
+        }
+    }
+
+    pub fn parent(&self) -> Option<Self> {
+        if self.path.is_empty() {
+            return None;
+        }
+        let trimmed = self.path.trim_end_matches('/');
+        let parent = trimmed.rsplit_once('/').map_or("", |(parent, _)| parent);
+        Some(Self {
+            raw: render_location(self.store_kind, self.bucket(), parent),
+            store_kind: self.store_kind,
+            bucket: self.bucket.clone(),
+            path: parent.to_string(),
+        })
+    }
+
+    pub fn relative_to(&self, root: &Self) -> Option<String> {
+        if self.store_kind != root.store_kind || self.bucket != root.bucket {
+            return None;
+        }
+        let root_path = root.path.trim_matches('/');
+        let path = self.path.trim_matches('/');
+        if root_path.is_empty() {
+            return Some(path.to_string());
+        }
+        path.strip_prefix(root_path)
+            .map(|value| value.trim_start_matches('/').to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IcebergBrowseCatalog {
+    pub name: String,
+    pub location: String,
+    pub namespaces: Vec<IcebergBrowseNamespace>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IcebergBrowseNamespace {
+    pub schema: Schema,
+    pub namespace_path: Vec<String>,
+    pub tables: Vec<IcebergBrowseTable>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IcebergBrowseTable {
+    pub table: Table,
+    pub location: String,
+    pub metadata: IcebergTableMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IcebergTableMetadata {
+    pub table_root: String,
+    pub metadata_file: String,
+    pub table_uuid: Option<String>,
+    pub format_version: Option<i64>,
+    pub last_updated_ms: Option<i64>,
+    pub current_schema_id: Option<i64>,
+    pub partition_spec_json: String,
+    pub snapshot_count: i64,
+    pub total_data_files: i64,
+    pub partition_columns: Vec<String>,
+    pub column_aliases: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IcebergSchemaField {
+    pub id: i64,
+    pub name: String,
+    pub type_signature: TypeSignature,
+    pub nullable: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct IcebergResolvedTable {
+    table_root: IcebergObjectLocation,
+    current_schema: Vec<IcebergSchemaField>,
+    alias_map: HashMap<String, String>,
+    partition_columns: Vec<String>,
+    metadata: IcebergTableMetadata,
+    parquet_files: Vec<IcebergDiscoveredFile>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IcebergScanPlan {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<ScalarValue>>,
+    pub scanned_files: usize,
+    pub pruned_files: usize,
+    pub metadata: IcebergTableMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IcebergFileScanSummary {
+    pub file_path: String,
+    pub partition_values: HashMap<String, ScalarValue>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum IcebergPartitionPredicate {
+    Eq(String, ScalarValue),
+    Lt(String, ScalarValue),
+    Lte(String, ScalarValue),
+    Gt(String, ScalarValue),
+    Gte(String, ScalarValue),
+    In(String, Vec<ScalarValue>),
+    Between(String, ScalarValue, ScalarValue),
+}
+
+#[derive(Debug, Clone)]
+struct IcebergDiscoveredFile {
+    location: IcebergObjectLocation,
+    partition_values: HashMap<String, ScalarValue>,
+}
+
+#[derive(Debug, Clone)]
+struct IcebergStorage {
+    kind: IcebergStorageKind,
+    bucket: Option<String>,
+    store: Arc<DynObjectStore>,
+}
+
+impl IcebergStorage {
+    async fn from_location(location: &IcebergObjectLocation) -> Result<Self, CatalogError> {
+        let store: Arc<DynObjectStore> = match location.store_kind() {
+            IcebergStorageKind::Local => Arc::new(LocalFileSystem::new()),
+            IcebergStorageKind::S3 => Arc::new(
+                AmazonS3Builder::from_env()
+                    .with_bucket_name(location.bucket().unwrap_or_default())
+                    .build()
+                    .map_err(to_catalog_error)?,
+            ),
+            IcebergStorageKind::Gcs => Arc::new(
+                GoogleCloudStorageBuilder::from_env()
+                    .with_bucket_name(location.bucket().unwrap_or_default())
+                    .build()
+                    .map_err(to_catalog_error)?,
+            ),
+            IcebergStorageKind::AzureBlob => Arc::new(
+                MicrosoftAzureBuilder::from_env()
+                    .with_container_name(location.bucket().unwrap_or_default())
+                    .build()
+                    .map_err(to_catalog_error)?,
+            ),
+        };
+
+        Ok(Self {
+            kind: location.store_kind(),
+            bucket: location.bucket().map(ToOwned::to_owned),
+            store,
+        })
+    }
+
+    async fn read_to_string(&self, location: &IcebergObjectLocation) -> Result<String, CatalogError> {
+        match self.kind {
+            IcebergStorageKind::Local => std::fs::read_to_string(location.path()).map_err(to_catalog_error),
+            _ => {
+                let bytes = self
+                    .store
+                    .get(&object_path(location.path()))
+                    .await
+                    .map_err(to_catalog_error)?
+                    .bytes()
+                    .await
+                    .map_err(to_catalog_error)?;
+                String::from_utf8(bytes.to_vec()).map_err(to_catalog_error)
+            }
+        }
+    }
+
+    async fn read_bytes(&self, location: &IcebergObjectLocation) -> Result<Vec<u8>, CatalogError> {
+        match self.kind {
+            IcebergStorageKind::Local => std::fs::read(location.path()).map_err(to_catalog_error),
+            _ => Ok(self
+                .store
+                .get(&object_path(location.path()))
+                .await
+                .map_err(to_catalog_error)?
+                .bytes()
+                .await
+                .map_err(to_catalog_error)?
+                .to_vec()),
+        }
+    }
+
+    async fn list_recursive(
+        &self,
+        prefix: &IcebergObjectLocation,
+    ) -> Result<Vec<IcebergObjectLocation>, CatalogError> {
+        if self.kind == IcebergStorageKind::Local {
+            let mut out = Vec::new();
+            collect_local_files(Path::new(prefix.path()), &mut out)?;
+            return Ok(out
+                .into_iter()
+                .map(|path| IcebergObjectLocation {
+                    raw: path.clone(),
+                    store_kind: IcebergStorageKind::Local,
+                    bucket: None,
+                    path,
+                })
+                .collect());
+        }
+
+        let entries = self
+            .store
+            .list(Some(&object_path(prefix.path())))
+            .try_collect::<Vec<ObjectMeta>>()
+            .await
+            .map_err(to_catalog_error)?;
+        Ok(entries
+            .into_iter()
+            .map(|entry| IcebergObjectLocation {
+                raw: render_location(self.kind, self.bucket.as_deref(), entry.location.as_ref()),
+                store_kind: self.kind,
+                bucket: self.bucket.clone(),
+                path: entry.location.to_string(),
+            })
+            .collect())
+    }
+}
+
+pub async fn browse_iceberg_catalogs(
+    root: &str,
+) -> Result<Vec<IcebergBrowseCatalog>, CatalogError> {
+    let location = IcebergObjectLocation::parse(root)?;
+    let table_roots = discover_table_roots(&location).await?;
+    if table_roots.is_empty() {
+        return Err(catalog_error(format!(
+            "no Iceberg tables found under {}",
+            location.raw()
+        )));
+    }
+
+    let layout = IcebergCatalogLayout::from_table_roots(&location, &table_roots);
+    let mut catalogs = BTreeMap::<String, BTreeMap<String, Vec<IcebergBrowseTable>>>::new();
+    let mut namespace_paths =
+        HashMap::<(String, String), Vec<String>>::with_capacity(table_roots.len());
+
+    let mut next_schema_oid = 20_000_u32;
+    let mut next_table_oid = 30_000_u32;
+    let mut next_column_oid = 40_000_u32;
+
+    for root_location in table_roots {
+        let resolved = resolve_iceberg_table(root_location.raw()).await?;
+        let entry = layout.entry_for(&location, &resolved.table_root);
+        let schema_name = if entry.namespace_path.is_empty() {
+            "default".to_string()
+        } else {
+            entry.namespace_path.join(".")
+        };
+
+        let columns = resolved
+            .current_schema
+            .iter()
+            .enumerate()
+            .map(|(idx, field)| {
+                let oid = next_column_oid;
+                next_column_oid += 1;
+                Column::new(
+                    oid,
+                    field.name.clone(),
+                    field.type_signature,
+                    idx as u16,
+                    field.nullable,
+                    false,
+                    false,
+                    None,
+                    None,
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+        let table = Table::new(
+            next_table_oid,
+            next_schema_oid,
+            schema_name.clone(),
+            entry.table_name.clone(),
+            TableKind::Heap,
+            columns,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            None,
+        );
+        next_table_oid += 1;
+
+        let browse_table = IcebergBrowseTable {
+            table,
+            location: resolved.table_root.raw().to_string(),
+            metadata: resolved.metadata.clone(),
+        };
+
+        catalogs
+            .entry(entry.catalog_name.clone())
+            .or_default()
+            .entry(schema_name.clone())
+            .or_default()
+            .push(browse_table);
+        namespace_paths.insert(
+            (entry.catalog_name.clone(), schema_name),
+            entry.namespace_path.clone(),
+        );
+    }
+
+    let mut out = Vec::new();
+    for (catalog_name, schemas) in catalogs {
+        let location = layout.catalog_location(&location, &catalog_name);
+        let namespaces = schemas
+            .into_iter()
+            .map(|(schema_name, mut tables)| {
+                tables.sort_by(|left, right| left.table.name().cmp(right.table.name()));
+                let schema = Schema::new(next_schema_oid, schema_name.clone());
+                next_schema_oid += 1;
+                IcebergBrowseNamespace {
+                    schema,
+                    namespace_path: namespace_paths
+                        .remove(&(catalog_name.clone(), schema_name))
+                        .unwrap_or_default(),
+                    tables,
+                }
+            })
+            .collect::<Vec<_>>();
+        out.push(IcebergBrowseCatalog {
+            name: catalog_name,
+            location,
+            namespaces,
+        });
+    }
+
+    out.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(out)
+}
+
+pub async fn resolve_iceberg_table(path: &str) -> Result<IcebergResolvedTable, CatalogError> {
+    let input = IcebergObjectLocation::parse(path)?;
+    let table_root = resolve_iceberg_table_root(&input)?;
+    let storage = IcebergStorage::from_location(&table_root).await?;
+    let metadata_file = resolve_iceberg_metadata_file(&storage, &input).await?;
+    let metadata_text = storage.read_to_string(&metadata_file).await?;
+    let metadata_json = serde_json::from_str::<JsonValue>(&metadata_text).map_err(to_catalog_error)?;
+
+    let current_schema_id = metadata_json
+        .get("current-schema-id")
+        .and_then(JsonValue::as_i64);
+    let schemas = metadata_json
+        .get("schemas")
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| catalog_error("Iceberg metadata is missing schemas"))?;
+    let current_schema_json = if let Some(current_schema_id) = current_schema_id {
+        schemas
+            .iter()
+            .find(|schema| schema.get("schema-id").and_then(JsonValue::as_i64) == Some(current_schema_id))
+            .or_else(|| schemas.last())
+    } else {
+        schemas.last()
+    }
+    .ok_or_else(|| catalog_error("Iceberg metadata did not contain a usable schema"))?;
+
+    let current_schema = parse_schema_fields(current_schema_json)?;
+    let alias_map = collect_schema_aliases(schemas, &current_schema);
+    let partition_columns = current_partition_columns(&metadata_json);
+    let parquet_files = discover_iceberg_parquet_files(&storage, &table_root, &partition_columns, &current_schema).await?;
+
+    let metadata = IcebergTableMetadata {
+        table_root: table_root.raw().to_string(),
+        metadata_file: metadata_file.raw().to_string(),
+        table_uuid: metadata_json
+            .get("table-uuid")
+            .and_then(JsonValue::as_str)
+            .map(ToOwned::to_owned),
+        format_version: metadata_json.get("format-version").and_then(JsonValue::as_i64),
+        last_updated_ms: metadata_json.get("last-updated-ms").and_then(JsonValue::as_i64),
+        current_schema_id,
+        partition_spec_json: metadata_json
+            .get("partition-specs")
+            .cloned()
+            .unwrap_or_else(|| JsonValue::Array(Vec::new()))
+            .to_string(),
+        snapshot_count: metadata_json
+            .get("snapshots")
+            .and_then(JsonValue::as_array)
+            .map_or(0_i64, |items| items.len() as i64),
+        total_data_files: parquet_files.len() as i64,
+        partition_columns,
+        column_aliases: alias_map.clone(),
+    };
+
+    Ok(IcebergResolvedTable {
+        table_root,
+        current_schema,
+        alias_map,
+        partition_columns: metadata.partition_columns.clone(),
+        metadata,
+        parquet_files,
+    })
+}
+
+pub async fn read_iceberg_metadata(path: &str) -> Result<IcebergTableMetadata, CatalogError> {
+    Ok(resolve_iceberg_table(path).await?.metadata)
+}
+
+pub async fn plan_iceberg_scan(
+    path: &str,
+    requested_columns: Option<&[String]>,
+    partition_predicates: &[IcebergPartitionPredicate],
+) -> Result<IcebergScanPlan, CatalogError> {
+    let resolved = resolve_iceberg_table(path).await?;
+    let requested = requested_columns.map(|cols| {
+        cols.iter()
+            .map(|column| column.to_ascii_lowercase())
+            .collect::<HashSet<_>>()
+    });
+    let output_fields = resolved
+        .current_schema
+        .iter()
+        .filter(|field| {
+            requested
+                .as_ref()
+                .is_none_or(|requested| requested.contains(&field.name.to_ascii_lowercase()))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let output_columns = output_fields
+        .iter()
+        .map(|field| field.name.clone())
+        .collect::<Vec<_>>();
+    let output_index = output_fields
+        .iter()
+        .enumerate()
+        .map(|(idx, field)| (field.name.to_ascii_lowercase(), idx))
+        .collect::<HashMap<_, _>>();
+
+    let files = if partition_predicates.is_empty() {
+        resolved.parquet_files.clone()
+    } else {
+        resolved
+            .parquet_files
+            .iter()
+            .filter(|file| file_matches_partition_predicates(file, partition_predicates))
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+
+    let scanned_files = files.len();
+    let pruned_files = resolved.parquet_files.len().saturating_sub(scanned_files);
+    let storage = IcebergStorage::from_location(&resolved.table_root).await?;
+    let mut rows = Vec::new();
+
+    for file in files {
+        let file_rows = scan_single_parquet_file(
+            &storage,
+            &file.location,
+            &output_fields,
+            &output_index,
+            &resolved.alias_map,
+        )
+        .await?;
+        rows.extend(file_rows);
+    }
+
+    Ok(IcebergScanPlan {
+        columns: output_columns,
+        rows,
+        scanned_files,
+        pruned_files,
+        metadata: resolved.metadata,
+    })
+}
+
+pub async fn scan_iceberg_table_with_predicate(
+    path: &str,
+    predicate: Option<&Expr>,
+    qualifiers: &[String],
+    params: &[Option<String>],
+) -> Result<IcebergScanPlan, EngineError> {
+    let resolved = resolve_iceberg_table(path).await.map_err(to_engine_error)?;
+    let partition_fields = resolved
+        .current_schema
+        .iter()
+        .filter(|field| {
+            resolved
+                .partition_columns
+                .iter()
+                .any(|partition| partition.eq_ignore_ascii_case(&field.name))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let partition_predicates = predicate
+        .map(|predicate| extract_partition_predicates(predicate, qualifiers, &partition_fields, params))
+        .transpose()?
+        .unwrap_or_default();
+    plan_iceberg_scan(path, None, &partition_predicates)
+        .await
+        .map_err(to_engine_error)
+}
+
+pub async fn list_iceberg_data_files(
+    path: &str,
+    partition_predicates: &[IcebergPartitionPredicate],
+) -> Result<Vec<IcebergFileScanSummary>, CatalogError> {
+    let resolved = resolve_iceberg_table(path).await?;
+    Ok(resolved
+        .parquet_files
+        .into_iter()
+        .filter(|file| file_matches_partition_predicates(file, partition_predicates))
+        .map(|file| IcebergFileScanSummary {
+            file_path: file.location.raw().to_string(),
+            partition_values: file.partition_values,
+        })
+        .collect())
+}
+
+pub fn extract_partition_predicates(
+    predicate: &Expr,
+    qualifiers: &[String],
+    partition_fields: &[IcebergSchemaField],
+    params: &[Option<String>],
+) -> Result<Vec<IcebergPartitionPredicate>, EngineError> {
+    let partition_lookup = partition_fields
+        .iter()
+        .map(|field| (field.name.to_ascii_lowercase(), field.clone()))
+        .collect::<HashMap<_, _>>();
+    let mut out = Vec::new();
+    for conjunct in decompose_and_conjuncts(predicate) {
+        if let Some(extracted) = extract_single_partition_predicate(
+            &conjunct,
+            qualifiers,
+            &partition_lookup,
+            params,
+        )? {
+            out.push(extracted);
+        }
+    }
+    Ok(out)
+}
+
+pub fn compare_iceberg_metadata_files(left: &str, right: &str) -> std::cmp::Ordering {
+    iceberg_metadata_version(left)
+        .cmp(&iceberg_metadata_version(right))
+        .then_with(|| left.cmp(right))
+}
+
+pub fn iceberg_metadata_version(file_name: &str) -> u64 {
+    let stem = file_name
+        .strip_suffix(".metadata.json")
+        .unwrap_or(file_name);
+    let stem = stem.strip_prefix('v').unwrap_or(stem);
+    let digits = stem
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    digits.parse::<u64>().unwrap_or(0)
+}
+
+fn current_partition_columns(metadata_json: &JsonValue) -> Vec<String> {
+    metadata_json
+        .get("partition-specs")
+        .and_then(JsonValue::as_array)
+        .and_then(|specs| specs.last())
+        .and_then(|spec| spec.get("fields"))
+        .and_then(JsonValue::as_array)
+        .map(|fields| {
+            fields
+                .iter()
+                .filter_map(|field| field.get("name").and_then(JsonValue::as_str))
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_schema_fields(schema: &JsonValue) -> Result<Vec<IcebergSchemaField>, CatalogError> {
+    let fields = schema
+        .get("fields")
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| catalog_error("Iceberg schema is missing fields"))?;
+    let mut out = Vec::with_capacity(fields.len());
+    for field in fields {
+        let id = field
+            .get("id")
+            .and_then(JsonValue::as_i64)
+            .ok_or_else(|| catalog_error("Iceberg schema field is missing an id"))?;
+        let name = field
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| catalog_error("Iceberg schema field is missing a name"))?
+            .to_string();
+        let required = field
+            .get("required")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false);
+        let type_signature = parse_type_signature(field.get("type")).unwrap_or(TypeSignature::Text);
+        out.push(IcebergSchemaField {
+            id,
+            name,
+            type_signature,
+            nullable: !required,
+        });
+    }
+    Ok(out)
+}
+
+fn parse_type_signature(value: Option<&JsonValue>) -> Option<TypeSignature> {
+    let type_name = match value {
+        Some(JsonValue::String(value)) => value.as_str(),
+        Some(JsonValue::Object(map)) => map.get("type")?.as_str()?,
+        _ => return None,
+    };
+    Some(match type_name {
+        "boolean" => TypeSignature::Bool,
+        "int" | "long" => TypeSignature::Int8,
+        "float" | "double" => TypeSignature::Float8,
+        "decimal" => TypeSignature::Numeric,
+        "date" => TypeSignature::Date,
+        "timestamp" | "timestamptz" => TypeSignature::Timestamp,
+        _ => TypeSignature::Text,
+    })
+}
+
+fn collect_schema_aliases(
+    schemas: &[JsonValue],
+    current_schema: &[IcebergSchemaField],
+) -> HashMap<String, String> {
+    let current_names = current_schema
+        .iter()
+        .map(|field| (field.id, field.name.clone()))
+        .collect::<HashMap<_, _>>();
+    let mut aliases = HashMap::new();
+    for schema in schemas {
+        let Ok(fields) = parse_schema_fields(schema) else {
+            continue;
+        };
+        for field in fields {
+            let Some(current_name) = current_names.get(&field.id) else {
+                continue;
+            };
+            aliases.insert(field.name.to_ascii_lowercase(), current_name.clone());
+        }
+    }
+    aliases
+}
+
+async fn discover_table_roots(
+    root: &IcebergObjectLocation,
+) -> Result<Vec<IcebergObjectLocation>, CatalogError> {
+    if can_be_direct_table(root) {
+        if let Ok(direct) = resolve_iceberg_table_root(root) {
+            let storage = IcebergStorage::from_location(&direct).await?;
+            if resolve_iceberg_metadata_file(&storage, root).await.is_ok() {
+                return Ok(vec![direct]);
+            }
+        }
+    }
+
+    let storage = IcebergStorage::from_location(root).await?;
+    let objects = storage.list_recursive(root).await?;
+    let mut roots: HashSet<String> = HashSet::new();
+    for object in objects {
+        let Some(file_name) = object.file_name() else {
+            continue;
+        };
+        if !file_name.ends_with(".metadata.json") {
+            continue;
+        }
+        let Some(parent) = object.parent() else {
+            continue;
+        };
+        let Some(root_dir) = (if parent.file_name().is_some_and(|name| name.eq_ignore_ascii_case("metadata")) {
+            parent.parent()
+        } else {
+            object.parent()
+        }) else {
+            continue;
+        };
+        roots.insert(root_dir.raw().to_string());
+    }
+
+    let mut out = roots
+        .into_iter()
+        .map(|value| IcebergObjectLocation::parse(value.as_str()))
+        .collect::<Result<Vec<_>, _>>()?;
+    out.sort_by(|left, right| left.raw().cmp(right.raw()));
+    Ok(out)
+}
+
+fn can_be_direct_table(location: &IcebergObjectLocation) -> bool {
+    location.store_kind() == IcebergStorageKind::Local || !location.path().is_empty()
+}
+
+fn resolve_iceberg_table_root(
+    location: &IcebergObjectLocation,
+) -> Result<IcebergObjectLocation, CatalogError> {
+    if location.is_directory_hint() {
+        return Ok(location.clone());
+    }
+    if location
+        .extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("parquet"))
+    {
+        return location.parent().ok_or_else(|| {
+            catalog_error(format!(
+                "cannot determine Iceberg table root from {}",
+                location.raw()
+            ))
+        });
+    }
+
+    if location
+        .file_name()
+        .is_some_and(|name| name.ends_with(".metadata.json"))
+    {
+        let parent = location.parent().ok_or_else(|| {
+            catalog_error(format!(
+                "cannot determine Iceberg table root from {}",
+                location.raw()
+            ))
+        })?;
+        if parent.file_name().is_some_and(|name| name.eq_ignore_ascii_case("metadata")) {
+            return parent.parent().ok_or_else(|| {
+                catalog_error(format!(
+                    "cannot determine Iceberg table root from {}",
+                    location.raw()
+                ))
+            });
+        }
+        return Ok(parent);
+    }
+
+    Ok(location.clone())
+}
+
+async fn resolve_iceberg_metadata_file(
+    storage: &IcebergStorage,
+    input: &IcebergObjectLocation,
+) -> Result<IcebergObjectLocation, CatalogError> {
+    if input
+        .file_name()
+        .is_some_and(|name| name.ends_with(".metadata.json"))
+    {
+        return Ok(input.clone());
+    }
+
+    let table_root = resolve_iceberg_table_root(input)?;
+    let metadata_dir = table_root.join("metadata");
+    let mut candidates = storage
+        .list_recursive(&metadata_dir)
+        .await?
+        .into_iter()
+        .filter(|entry| {
+            entry
+                .file_name()
+                .is_some_and(|name| name.ends_with(".metadata.json"))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        compare_iceberg_metadata_files(
+            left.file_name().unwrap_or_default(),
+            right.file_name().unwrap_or_default(),
+        )
+    });
+    candidates
+        .pop()
+        .ok_or_else(|| catalog_error(format!("no Iceberg metadata found under {}", table_root.raw())))
+}
+
+async fn discover_iceberg_parquet_files(
+    storage: &IcebergStorage,
+    table_root: &IcebergObjectLocation,
+    partition_columns: &[String],
+    current_schema: &[IcebergSchemaField],
+) -> Result<Vec<IcebergDiscoveredFile>, CatalogError> {
+    let data_dir = table_root.join("data");
+    let mut candidates = storage.list_recursive(&data_dir).await?;
+    if candidates.is_empty() {
+        candidates = storage.list_recursive(table_root).await?;
+    }
+    let partition_lookup = current_schema
+        .iter()
+        .map(|field| (field.name.to_ascii_lowercase(), field.type_signature))
+        .collect::<HashMap<_, _>>();
+    let mut files = Vec::new();
+    for entry in candidates {
+        if !entry
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("parquet"))
+        {
+            continue;
+        }
+        let partition_values = parse_partition_values(&entry, &data_dir, partition_columns, &partition_lookup);
+        files.push(IcebergDiscoveredFile {
+            location: entry,
+            partition_values,
+        });
+    }
+    files.sort_by(|left, right| left.location.raw().cmp(right.location.raw()));
+    Ok(files)
+}
+
+fn parse_partition_values(
+    file: &IcebergObjectLocation,
+    data_root: &IcebergObjectLocation,
+    partition_columns: &[String],
+    type_lookup: &HashMap<String, TypeSignature>,
+) -> HashMap<String, ScalarValue> {
+    let mut out = HashMap::new();
+    let Some(relative) = file.relative_to(data_root) else {
+        return out;
+    };
+    for component in relative.split('/') {
+        let Some((name, value)) = component.split_once('=') else {
+            continue;
+        };
+        if !partition_columns
+            .iter()
+            .any(|partition| partition.eq_ignore_ascii_case(name))
+        {
+            continue;
+        }
+        let type_signature = type_lookup
+            .get(&name.to_ascii_lowercase())
+            .copied()
+            .unwrap_or(TypeSignature::Text);
+        let scalar = coerce_text_to_type(value, type_signature).unwrap_or_else(|_| {
+            ScalarValue::Text(value.to_string())
+        });
+        out.insert(name.to_ascii_lowercase(), scalar);
+    }
+    out
+}
+
+async fn scan_single_parquet_file(
+    storage: &IcebergStorage,
+    file: &IcebergObjectLocation,
+    output_fields: &[IcebergSchemaField],
+    output_index: &HashMap<String, usize>,
+    alias_map: &HashMap<String, String>,
+) -> Result<Vec<Vec<ScalarValue>>, CatalogError> {
+    let mut rows = Vec::new();
+    if storage.kind == IcebergStorageKind::Local {
+        let file = std::fs::File::open(file.path()).map_err(to_catalog_error)?;
+        let reader = SerializedFileReader::new(file).map_err(to_catalog_error)?;
+        read_parquet_rows(&reader, output_fields, output_index, alias_map, &mut rows)?;
+        return Ok(rows);
+    }
+
+    let bytes = Bytes::from(storage.read_bytes(file).await?);
+    let reader = SerializedFileReader::new(bytes).map_err(to_catalog_error)?;
+    read_parquet_rows(&reader, output_fields, output_index, alias_map, &mut rows)?;
+    Ok(rows)
+}
+
+fn read_parquet_rows<R>(
+    reader: &SerializedFileReader<R>,
+    output_fields: &[IcebergSchemaField],
+    output_index: &HashMap<String, usize>,
+    alias_map: &HashMap<String, String>,
+    rows: &mut Vec<Vec<ScalarValue>>,
+) -> Result<(), CatalogError>
+where
+    R: parquet::file::reader::ChunkReader + 'static,
+{
+    let row_iter = reader.get_row_iter(None).map_err(to_catalog_error)?;
+    for row_result in row_iter {
+        let row = row_result.map_err(to_catalog_error)?;
+        let mut output_row = vec![ScalarValue::Null; output_fields.len()];
+        for (physical_name, field) in row.get_column_iter() {
+            let canonical = alias_map
+                .get(&physical_name.to_ascii_lowercase())
+                .cloned()
+                .unwrap_or_else(|| physical_name.to_string());
+            let Some(idx) = output_index.get(&canonical.to_ascii_lowercase()) else {
+                continue;
+            };
+            let logical_field = &output_fields[*idx];
+            output_row[*idx] = coerce_parquet_field(field, logical_field)?;
+        }
+        rows.push(output_row);
+    }
+    Ok(())
+}
+
+fn coerce_parquet_field(
+    field: &ParquetField,
+    logical_field: &IcebergSchemaField,
+) -> Result<ScalarValue, CatalogError> {
+    let scalar = parquet_field_to_scalar(field);
+    if matches!(scalar, ScalarValue::Null) {
+        return Ok(ScalarValue::Null);
+    }
+    coerce_scalar_to_type(scalar, logical_field.type_signature)
+}
+
+fn parquet_field_to_scalar(field: &ParquetField) -> ScalarValue {
+    match field {
+        ParquetField::Null => ScalarValue::Null,
+        ParquetField::Bool(value) => ScalarValue::Bool(*value),
+        ParquetField::Byte(value) => ScalarValue::Int(i64::from(*value)),
+        ParquetField::Short(value) => ScalarValue::Int(i64::from(*value)),
+        ParquetField::Int(value) => ScalarValue::Int(i64::from(*value)),
+        ParquetField::Long(value) => ScalarValue::Int(*value),
+        ParquetField::UByte(value) => ScalarValue::Int(i64::from(*value)),
+        ParquetField::UShort(value) => ScalarValue::Int(i64::from(*value)),
+        ParquetField::UInt(value) => ScalarValue::Int(i64::from(*value)),
+        ParquetField::ULong(value) => i64::try_from(*value)
+            .map(ScalarValue::Int)
+            .unwrap_or_else(|_| ScalarValue::Text(value.to_string())),
+        ParquetField::Float16(value) => ScalarValue::Float(f64::from(*value)),
+        ParquetField::Float(value) => ScalarValue::Float(f64::from(*value)),
+        ParquetField::Double(value) => ScalarValue::Float(*value),
+        ParquetField::Decimal(value) => ScalarValue::Text(parquet_decimal_to_text(value)),
+        ParquetField::Str(value) => ScalarValue::Text(value.clone()),
+        ParquetField::Bytes(value) => String::from_utf8(value.data().to_vec())
+            .map(ScalarValue::Text)
+            .unwrap_or_else(|_| ScalarValue::Text(base64::prelude::BASE64_STANDARD.encode(value.data()))),
+        ParquetField::Date(value) => ScalarValue::Text(value.to_string()),
+        ParquetField::TimeMillis(value) => ScalarValue::Text(value.to_string()),
+        ParquetField::TimeMicros(value) => ScalarValue::Text(value.to_string()),
+        ParquetField::TimestampMillis(value) => ScalarValue::Text(value.to_string()),
+        ParquetField::TimestampMicros(value) => ScalarValue::Text(value.to_string()),
+        ParquetField::Group(_)
+        | ParquetField::ListInternal(_)
+        | ParquetField::MapInternal(_) => ScalarValue::Text(field.to_string()),
+    }
+}
+
+fn parquet_decimal_to_text(value: &parquet::data_type::Decimal) -> String {
+    let bytes = value.data();
+    let scale = value.scale();
+    if bytes.len() > 16 {
+        return format!("{value:?}");
+    }
+
+    let sign_extension = if bytes.first().is_some_and(|byte| byte & 0x80 != 0) {
+        0xFF
+    } else {
+        0x00
+    };
+    let mut padded = [sign_extension; 16];
+    let start = 16 - bytes.len();
+    padded[start..].copy_from_slice(bytes);
+    let unscaled = i128::from_be_bytes(padded);
+    format_scaled_i128(unscaled, scale)
+}
+
+fn format_scaled_i128(value: i128, scale: i32) -> String {
+    if scale <= 0 {
+        return value.to_string();
+    }
+
+    let sign = if value < 0 { "-" } else { "" };
+    let abs = value.unsigned_abs().to_string();
+    let scale_usize = usize::try_from(scale).unwrap_or(0);
+    if abs.len() <= scale_usize {
+        let zeros = "0".repeat(scale_usize.saturating_sub(abs.len()));
+        return format!("{sign}0.{zeros}{abs}");
+    }
+
+    let split = abs.len() - scale_usize;
+    format!("{sign}{}.{}", &abs[..split], &abs[split..])
+}
+
+fn file_matches_partition_predicates(
+    file: &IcebergDiscoveredFile,
+    predicates: &[IcebergPartitionPredicate],
+) -> bool {
+    predicates
+        .iter()
+        .all(|predicate| evaluate_partition_predicate(predicate, &file.partition_values))
+}
+
+fn evaluate_partition_predicate(
+    predicate: &IcebergPartitionPredicate,
+    partition_values: &HashMap<String, ScalarValue>,
+) -> bool {
+    match predicate {
+        IcebergPartitionPredicate::Eq(column, value) => {
+            compare_partition_value(partition_values.get(column), value, std::cmp::Ordering::Equal)
+        }
+        IcebergPartitionPredicate::Lt(column, value) => {
+            compare_partition_value(partition_values.get(column), value, std::cmp::Ordering::Less)
+        }
+        IcebergPartitionPredicate::Lte(column, value) => partition_values
+            .get(column)
+            .is_none_or(|partition| {
+                let ordering = scalar_cmp(partition, value);
+                ordering == std::cmp::Ordering::Less || ordering == std::cmp::Ordering::Equal
+            }),
+        IcebergPartitionPredicate::Gt(column, value) => partition_values
+            .get(column)
+            .is_none_or(|partition| scalar_cmp(partition, value) == std::cmp::Ordering::Greater),
+        IcebergPartitionPredicate::Gte(column, value) => partition_values
+            .get(column)
+            .is_none_or(|partition| {
+                let ordering = scalar_cmp(partition, value);
+                ordering == std::cmp::Ordering::Greater || ordering == std::cmp::Ordering::Equal
+            }),
+        IcebergPartitionPredicate::In(column, values) => partition_values
+            .get(column)
+            .is_none_or(|partition| values.iter().any(|value| scalar_cmp(partition, value) == std::cmp::Ordering::Equal)),
+        IcebergPartitionPredicate::Between(column, low, high) => partition_values
+            .get(column)
+            .is_none_or(|partition| {
+                let low_cmp = scalar_cmp(partition, low);
+                let high_cmp = scalar_cmp(partition, high);
+                (low_cmp == std::cmp::Ordering::Greater || low_cmp == std::cmp::Ordering::Equal)
+                    && (high_cmp == std::cmp::Ordering::Less
+                        || high_cmp == std::cmp::Ordering::Equal)
+            }),
+    }
+}
+
+fn compare_partition_value(
+    value: Option<&ScalarValue>,
+    target: &ScalarValue,
+    wanted: std::cmp::Ordering,
+) -> bool {
+    value.is_none_or(|value| scalar_cmp(value, target) == wanted)
+}
+
+fn extract_single_partition_predicate(
+    expr: &Expr,
+    qualifiers: &[String],
+    partition_lookup: &HashMap<String, IcebergSchemaField>,
+    params: &[Option<String>],
+) -> Result<Option<IcebergPartitionPredicate>, EngineError> {
+    match expr {
+        Expr::Binary { left, op, right } => {
+            if let Some((column, field, value, reverse)) =
+                extract_partition_column_and_value(left, right, qualifiers, partition_lookup, params)?
+            {
+                let predicate = match (op.clone(), reverse) {
+                    (BinaryOp::Eq, false | true) => IcebergPartitionPredicate::Eq(column, value),
+                    (BinaryOp::Lt, false) => IcebergPartitionPredicate::Lt(column, value),
+                    (BinaryOp::Lt, true) => IcebergPartitionPredicate::Gt(column, value),
+                    (BinaryOp::Lte, false) => IcebergPartitionPredicate::Lte(column, value),
+                    (BinaryOp::Lte, true) => IcebergPartitionPredicate::Gte(column, value),
+                    (BinaryOp::Gt, false) => IcebergPartitionPredicate::Gt(column, value),
+                    (BinaryOp::Gt, true) => IcebergPartitionPredicate::Lt(column, value),
+                    (BinaryOp::Gte, false) => IcebergPartitionPredicate::Gte(column, value),
+                    (BinaryOp::Gte, true) => IcebergPartitionPredicate::Lte(column, value),
+                    _ => return Ok(None),
+                };
+                let _ = field;
+                return Ok(Some(predicate));
+            }
+            Ok(None)
+        }
+        Expr::InList { expr, list, negated } if !negated => {
+            let Some((column, field)) = extract_partition_column(expr, qualifiers, partition_lookup) else {
+                return Ok(None);
+            };
+            let mut values = Vec::with_capacity(list.len());
+            for item in list {
+                let scalar = eval_constant_scalar(item, params)?;
+                values.push(coerce_scalar_to_type(scalar, field.type_signature).map_err(to_engine_error)?);
+            }
+            Ok(Some(IcebergPartitionPredicate::In(column, values)))
+        }
+        Expr::Between {
+            expr,
+            low,
+            high,
+            negated,
+        } if !negated => {
+            let Some((column, field)) = extract_partition_column(expr, qualifiers, partition_lookup) else {
+                return Ok(None);
+            };
+            let low = coerce_scalar_to_type(eval_constant_scalar(low, params)?, field.type_signature)
+                .map_err(to_engine_error)?;
+            let high = coerce_scalar_to_type(eval_constant_scalar(high, params)?, field.type_signature)
+                .map_err(to_engine_error)?;
+            Ok(Some(IcebergPartitionPredicate::Between(column, low, high)))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn extract_partition_column_and_value(
+    left: &Expr,
+    right: &Expr,
+    qualifiers: &[String],
+    partition_lookup: &HashMap<String, IcebergSchemaField>,
+    params: &[Option<String>],
+) -> Result<Option<(String, IcebergSchemaField, ScalarValue, bool)>, EngineError> {
+    if let Some((column, field)) = extract_partition_column(left, qualifiers, partition_lookup) {
+        let value = eval_constant_scalar(right, params)?;
+        let value = coerce_scalar_to_type(value, field.type_signature).map_err(to_engine_error)?;
+        return Ok(Some((column, field, value, false)));
+    }
+    if let Some((column, field)) = extract_partition_column(right, qualifiers, partition_lookup) {
+        let value = eval_constant_scalar(left, params)?;
+        let value = coerce_scalar_to_type(value, field.type_signature).map_err(to_engine_error)?;
+        return Ok(Some((column, field, value, true)));
+    }
+    Ok(None)
+}
+
+fn extract_partition_column(
+    expr: &Expr,
+    qualifiers: &[String],
+    partition_lookup: &HashMap<String, IcebergSchemaField>,
+) -> Option<(String, IcebergSchemaField)> {
+    let Expr::Identifier(parts) = expr else {
+        return None;
+    };
+    match parts.as_slice() {
+        [column] => partition_lookup
+            .get(&column.to_ascii_lowercase())
+            .cloned()
+            .map(|field| (field.name.to_ascii_lowercase(), field)),
+        [qualifier, column] if qualifiers.iter().any(|item| item.eq_ignore_ascii_case(qualifier)) => {
+            partition_lookup
+                .get(&column.to_ascii_lowercase())
+                .cloned()
+                .map(|field| (field.name.to_ascii_lowercase(), field))
+        }
+        _ => None,
+    }
+}
+
+fn eval_constant_scalar(expr: &Expr, params: &[Option<String>]) -> Result<ScalarValue, EngineError> {
+    match expr {
+        Expr::Null => Ok(ScalarValue::Null),
+        Expr::Boolean(value) => Ok(ScalarValue::Bool(*value)),
+        Expr::Integer(value) => Ok(ScalarValue::Int(*value)),
+        Expr::Float(value) => Ok(ScalarValue::Float(
+            value.parse::<f64>().map_err(|_| EngineError {
+                message: "unsupported partition predicate literal".to_string(),
+            })?,
+        )),
+        Expr::String(value) => Ok(ScalarValue::Text(value.clone())),
+        Expr::Unary { op: UnaryOp::Minus, expr } => match eval_constant_scalar(expr, params)? {
+            ScalarValue::Int(value) => Ok(ScalarValue::Int(-value)),
+            ScalarValue::Float(value) => Ok(ScalarValue::Float(-value)),
+            _ => Err(EngineError {
+                message: "unsupported partition predicate literal".to_string(),
+            }),
+        },
+        Expr::Unary { op: UnaryOp::Plus, expr } => eval_constant_scalar(expr, params),
+        Expr::Cast { expr, .. } => eval_constant_scalar(expr, params),
+        Expr::Parameter(index) => params
+            .get(index.saturating_sub(1) as usize)
+            .and_then(Option::as_ref)
+            .map(|value| ScalarValue::Text(value.clone()))
+            .ok_or_else(|| EngineError {
+                message: format!("missing value for parameter ${index}"),
+            }),
+        _ => Err(EngineError {
+            message: "unsupported partition predicate expression".to_string(),
+        }),
+    }
+}
+
+fn coerce_scalar_to_type(
+    value: ScalarValue,
+    type_signature: TypeSignature,
+) -> Result<ScalarValue, CatalogError> {
+    if matches!(value, ScalarValue::Null) {
+        return Ok(ScalarValue::Null);
+    }
+
+    match (type_signature, value) {
+        (TypeSignature::Bool, ScalarValue::Bool(value)) => Ok(ScalarValue::Bool(value)),
+        (TypeSignature::Bool, ScalarValue::Text(value)) => match value.trim().to_ascii_lowercase().as_str() {
+            "true" | "t" | "1" => Ok(ScalarValue::Bool(true)),
+            "false" | "f" | "0" => Ok(ScalarValue::Bool(false)),
+            _ => Err(catalog_error("invalid boolean literal")),
+        },
+        (TypeSignature::Int8, ScalarValue::Int(value)) => Ok(ScalarValue::Int(value)),
+        (TypeSignature::Int8, ScalarValue::Text(value)) => value
+            .trim()
+            .parse::<i64>()
+            .map(ScalarValue::Int)
+            .map_err(to_catalog_error),
+        (TypeSignature::Float8, ScalarValue::Int(value)) => Ok(ScalarValue::Float(value as f64)),
+        (TypeSignature::Float8, ScalarValue::Float(value)) => Ok(ScalarValue::Float(value)),
+        (TypeSignature::Float8, ScalarValue::Text(value)) => value
+            .trim()
+            .parse::<f64>()
+            .map(ScalarValue::Float)
+            .map_err(to_catalog_error),
+        (TypeSignature::Numeric, ScalarValue::Int(value)) => {
+            Ok(ScalarValue::Numeric(rust_decimal::Decimal::from(value)))
+        }
+        (TypeSignature::Numeric, ScalarValue::Float(value)) => {
+            use rust_decimal::prelude::FromPrimitive;
+            Ok(ScalarValue::Numeric(
+                rust_decimal::Decimal::from_f64(value)
+                    .ok_or_else(|| catalog_error("invalid numeric literal"))?,
+            ))
+        }
+        (TypeSignature::Numeric, ScalarValue::Numeric(value)) => Ok(ScalarValue::Numeric(value)),
+        (TypeSignature::Numeric, ScalarValue::Text(value)) => value
+            .trim()
+            .parse::<rust_decimal::Decimal>()
+            .map(ScalarValue::Numeric)
+            .map_err(to_catalog_error),
+        (TypeSignature::Text, ScalarValue::Text(value)) => Ok(ScalarValue::Text(value)),
+        (TypeSignature::Text, value) => Ok(ScalarValue::Text(value.render())),
+        (TypeSignature::Date, ScalarValue::Text(value)) => Ok(ScalarValue::Text(value.trim().to_string())),
+        (TypeSignature::Timestamp, ScalarValue::Text(value)) => {
+            Ok(ScalarValue::Text(value.trim().to_string()))
+        }
+        (TypeSignature::Vector(_), value) => Ok(ScalarValue::Text(value.render())),
+        (_, value) => Err(catalog_error(format!(
+            "unsupported Iceberg type coercion from {}",
+            value.render()
+        ))),
+    }
+}
+
+fn coerce_text_to_type(value: &str, type_signature: TypeSignature) -> Result<ScalarValue, CatalogError> {
+    coerce_scalar_to_type(ScalarValue::Text(value.to_string()), type_signature)
+}
+
+fn scalar_cmp(left: &ScalarValue, right: &ScalarValue) -> std::cmp::Ordering {
+    match (left, right) {
+        (ScalarValue::Int(left), ScalarValue::Int(right)) => left.cmp(right),
+        (ScalarValue::Int(left), ScalarValue::Float(right)) => {
+            (*left as f64).partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal)
+        }
+        (ScalarValue::Float(left), ScalarValue::Int(right)) => {
+            left.partial_cmp(&(*right as f64)).unwrap_or(std::cmp::Ordering::Equal)
+        }
+        (ScalarValue::Float(left), ScalarValue::Float(right)) => {
+            left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal)
+        }
+        _ => left.render().cmp(&right.render()),
+    }
+}
+
+fn decompose_and_conjuncts(expr: &Expr) -> Vec<Expr> {
+    let mut out = Vec::new();
+    decompose_and_conjuncts_inner(expr, &mut out);
+    out
+}
+
+fn decompose_and_conjuncts_inner(expr: &Expr, out: &mut Vec<Expr>) {
+    if let Expr::Binary {
+        left,
+        op: BinaryOp::And,
+        right,
+    } = expr
+    {
+        decompose_and_conjuncts_inner(left, out);
+        decompose_and_conjuncts_inner(right, out);
+    } else {
+        out.push(expr.clone());
+    }
+}
+
+fn normalize_object_path(value: &str) -> String {
+    if value.is_empty() {
+        return String::new();
+    }
+    let normalized = value.replace('\\', "/");
+    if normalized.starts_with('/') {
+        normalized
+    } else {
+        normalized.trim_matches('/').to_string()
+    }
+}
+
+fn render_location(kind: IcebergStorageKind, bucket: Option<&str>, path: &str) -> String {
+    match kind {
+        IcebergStorageKind::Local => path.to_string(),
+        IcebergStorageKind::S3 => format!("s3://{}/{}", bucket.unwrap_or_default(), path),
+        IcebergStorageKind::Gcs => format!("gs://{}/{}", bucket.unwrap_or_default(), path),
+        IcebergStorageKind::AzureBlob => format!("az://{}/{}", bucket.unwrap_or_default(), path),
+    }
+}
+
+fn object_path(path: &str) -> ObjectPath {
+    ObjectPath::from(path.trim_matches('/'))
+}
+
+fn collect_local_files(directory: &Path, out: &mut Vec<String>) -> Result<(), CatalogError> {
+    if directory.is_file() {
+        out.push(directory.to_string_lossy().replace('\\', "/"));
+        return Ok(());
+    }
+    if !directory.exists() {
+        return Ok(());
+    }
+    for entry_result in std::fs::read_dir(directory).map_err(to_catalog_error)? {
+        let entry = entry_result.map_err(to_catalog_error)?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(to_catalog_error)?;
+        if file_type.is_dir() {
+            collect_local_files(&path, out)?;
+        } else if file_type.is_file() {
+            out.push(path.to_string_lossy().replace('\\', "/"));
+        }
+    }
+    Ok(())
+}
+
+fn to_catalog_error(error: impl std::fmt::Display) -> CatalogError {
+    catalog_error(error.to_string())
+}
+
+fn to_engine_error(error: CatalogError) -> EngineError {
+    EngineError {
+        message: error.message,
+    }
+}
+
+fn catalog_error(message: impl Into<String>) -> CatalogError {
+    CatalogError {
+        message: message.into(),
+    }
+}
+
+#[derive(Debug)]
+struct IcebergCatalogLayout {
+    root_name: String,
+    root_has_direct_tables: bool,
+    distinct_first_segments: HashSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct IcebergCatalogEntry {
+    catalog_name: String,
+    namespace_path: Vec<String>,
+    table_name: String,
+}
+
+impl IcebergCatalogLayout {
+    fn from_table_roots(root: &IcebergObjectLocation, tables: &[IcebergObjectLocation]) -> Self {
+        let mut distinct_first_segments = HashSet::new();
+        let mut root_has_direct_tables = false;
+        for table in tables {
+            let relative = table.relative_to(root).unwrap_or_default();
+            let segments = split_path_segments(&relative);
+            if segments.len() <= 1 {
+                root_has_direct_tables = true;
+            }
+            if let Some(first) = segments.first() {
+                distinct_first_segments.insert(first.clone());
+            }
+        }
+        Self {
+            root_name: root
+                .file_name()
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| "iceberg".to_string()),
+            root_has_direct_tables,
+            distinct_first_segments,
+        }
+    }
+
+    fn entry_for(
+        &self,
+        root: &IcebergObjectLocation,
+        table_root: &IcebergObjectLocation,
+    ) -> IcebergCatalogEntry {
+        let relative = table_root.relative_to(root).unwrap_or_default();
+        let mut segments = split_path_segments(&relative);
+        if segments.is_empty() {
+            return IcebergCatalogEntry {
+                catalog_name: self.root_name.clone(),
+                namespace_path: Vec::new(),
+                table_name: table_root
+                    .file_name()
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| "table".to_string()),
+            };
+        }
+
+        let use_first_segment_as_catalog = !self.root_has_direct_tables
+            && self.distinct_first_segments.len() > 1
+            && segments.len() >= 2;
+        let catalog_name = if use_first_segment_as_catalog {
+            segments.remove(0)
+        } else {
+            self.root_name.clone()
+        };
+        let table_name = segments
+            .pop()
+            .unwrap_or_else(|| table_root.file_name().unwrap_or("table").to_string());
+        IcebergCatalogEntry {
+            catalog_name,
+            namespace_path: segments,
+            table_name,
+        }
+    }
+
+    fn catalog_location(&self, root: &IcebergObjectLocation, catalog_name: &str) -> String {
+        if self.root_has_direct_tables || self.distinct_first_segments.len() <= 1 {
+            root.raw().to_string()
+        } else {
+            root.join(catalog_name).raw().to_string()
+        }
+    }
+}
+
+fn split_path_segments(path: &str) -> Vec<String> {
+    path.split('/')
+        .filter(|segment| !segment.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_local_storage_locations() {
+        let location = IcebergObjectLocation::parse("/tmp/demo/table").expect("local path should parse");
+        assert_eq!(location.store_kind(), IcebergStorageKind::Local);
+        assert_eq!(location.path(), "/tmp/demo/table");
+    }
+
+    #[test]
+    fn parses_cloud_storage_locations() {
+        let s3 = IcebergObjectLocation::parse("s3://warehouse/trades").expect("s3 uri should parse");
+        assert_eq!(s3.store_kind(), IcebergStorageKind::S3);
+        assert_eq!(s3.bucket(), Some("warehouse"));
+        assert_eq!(s3.path(), "trades");
+
+        let gcs = IcebergObjectLocation::parse("gs://lake/crypto/trades").expect("gs uri should parse");
+        assert_eq!(gcs.store_kind(), IcebergStorageKind::Gcs);
+        assert_eq!(gcs.bucket(), Some("lake"));
+
+        let azure =
+            IcebergObjectLocation::parse("az://container/root/table").expect("azure uri should parse");
+        assert_eq!(azure.store_kind(), IcebergStorageKind::AzureBlob);
+        assert_eq!(azure.bucket(), Some("container"));
+    }
+
+    #[test]
+    fn orders_metadata_versions() {
+        assert!(compare_iceberg_metadata_files("v1.metadata.json", "v2.metadata.json").is_lt());
+        assert_eq!(iceberg_metadata_version("v17.metadata.json"), 17);
+    }
+
+    #[test]
+    fn layout_detects_multiple_catalogs() {
+        let root = IcebergObjectLocation::parse("/tmp/warehouse").expect("root should parse");
+        let tables = vec![
+            IcebergObjectLocation::parse("/tmp/warehouse/alpha/crypto/trades").expect("table should parse"),
+            IcebergObjectLocation::parse("/tmp/warehouse/beta/market/ohlcv").expect("table should parse"),
+        ];
+        let layout = IcebergCatalogLayout::from_table_roots(&root, &tables);
+        let first = layout.entry_for(&root, &tables[0]);
+        assert_eq!(first.catalog_name, "alpha");
+        assert_eq!(first.namespace_path, vec!["crypto"]);
+        assert_eq!(first.table_name, "trades");
+    }
+
+    #[test]
+    fn partition_values_parse_from_hive_paths() {
+        let data_root =
+            IcebergObjectLocation::parse("/tmp/table/data").expect("data root should parse");
+        let file = IcebergObjectLocation::parse("/tmp/table/data/day=2024-01-01/symbol=btc/part-1.parquet")
+            .expect("file should parse");
+        let values = parse_partition_values(
+            &file,
+            &data_root,
+            &["day".to_string(), "symbol".to_string()],
+            &HashMap::from([
+                ("day".to_string(), TypeSignature::Date),
+                ("symbol".to_string(), TypeSignature::Text),
+            ]),
+        );
+        assert_eq!(
+            values.get("day"),
+            Some(&ScalarValue::Text("2024-01-01".to_string()))
+        );
+        assert_eq!(
+            values.get("symbol"),
+            Some(&ScalarValue::Text("btc".to_string()))
+        );
+    }
+}

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -8,6 +8,8 @@ use std::sync::Mutex;
 use std::sync::{OnceLock, RwLock};
 
 pub mod dependency;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iceberg;
 pub mod oid;
 pub mod schema;
 pub mod search_path;

--- a/src/executor/exec_main/mod.rs
+++ b/src/executor/exec_main/mod.rs
@@ -3,9 +3,7 @@ use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
 #[cfg(not(target_arch = "wasm32"))]
-use std::fs::{self, File};
-#[cfg(not(target_arch = "wasm32"))]
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::{
@@ -48,10 +46,6 @@ use crate::utils::adt::misc::{
     parse_f64_numeric_scalar, render_expr_to_sql, truthy,
 };
 use crate::utils::fmgr::eval_scalar_function;
-#[cfg(not(target_arch = "wasm32"))]
-use parquet::file::reader::{FileReader, SerializedFileReader};
-#[cfg(not(target_arch = "wasm32"))]
-use parquet::record::Field as ParquetField;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
 mod aggregation;

--- a/src/executor/exec_main/query_pipeline.rs
+++ b/src/executor/exec_main/query_pipeline.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use super::table_functions::evaluate_table_function_with_predicate;
 
 pub async fn execute_query(
     query: &Query,
@@ -525,6 +526,23 @@ async fn execute_select_internal(
                     let remaining_predicate =
                         remaining_predicate_from_applied(&relation_predicates, &applied);
                     (table_eval.rows, remaining_predicate)
+                }
+                TableExpression::Function(function) => {
+                    if let Some(table_eval) = evaluate_table_function_with_predicate(
+                        function,
+                        params,
+                        outer_scope,
+                        select.where_clause.as_ref(),
+                    )
+                    .await?
+                    {
+                        (table_eval.rows, select.where_clause.clone())
+                    } else {
+                        (
+                            evaluate_from_clause(&select.from, params, outer_scope).await?,
+                            select.where_clause.clone(),
+                        )
+                    }
                 }
                 _ => (
                     evaluate_from_clause(&select.from, params, outer_scope).await?,

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -68,6 +68,109 @@ pub(super) async fn evaluate_table_function(
     })
 }
 
+#[cfg(target_arch = "wasm32")]
+pub(super) async fn evaluate_table_function_with_predicate(
+    _function: &TableFunctionRef,
+    _params: &[Option<String>],
+    _outer_scope: Option<&EvalScope>,
+    _predicate: Option<&Expr>,
+) -> Result<Option<TableEval>, EngineError> {
+    Ok(None)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) async fn evaluate_table_function_with_predicate(
+    function: &TableFunctionRef,
+    params: &[Option<String>],
+    outer_scope: Option<&EvalScope>,
+    predicate: Option<&Expr>,
+) -> Result<Option<TableEval>, EngineError> {
+    let fn_name = function
+        .name
+        .last()
+        .map(|name| name.to_ascii_lowercase())
+        .unwrap_or_default();
+    if fn_name != "iceberg_scan" {
+        return Ok(None);
+    }
+
+    let mut scope = EvalScope::default();
+    if let Some(outer) = outer_scope {
+        scope.inherit_outer(outer);
+    }
+
+    let mut args = Vec::with_capacity(function.args.len());
+    for arg in &function.args {
+        args.push(eval_expr(arg, &scope, params).await?);
+    }
+    if args.len() != 1 {
+        return Err(EngineError {
+            message: "iceberg_scan() expects exactly one argument (table path)".to_string(),
+        });
+    }
+    if matches!(args[0], ScalarValue::Null) {
+        return Ok(Some(TableEval {
+            rows: Vec::new(),
+            columns: vec!["value".to_string()],
+            null_scope: scope_from_row(&["value".to_string()], &[ScalarValue::Null], &[], &["value".to_string()]),
+        }));
+    }
+
+    let input_path = match &args[0] {
+        ScalarValue::Text(text) => text.trim().to_string(),
+        other => other.render(),
+    };
+    let qualifiers = function
+        .alias
+        .as_ref()
+        .map(|alias| vec![alias.to_ascii_lowercase()])
+        .or_else(|| {
+            function
+                .name
+                .last()
+                .map(|name| vec![name.to_ascii_lowercase()])
+        })
+        .unwrap_or_default();
+    let scan_plan = crate::catalog::iceberg::scan_iceberg_table_with_predicate(
+        &input_path,
+        predicate,
+        &qualifiers,
+        params,
+    )
+    .await?;
+    let mut columns = scan_plan.columns;
+    if !function.column_aliases.is_empty() {
+        if function.column_aliases.len() != columns.len() {
+            return Err(EngineError {
+                message: format!(
+                    "table function {} expects {} column aliases, got {}",
+                    function
+                        .name
+                        .last()
+                        .map(String::as_str)
+                        .unwrap_or("function"),
+                    columns.len(),
+                    function.column_aliases.len()
+                ),
+            });
+        }
+        columns = function.column_aliases.clone();
+    }
+    let projection_names = columns.clone();
+    let mut scoped_rows = Vec::with_capacity(scan_plan.rows.len());
+    for row in &scan_plan.rows {
+        scoped_rows.push(scope_from_row(&columns, row, &qualifiers, &projection_names));
+    }
+    let null_values = vec![ScalarValue::Null; columns.len()];
+    let null_scope = scope_from_row(&columns, &null_values, &qualifiers, &projection_names);
+
+    Ok(Some(TableEval {
+        rows: scoped_rows,
+        columns,
+        null_scope,
+    }))
+}
+
 pub(super) async fn evaluate_set_returning_function(
     function: &TableFunctionRef,
     args: &[ScalarValue],
@@ -111,7 +214,7 @@ pub(super) async fn evaluate_set_returning_function(
         "pg_input_error_info" => eval_pg_input_error_info_set_function(args, &fn_name),
         "json_table" => eval_json_table_function(args, &fn_name).await,
         "iceberg_scan" => eval_iceberg_scan_function(args, &fn_name).await,
-        "iceberg_metadata" => eval_iceberg_metadata_function(args, &fn_name),
+        "iceberg_metadata" => eval_iceberg_metadata_function(args, &fn_name).await,
         "pg_get_keywords" => eval_pg_get_keywords(),
         "messages" if function.name.len() == 2 && function.name[0].eq_ignore_ascii_case("ws") => {
             execute_ws_messages(args).await
@@ -551,26 +654,24 @@ pub(super) async fn eval_iceberg_scan_function(
         });
     }
 
-    let input = Path::new(&input_path);
-    let metadata_columns = read_iceberg_metadata_columns(input);
-    let parquet_files = discover_iceberg_parquet_files(input, fn_name)?;
-    if parquet_files.is_empty() {
-        if let Some(columns) = metadata_columns {
-            return Ok((columns, Vec::new()));
-        }
-        return Err(EngineError {
-            message: format!(
-                "{fn_name}(): no parquet files found under {}",
-                input.display()
-            ),
-        });
-    }
-
-    scan_iceberg_parquet_files(
-        &parquet_files,
-        metadata_columns.unwrap_or_default(),
-        fn_name,
-    )
+    let scan_plan = crate::catalog::iceberg::plan_iceberg_scan(&input_path, None, &[])
+        .await
+        .map_err(|error| {
+            let message = if error.message.starts_with("no Iceberg metadata found under") {
+                let input = Path::new(&input_path);
+                if !input.exists() {
+                    format!(
+                        "{fn_name}() expects an existing Iceberg table directory, metadata file, or parquet file path"
+                    )
+                } else {
+                    format!("{fn_name}(): no parquet files found under {input_path}")
+                }
+            } else {
+                format!("{fn_name}(): {}", error.message)
+            };
+            EngineError { message }
+        })?;
+    Ok((scan_plan.columns, scan_plan.rows))
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -584,7 +685,7 @@ pub(super) async fn eval_iceberg_scan_function(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(super) fn eval_iceberg_metadata_function(
+pub(super) async fn eval_iceberg_metadata_function(
     args: &[ScalarValue],
     fn_name: &str,
 ) -> Result<(Vec<String>, Vec<Vec<ScalarValue>>), EngineError> {
@@ -623,61 +724,33 @@ pub(super) fn eval_iceberg_metadata_function(
         });
     }
 
-    let input = Path::new(&input_path);
-    let metadata_file = resolve_iceberg_metadata_file(input).ok_or_else(|| EngineError {
-        message: format!(
-            "{fn_name}(): could not resolve Iceberg metadata file for {}",
-            input.display()
-        ),
-    })?;
-    let metadata_text = fs::read_to_string(&metadata_file).map_err(|err| EngineError {
-        message: format!(
-            "{fn_name}(): failed to read metadata file {}: {err}",
-            metadata_file.display()
-        ),
-    })?;
-    let metadata_json =
-        serde_json::from_str::<JsonValue>(&metadata_text).map_err(|err| EngineError {
-            message: format!(
-                "{fn_name}(): failed to parse metadata file {}: {err}",
-                metadata_file.display()
-            ),
-        })?;
-
-    let parquet_files = discover_iceberg_parquet_files(input, fn_name)?;
-    let snapshots = metadata_json
-        .get("snapshots")
-        .and_then(JsonValue::as_array)
-        .map_or(0_i64, |items| {
-            i64::try_from(items.len()).unwrap_or(i64::MAX)
-        });
-    let partition_spec = metadata_json
-        .get("partition-specs")
-        .cloned()
-        .unwrap_or_else(|| JsonValue::Array(Vec::new()));
+    let metadata =
+        crate::catalog::iceberg::read_iceberg_metadata(&input_path)
+            .await
+            .map_err(|error| EngineError {
+                message: format!("{fn_name}(): {}", error.message),
+            })?;
 
     let row = vec![
-        metadata_json
-            .get("table-uuid")
-            .and_then(JsonValue::as_str)
-            .map_or(ScalarValue::Null, |value| {
-                ScalarValue::Text(value.to_string())
-            }),
-        metadata_json
-            .get("format-version")
-            .and_then(JsonValue::as_i64)
-            .map_or(ScalarValue::Null, ScalarValue::Int),
-        metadata_json
-            .get("last-updated-ms")
-            .and_then(JsonValue::as_i64)
-            .map_or(ScalarValue::Null, ScalarValue::Int),
-        metadata_json
-            .get("current-schema-id")
-            .and_then(JsonValue::as_i64)
-            .map_or(ScalarValue::Null, ScalarValue::Int),
-        ScalarValue::Text(partition_spec.to_string()),
-        ScalarValue::Int(snapshots),
-        ScalarValue::Int(i64::try_from(parquet_files.len()).unwrap_or(i64::MAX)),
+        metadata
+            .table_uuid
+            .map(ScalarValue::Text)
+            .unwrap_or(ScalarValue::Null),
+        metadata
+            .format_version
+            .map(ScalarValue::Int)
+            .unwrap_or(ScalarValue::Null),
+        metadata
+            .last_updated_ms
+            .map(ScalarValue::Int)
+            .unwrap_or(ScalarValue::Null),
+        metadata
+            .current_schema_id
+            .map(ScalarValue::Int)
+            .unwrap_or(ScalarValue::Null),
+        ScalarValue::Text(metadata.partition_spec_json),
+        ScalarValue::Int(metadata.snapshot_count),
+        ScalarValue::Int(metadata.total_data_files),
     ];
 
     Ok((
@@ -690,421 +763,13 @@ pub(super) fn eval_iceberg_metadata_function(
 }
 
 #[cfg(target_arch = "wasm32")]
-pub(super) fn eval_iceberg_metadata_function(
+pub(super) async fn eval_iceberg_metadata_function(
     _args: &[ScalarValue],
     fn_name: &str,
 ) -> Result<(Vec<String>, Vec<Vec<ScalarValue>>), EngineError> {
     Err(EngineError {
         message: format!("{fn_name}() is not supported on wasm targets"),
     })
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn scan_iceberg_parquet_files(
-    parquet_files: &[PathBuf],
-    mut columns: Vec<String>,
-    fn_name: &str,
-) -> Result<(Vec<String>, Vec<Vec<ScalarValue>>), EngineError> {
-    let mut column_index = HashMap::new();
-    for (idx, name) in columns.iter().enumerate() {
-        column_index.insert(name.to_ascii_lowercase(), idx);
-    }
-
-    let mut rows = Vec::new();
-    for file_path in parquet_files {
-        let file = File::open(file_path).map_err(|err| EngineError {
-            message: format!(
-                "{fn_name}(): failed to open parquet file {}: {err}",
-                file_path.display()
-            ),
-        })?;
-        let reader = SerializedFileReader::new(file).map_err(|err| EngineError {
-            message: format!(
-                "{fn_name}(): failed to read parquet file {}: {err}",
-                file_path.display()
-            ),
-        })?;
-
-        for name in parquet_root_field_names(&reader) {
-            ensure_iceberg_column(&name, &mut columns, &mut column_index, &mut rows);
-        }
-
-        let row_iter = reader.get_row_iter(None).map_err(|err| EngineError {
-            message: format!(
-                "{fn_name}(): failed to iterate parquet rows in {}: {err}",
-                file_path.display()
-            ),
-        })?;
-
-        for row_result in row_iter {
-            let row = row_result.map_err(|err| EngineError {
-                message: format!(
-                    "{fn_name}(): failed to decode parquet row in {}: {err}",
-                    file_path.display()
-                ),
-            })?;
-            let mut output_row = vec![ScalarValue::Null; columns.len()];
-            for (name, field) in row.get_column_iter() {
-                let idx = ensure_iceberg_column(name, &mut columns, &mut column_index, &mut rows);
-                if idx >= output_row.len() {
-                    output_row.resize(columns.len(), ScalarValue::Null);
-                }
-                output_row[idx] = parquet_field_to_scalar(field);
-            }
-            rows.push(output_row);
-        }
-    }
-
-    if columns.is_empty() {
-        columns.push("value".to_string());
-    }
-    Ok((columns, rows))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn parquet_root_field_names(reader: &SerializedFileReader<File>) -> Vec<String> {
-    reader
-        .metadata()
-        .file_metadata()
-        .schema()
-        .get_fields()
-        .iter()
-        .map(|field| field.name().to_string())
-        .collect()
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn ensure_iceberg_column(
-    name: &str,
-    columns: &mut Vec<String>,
-    column_index: &mut HashMap<String, usize>,
-    rows: &mut Vec<Vec<ScalarValue>>,
-) -> usize {
-    let key = name.to_ascii_lowercase();
-    if let Some(idx) = column_index.get(&key) {
-        return *idx;
-    }
-
-    let idx = columns.len();
-    columns.push(name.to_string());
-    column_index.insert(key, idx);
-    for row in rows {
-        row.push(ScalarValue::Null);
-    }
-    idx
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn parquet_field_to_scalar(field: &ParquetField) -> ScalarValue {
-    match field {
-        ParquetField::Null => ScalarValue::Null,
-        ParquetField::Bool(value) => ScalarValue::Bool(*value),
-        ParquetField::Byte(value) => ScalarValue::Int(i64::from(*value)),
-        ParquetField::Short(value) => ScalarValue::Int(i64::from(*value)),
-        ParquetField::Int(value) => ScalarValue::Int(i64::from(*value)),
-        ParquetField::Long(value) => ScalarValue::Int(*value),
-        ParquetField::UByte(value) => ScalarValue::Int(i64::from(*value)),
-        ParquetField::UShort(value) => ScalarValue::Int(i64::from(*value)),
-        ParquetField::UInt(value) => ScalarValue::Int(i64::from(*value)),
-        ParquetField::ULong(value) => {
-            if let Ok(v) = i64::try_from(*value) {
-                ScalarValue::Int(v)
-            } else {
-                ScalarValue::Text(value.to_string())
-            }
-        }
-        ParquetField::Float16(value) => ScalarValue::Float(f64::from(*value)),
-        ParquetField::Float(value) => ScalarValue::Float(f64::from(*value)),
-        ParquetField::Double(value) => ScalarValue::Float(*value),
-        ParquetField::Decimal(value) => ScalarValue::Text(parquet_decimal_to_text(value)),
-        ParquetField::Str(value) => ScalarValue::Text(value.clone()),
-        ParquetField::Bytes(value) => {
-            if let Ok(text) = String::from_utf8(value.data().to_vec()) {
-                ScalarValue::Text(text)
-            } else {
-                use base64::Engine;
-                ScalarValue::Text(base64::prelude::BASE64_STANDARD.encode(value.data()))
-            }
-        }
-        ParquetField::Date(value) => ScalarValue::Text(value.to_string()),
-        ParquetField::TimeMillis(value) => ScalarValue::Text(value.to_string()),
-        ParquetField::TimeMicros(value) => ScalarValue::Text(value.to_string()),
-        ParquetField::TimestampMillis(value) => ScalarValue::Text(value.to_string()),
-        ParquetField::TimestampMicros(value) => ScalarValue::Text(value.to_string()),
-        ParquetField::Group(_) | ParquetField::ListInternal(_) | ParquetField::MapInternal(_) => {
-            ScalarValue::Text(field.to_string())
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn parquet_decimal_to_text(value: &parquet::data_type::Decimal) -> String {
-    let bytes = value.data();
-    let scale = value.scale();
-    if bytes.len() > 16 {
-        return format!("{value:?}");
-    }
-
-    let sign_extension = if bytes.first().is_some_and(|byte| byte & 0x80 != 0) {
-        0xFF
-    } else {
-        0x00
-    };
-    let mut padded = [sign_extension; 16];
-    let start = 16 - bytes.len();
-    padded[start..].copy_from_slice(bytes);
-    let unscaled = i128::from_be_bytes(padded);
-    format_scaled_i128(unscaled, scale)
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn format_scaled_i128(value: i128, scale: i32) -> String {
-    if scale <= 0 {
-        return value.to_string();
-    }
-
-    let sign = if value < 0 { "-" } else { "" };
-    let abs = value.unsigned_abs().to_string();
-    let scale_usize = usize::try_from(scale).unwrap_or(0);
-
-    if abs.len() <= scale_usize {
-        let zeros = "0".repeat(scale_usize.saturating_sub(abs.len()));
-        return format!("{sign}0.{zeros}{abs}");
-    }
-
-    let split = abs.len() - scale_usize;
-    format!("{sign}{}.{}", &abs[..split], &abs[split..])
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn discover_iceberg_parquet_files(
-    path: &Path,
-    fn_name: &str,
-) -> Result<Vec<PathBuf>, EngineError> {
-    if path.is_file()
-        && path
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("parquet"))
-    {
-        return Ok(vec![path.to_path_buf()]);
-    }
-
-    let table_root = resolve_iceberg_table_root(path, fn_name)?;
-    let mut parquet_files = Vec::new();
-
-    let data_dir = table_root.join("data");
-    if data_dir.is_dir() {
-        collect_parquet_files(&data_dir, &mut parquet_files, fn_name)?;
-    }
-    if parquet_files.is_empty() {
-        collect_parquet_files(&table_root, &mut parquet_files, fn_name)?;
-    }
-
-    parquet_files.sort();
-    Ok(parquet_files)
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn resolve_iceberg_table_root(
-    path: &Path,
-    fn_name: &str,
-) -> Result<PathBuf, EngineError> {
-    if path.is_dir() {
-        return Ok(path.to_path_buf());
-    }
-    if path.is_file() {
-        let file_name = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("");
-        let is_json_path = path
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("json"));
-        if file_name.to_ascii_lowercase().ends_with(".metadata.json") || is_json_path {
-            let parent = path.parent().ok_or_else(|| EngineError {
-                message: format!(
-                    "{fn_name}(): cannot determine table root from {}",
-                    path.display()
-                ),
-            })?;
-            if parent
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.eq_ignore_ascii_case("metadata"))
-                && let Some(root) = parent.parent()
-            {
-                return Ok(root.to_path_buf());
-            }
-            return Ok(parent.to_path_buf());
-        }
-        if file_name.ends_with(".parquet") {
-            return path
-                .parent()
-                .map(Path::to_path_buf)
-                .ok_or_else(|| EngineError {
-                    message: format!(
-                        "{fn_name}(): cannot determine table root from {}",
-                        path.display()
-                    ),
-                });
-        }
-    }
-
-    Err(EngineError {
-        message: format!(
-            "{fn_name}() expects an existing Iceberg table directory, metadata file, or parquet file path"
-        ),
-    })
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn collect_parquet_files(
-    directory: &Path,
-    parquet_files: &mut Vec<PathBuf>,
-    fn_name: &str,
-) -> Result<(), EngineError> {
-    let entries = fs::read_dir(directory).map_err(|err| EngineError {
-        message: format!(
-            "{fn_name}(): failed to read directory {}: {err}",
-            directory.display()
-        ),
-    })?;
-    for entry_result in entries {
-        let entry = entry_result.map_err(|err| EngineError {
-            message: format!(
-                "{fn_name}(): failed to read directory entry in {}: {err}",
-                directory.display()
-            ),
-        })?;
-        let path = entry.path();
-        let file_type = entry.file_type().map_err(|err| EngineError {
-            message: format!(
-                "{fn_name}(): failed to inspect path {}: {err}",
-                path.display()
-            ),
-        })?;
-        if file_type.is_dir() {
-            collect_parquet_files(&path, parquet_files, fn_name)?;
-            continue;
-        }
-        if file_type.is_file()
-            && path
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("parquet"))
-        {
-            parquet_files.push(path);
-        }
-    }
-    Ok(())
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn read_iceberg_metadata_columns(path: &Path) -> Option<Vec<String>> {
-    let metadata_file = resolve_iceberg_metadata_file(path)?;
-    let metadata = fs::read_to_string(metadata_file).ok()?;
-    let json = serde_json::from_str::<JsonValue>(&metadata).ok()?;
-
-    if let Some(columns) = extract_schema_field_names(json.get("schema")) {
-        return Some(columns);
-    }
-
-    let current_schema_id = json.get("current-schema-id").and_then(JsonValue::as_i64);
-    let schemas = json.get("schemas").and_then(JsonValue::as_array)?;
-    if let Some(schema_id) = current_schema_id
-        && let Some(schema) = schemas
-            .iter()
-            .find(|schema| schema.get("schema-id").and_then(JsonValue::as_i64) == Some(schema_id))
-        && let Some(columns) = extract_schema_field_names(Some(schema))
-    {
-        return Some(columns);
-    }
-
-    schemas
-        .last()
-        .and_then(|schema| extract_schema_field_names(Some(schema)))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn resolve_iceberg_metadata_file(path: &Path) -> Option<PathBuf> {
-    if path.is_file()
-        && path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.ends_with(".metadata.json"))
-    {
-        return Some(path.to_path_buf());
-    }
-
-    let table_root = resolve_iceberg_table_root(path, "iceberg_scan").ok()?;
-    let metadata_dir = table_root.join("metadata");
-    if !metadata_dir.is_dir() {
-        return None;
-    }
-
-    let mut candidates = Vec::new();
-    for entry in fs::read_dir(metadata_dir).ok()? {
-        let entry = entry.ok()?;
-        let file_name = entry.file_name();
-        let file_name = file_name.to_str()?;
-        if file_name.ends_with(".metadata.json") {
-            candidates.push(entry.path());
-        }
-    }
-    if candidates.is_empty() {
-        return None;
-    }
-
-    candidates
-        .sort_by(|left, right| compare_iceberg_metadata_files(left.as_path(), right.as_path()));
-    candidates.pop()
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn compare_iceberg_metadata_files(left: &Path, right: &Path) -> Ordering {
-    let left_name = left
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("");
-    let right_name = right
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("");
-    let left_version = iceberg_metadata_version(left_name);
-    let right_version = iceberg_metadata_version(right_name);
-
-    left_version
-        .cmp(&right_version)
-        .then_with(|| left_name.cmp(right_name))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn iceberg_metadata_version(file_name: &str) -> u64 {
-    let stem = file_name
-        .strip_suffix(".metadata.json")
-        .unwrap_or(file_name);
-    let stem = stem.strip_prefix('v').unwrap_or(stem);
-    let digits = stem
-        .chars()
-        .take_while(|ch| ch.is_ascii_digit())
-        .collect::<String>();
-    digits.parse::<u64>().unwrap_or(0)
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) fn extract_schema_field_names(schema: Option<&JsonValue>) -> Option<Vec<String>> {
-    let fields = schema?.get("fields")?.as_array()?;
-    let columns = fields
-        .iter()
-        .filter_map(|field| field.get("name").and_then(JsonValue::as_str))
-        .map(std::string::ToString::to_string)
-        .collect::<Vec<_>>();
-    if columns.is_empty() {
-        return None;
-    }
-    Some(columns)
 }
 
 pub(super) fn eval_generate_series(

--- a/tests/iceberg_fixtures.rs
+++ b/tests/iceberg_fixtures.rs
@@ -20,6 +20,9 @@ pub struct IcebergFixtureSet {
     pub deribit_ohlcv: PathBuf,
     pub deribit_options: PathBuf,
     pub multi_schema: PathBuf,
+    pub evolved_schema: PathBuf,
+    pub partitioned_trades: PathBuf,
+    pub catalog_browser_root: PathBuf,
 }
 
 impl IcebergFixtureSet {
@@ -34,11 +37,17 @@ impl IcebergFixtureSet {
         let deribit_ohlcv = root.join("deribit_ohlcv");
         let deribit_options = root.join("deribit_options");
         let multi_schema = root.join("multi_schema");
+        let evolved_schema = root.join("evolved_schema");
+        let partitioned_trades = root.join("partitioned_trades");
+        let catalog_browser_root = root.join("catalog_browser_root");
 
         create_trades_table(&deribit_trades, 120, 2)?;
         create_ohlcv_table(&deribit_ohlcv, 60)?;
         create_options_table(&deribit_options, 40)?;
         create_multi_schema_table(&multi_schema)?;
+        create_evolved_schema_table(&evolved_schema)?;
+        create_partitioned_trades_table(&partitioned_trades)?;
+        create_catalog_browser_root(&catalog_browser_root)?;
 
         Ok(Self {
             root,
@@ -46,6 +55,9 @@ impl IcebergFixtureSet {
             deribit_ohlcv,
             deribit_options,
             multi_schema,
+            evolved_schema,
+            partitioned_trades,
+            catalog_browser_root,
         })
     }
 
@@ -456,5 +468,167 @@ fn create_multi_schema_table(table_root: &Path) -> FixtureResult<()> {
         "snapshots": []
     });
     fs::write(metadata_dir.join("v1.metadata.json"), serde_json::to_string_pretty(&metadata)?)?;
+    Ok(())
+}
+
+fn create_evolved_schema_table(table_root: &Path) -> FixtureResult<()> {
+    let (metadata_dir, data_dir) = create_table_dirs(table_root)?;
+
+    let legacy_schema = Arc::new(parse_message_type(
+        "message legacy {
+            REQUIRED INT64 id;
+            REQUIRED INT64 value;
+            REQUIRED BYTE_ARRAY legacy (UTF8);
+        }",
+    )?);
+    let legacy_file = fs::File::create(data_dir.join("v0_0000.parquet"))?;
+    let props = WriterProperties::builder().build();
+    let mut writer = SerializedFileWriter::new(legacy_file, legacy_schema, Arc::new(props.clone()))?;
+    let mut rg = writer.next_row_group()?;
+
+    let ids = vec![1_i64, 2, 3];
+    let values = vec![10_i64, 20, 30];
+    let legacy_values = vec![
+        ByteArray::from("alpha"),
+        ByteArray::from("beta"),
+        ByteArray::from("gamma"),
+    ];
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&ids, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&values, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<ByteArrayType>().write_batch(&legacy_values, None, None)?;
+    col.close()?;
+
+    rg.close()?;
+    writer.close()?;
+
+    let current_schema = Arc::new(parse_message_type(
+        "message current {
+            REQUIRED INT64 updated_at;
+            REQUIRED INT64 id;
+            REQUIRED DOUBLE amount;
+        }",
+    )?);
+    let current_file = fs::File::create(data_dir.join("v1_0000.parquet"))?;
+    let mut writer = SerializedFileWriter::new(current_file, current_schema, Arc::new(props))?;
+    let mut rg = writer.next_row_group()?;
+
+    let updated_at = vec![BASE_TIMESTAMP_MS + 1_000, BASE_TIMESTAMP_MS + 2_000];
+    let ids = vec![4_i64, 5];
+    let amounts = vec![40.5_f64, 50.5];
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&updated_at, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<Int64Type>().write_batch(&ids, None, None)?;
+    col.close()?;
+
+    let mut col = rg.next_column()?.unwrap();
+    col.typed::<DoubleType>().write_batch(&amounts, None, None)?;
+    col.close()?;
+
+    rg.close()?;
+    writer.close()?;
+
+    let metadata = json!({
+        "format-version": 2,
+        "table-uuid": "test-evolved-schema-uuid-001",
+        "current-schema-id": 1,
+        "schemas": [
+            {"schema-id": 0, "fields": [
+                {"id": 1, "name": "id", "type": "long", "required": true},
+                {"id": 2, "name": "value", "type": "long", "required": true},
+                {"id": 4, "name": "legacy", "type": "string", "required": true}
+            ]},
+            {"schema-id": 1, "fields": [
+                {"id": 1, "name": "id", "type": "long", "required": true},
+                {"id": 2, "name": "amount", "type": "double", "required": true},
+                {"id": 3, "name": "updated_at", "type": "long", "required": false}
+            ]}
+        ],
+        "partition-specs": [],
+        "snapshots": []
+    });
+    fs::write(metadata_dir.join("v1.metadata.json"), serde_json::to_string_pretty(&metadata)?)?;
+    Ok(())
+}
+
+fn create_partitioned_trades_table(table_root: &Path) -> FixtureResult<()> {
+    let (metadata_dir, data_dir) = create_table_dirs(table_root)?;
+    for (day, rows, offset) in [
+        ("2024-01-01", vec![(1_i64, 61_000.0_f64), (2, 61_100.0)], 0_i64),
+        ("2024-01-02", vec![(3_i64, 62_000.0_f64), (4, 62_100.0)], 10_000_i64),
+    ] {
+        let partition_dir = data_dir.join(format!("day={day}"));
+        fs::create_dir_all(&partition_dir)?;
+        let schema = Arc::new(parse_message_type(
+            "message partitioned_trades {
+                REQUIRED INT64 trade_id;
+                REQUIRED DOUBLE price;
+                REQUIRED BYTE_ARRAY day (UTF8);
+            }",
+        )?);
+        let file = fs::File::create(partition_dir.join(format!("part-{day}.parquet")))?;
+        let props = WriterProperties::builder().build();
+        let mut writer = SerializedFileWriter::new(file, schema, Arc::new(props))?;
+        let mut rg = writer.next_row_group()?;
+
+        let trade_ids = rows.iter().map(|(trade_id, _)| trade_id + offset).collect::<Vec<_>>();
+        let prices = rows.iter().map(|(_, price)| *price).collect::<Vec<_>>();
+        let days = rows
+            .iter()
+            .map(|_| ByteArray::from(day))
+            .collect::<Vec<_>>();
+
+        let mut col = rg.next_column()?.unwrap();
+        col.typed::<Int64Type>().write_batch(&trade_ids, None, None)?;
+        col.close()?;
+
+        let mut col = rg.next_column()?.unwrap();
+        col.typed::<DoubleType>().write_batch(&prices, None, None)?;
+        col.close()?;
+
+        let mut col = rg.next_column()?.unwrap();
+        col.typed::<ByteArrayType>().write_batch(&days, None, None)?;
+        col.close()?;
+
+        rg.close()?;
+        writer.close()?;
+    }
+
+    let metadata = json!({
+        "format-version": 2,
+        "table-uuid": "test-partitioned-trades-uuid-001",
+        "current-schema-id": 0,
+        "schemas": [{"schema-id": 0, "fields": [
+            {"id": 1, "name": "trade_id", "type": "long", "required": true},
+            {"id": 2, "name": "price", "type": "double", "required": true},
+            {"id": 3, "name": "day", "type": "date", "required": true}
+        ]}],
+        "partition-specs": [{
+            "spec-id": 0,
+            "fields": [
+                {"source-id": 3, "field-id": 1000, "name": "day", "transform": "identity"}
+            ]
+        }],
+        "snapshots": []
+    });
+    fs::write(metadata_dir.join("v1.metadata.json"), serde_json::to_string_pretty(&metadata)?)?;
+    Ok(())
+}
+
+fn create_catalog_browser_root(root: &Path) -> FixtureResult<()> {
+    create_trades_table(&root.join("alpha/crypto/trades"), 12, 1)?;
+    create_options_table(&root.join("alpha/derivatives/options"), 8)?;
+    create_ohlcv_table(&root.join("beta/market/spot/ohlcv"), 6)?;
     Ok(())
 }

--- a/tests/iceberg_tests.rs
+++ b/tests/iceberg_tests.rs
@@ -3,9 +3,11 @@
 mod iceberg_fixtures;
 
 use iceberg_fixtures::IcebergFixtureSet;
+use openassay::parser::ast::{QueryExpr, Statement};
 use openassay::parser::sql_parser::parse_statement;
 use openassay::storage::tuple::ScalarValue;
 use openassay::tcop::engine::{EngineError, QueryResult, execute_planned_query, plan_statement};
+use serde_json::Value as JsonValue;
 use std::future::Future;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
@@ -252,6 +254,92 @@ fn iceberg_scan_multi_schema_column_union() {
         // First row should have id=1
         assert_eq!(result.rows[0][0], ScalarValue::Int(1));
         assert_eq!(result.rows[0][1], ScalarValue::Int(10));
+    });
+}
+
+#[test]
+fn iceberg_scan_evolved_schema_uses_current_column_mapping() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let sql = format!(
+            "SELECT * FROM iceberg_scan('{}') ORDER BY id",
+            sql_path_literal(&guard.fixtures.evolved_schema)
+        );
+        let result = run_statement(&sql);
+        assert_eq!(result.columns, vec!["id", "amount", "updated_at"]);
+        assert_eq!(result.rows.len(), 5);
+        assert_eq!(result.rows[0][0], ScalarValue::Int(1));
+        assert_eq!(result.rows[0][1], ScalarValue::Float(10.0));
+        assert_eq!(result.rows[0][2], ScalarValue::Null);
+        assert_eq!(result.rows[3][0], ScalarValue::Int(4));
+        assert_eq!(result.rows[3][1], ScalarValue::Float(40.5));
+        assert_eq!(result.rows[3][2], ScalarValue::Int(1_700_000_001_000));
+    });
+}
+
+#[test]
+fn iceberg_partition_pruning_reduces_scanned_files() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let predicate = match parse_statement("SELECT 1 WHERE day = '2024-01-02'")
+            .expect("predicate statement should parse")
+        {
+            Statement::Query(query) => match query.body {
+                QueryExpr::Select(select) => {
+                    select.where_clause.expect("where clause should exist")
+                }
+                other => panic!("expected select query, got {other:?}"),
+            },
+            other => panic!("expected query statement, got {other:?}"),
+        };
+        let plan = block_on(openassay::catalog::iceberg::scan_iceberg_table_with_predicate(
+            &sql_path_literal(&guard.fixtures.partitioned_trades),
+            Some(&predicate),
+            &["iceberg_scan".to_string()],
+            &[],
+        ))
+        .expect("partitioned scan should succeed");
+        assert_eq!(plan.scanned_files, 1);
+        assert_eq!(plan.pruned_files, 1);
+        assert_eq!(plan.rows.len(), 2);
+    });
+}
+
+#[test]
+fn browser_catalog_browse_lists_iceberg_catalogs_and_tables() {
+    with_isolated_state(|| {
+        let guard = FixtureGuard::create();
+        let payload = block_on(openassay::browser::browse_catalog_json(
+            &sql_path_literal(&guard.fixtures.catalog_browser_root),
+        ));
+        let json: JsonValue = serde_json::from_str(&payload).expect("browse payload should parse");
+        assert_eq!(json.get("ok"), Some(&JsonValue::Bool(true)));
+        let catalogs = json["catalogs"].as_array().expect("catalogs array expected");
+        assert_eq!(catalogs.len(), 2);
+        assert_eq!(catalogs[0]["name"], JsonValue::String("alpha".to_string()));
+        assert_eq!(catalogs[1]["name"], JsonValue::String("beta".to_string()));
+
+        let alpha_namespaces = catalogs[0]["namespaces"]
+            .as_array()
+            .expect("alpha namespaces expected");
+        assert!(alpha_namespaces.iter().any(|namespace| {
+            namespace["tables"]
+                .as_array()
+                .is_some_and(|tables| {
+                    tables
+                        .iter()
+                        .any(|table| table["name"] == JsonValue::String("trades".to_string()))
+                })
+        }));
+        assert!(alpha_namespaces.iter().any(|namespace| {
+            namespace["tables"]
+                .as_array()
+                .is_some_and(|tables| {
+                    tables
+                        .iter()
+                        .any(|table| table["name"] == JsonValue::String("options".to_string()))
+                })
+        }));
     });
 }
 


### PR DESCRIPTION
Automated by Shipyard 🧠 (GPT-5.4, 700K tokens)

## Changes
- **New `src/catalog/iceberg.rs`** (1620 lines) — shared Iceberg catalog module
- **Cloud storage**: S3, GCS, Azure Blob via `object_store`
- **Schema evolution**: reconcile column changes using Iceberg field IDs
- **Partition pruning**: extract SQL predicates to skip irrelevant data files
- **Browser browsing**: `browse_catalog_json` for structured tree view
- **Refactored `table_functions.rs`**: replaced ad hoc scan with catalog calls
- **WASM compat**: gated behind `cfg(not(wasm32))`, WASM builds clean

749 tests pass ✅ | WASM builds ✅

Closes #106