### PR TITLE
chore: add Codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "header, diff, flags, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary
- Adds `.codecov.yml` with project coverage status check (auto target, 1% threshold)
- Matches configuration used in openferric

🤖 Generated with [Claude Code](https://claude.com/claude-code)