### PR TITLE
fix: CI failures — rustls CryptoProvider + pages notebook

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,10 +43,6 @@ jobs:
         run: |
           mkdir -p _site
           cp -r web/* _site/
-          mkdir -p _site/notebook
-          cp -r notebook/* _site/notebook/
-          cp -r web/pkg _site/notebook/pkg
-          cp web/worker.js _site/notebook/worker.js
           cp -r target/doc _site/docs
           touch _site/.nojekyll
 

--- a/src/bin/pg_server.rs
+++ b/src/bin/pg_server.rs
@@ -14,6 +14,12 @@ use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::ServerConnection;
 
 fn main() {
+    // Install the default CryptoProvider so rustls doesn't panic when both
+    // aws-lc-rs and ring features are enabled.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok(); // ignore AlreadyInstalled
+
     let addr = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "127.0.0.1:55432".to_string());


### PR DESCRIPTION
## Fixes

**1. compat workflow — pg_server crash**
```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```
Both `aws-lc-rs` and `ring` features are enabled. Fix: explicitly call `CryptoProvider::install_default()` before TLS init.

**2. pages workflow — notebook copy failure** 
```
cp: cannot stat 'notebook/*': No such file or directory
```
The `notebook/` directory was removed in PR #123 but the workflow still referenced it. Removed the stale copy steps.