### PR TITLE
fix: apply WHERE filters to ForeignScan results

### DIFF
--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -1284,6 +1284,10 @@ async fn evaluate_relation_with_predicates_impl(
                 .map(|column| column.name().to_string())
                 .collect::<Vec<_>>();
             let rows = crate::foreign::execute_foreign_scan(&table)?;
+            // Foreign scans do not apply scan_predicates at the storage level,
+            // so clear pushed_predicate_indexes so the caller knows all
+            // predicates still need post-scan evaluation.
+            pushed_predicate_indexes.clear();
             (columns, rows, None)
         }
     };

--- a/src/foreign.rs
+++ b/src/foreign.rs
@@ -606,4 +606,88 @@ mod tests {
             );
         });
     }
+
+    /// Helper: set up a foreign table with 3 rows for WHERE-filter tests.
+    /// Rows: [("hello",""), (NULL,"world"), ("","test")]
+    fn setup_filter_test_table() {
+        with_fdw_write(|reg| {
+            reg.register_wrapper(Arc::new(TestFdw {
+                rows: vec![
+                    vec![
+                        ScalarValue::Text("hello".to_string()),
+                        ScalarValue::Text(String::new()),
+                    ],
+                    vec![ScalarValue::Null, ScalarValue::Text("world".to_string())],
+                    vec![
+                        ScalarValue::Text(String::new()),
+                        ScalarValue::Text("test".to_string()),
+                    ],
+                ],
+            }));
+        });
+        run_sql("CREATE SERVER testserver FOREIGN DATA WRAPPER test_fdw");
+        run_sql("CREATE FOREIGN TABLE ft (a text, b text) SERVER testserver");
+    }
+
+    #[test]
+    fn foreign_scan_where_equality() {
+        with_isolated_state(|| {
+            setup_filter_test_table();
+            let result = run_sql("SELECT * FROM ft WHERE a = 'hello'");
+            assert_eq!(result.rows.len(), 1);
+            assert_eq!(result.rows[0][0], ScalarValue::Text("hello".to_string()));
+            assert_eq!(result.rows[0][1], ScalarValue::Text(String::new()));
+        });
+    }
+
+    #[test]
+    fn foreign_scan_where_empty_string() {
+        with_isolated_state(|| {
+            setup_filter_test_table();
+            let result = run_sql("SELECT * FROM ft WHERE b = ''");
+            assert_eq!(result.rows.len(), 1);
+            assert_eq!(result.rows[0][0], ScalarValue::Text("hello".to_string()));
+            assert_eq!(result.rows[0][1], ScalarValue::Text(String::new()));
+        });
+    }
+
+    #[test]
+    fn foreign_scan_where_inequality() {
+        with_isolated_state(|| {
+            setup_filter_test_table();
+            let result = run_sql("SELECT * FROM ft WHERE b != ''");
+            assert_eq!(result.rows.len(), 2);
+        });
+    }
+
+    #[test]
+    fn foreign_scan_where_is_null() {
+        with_isolated_state(|| {
+            setup_filter_test_table();
+            let result = run_sql("SELECT * FROM ft WHERE a IS NULL");
+            assert_eq!(result.rows.len(), 1);
+            assert_eq!(result.rows[0][0], ScalarValue::Null);
+            assert_eq!(result.rows[0][1], ScalarValue::Text("world".to_string()));
+        });
+    }
+
+    #[test]
+    fn foreign_scan_where_is_not_null() {
+        with_isolated_state(|| {
+            setup_filter_test_table();
+            let result = run_sql("SELECT * FROM ft WHERE a IS NOT NULL");
+            assert_eq!(result.rows.len(), 2);
+        });
+    }
+
+    #[test]
+    fn foreign_scan_where_compound() {
+        with_isolated_state(|| {
+            setup_filter_test_table();
+            let result = run_sql("SELECT * FROM ft WHERE a IS NOT NULL AND b != ''");
+            assert_eq!(result.rows.len(), 1);
+            assert_eq!(result.rows[0][0], ScalarValue::Text(String::new()));
+            assert_eq!(result.rows[0][1], ScalarValue::Text("test".to_string()));
+        });
+    }
 }


### PR DESCRIPTION
Fixes #128

## Problem
WHERE equality/inequality filters were not applied to ForeignScan results — all rows returned regardless of filter. IS NULL/IS NOT NULL worked fine.

## Root Cause
In `evaluate_relation_with_predicates_impl`, scan predicates are extracted and their indexes added to `pushed_predicate_indexes` for all table types. For heap tables the storage layer applies them, but for foreign tables they were ignored — yet the caller still thought they'd been handled and excluded them from post-scan filtering.

## Fix
One line: `pushed_predicate_indexes.clear()` in the `TableKind::Foreign` branch, ensuring all predicates remain for post-scan evaluation.

## Tests
6 new tests: equality, empty string, inequality, IS NULL, IS NOT NULL, compound WHERE on foreign tables.