### PR TITLE
feat: WebSocket robustness + integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ object_store = { workspace = true, features = ["aws", "azure", "gcp", "fs"] }
 [dev-dependencies]
 criterion.workspace = true
 proptest.workspace = true
+tungstenite.workspace = true
 
 [[bench]]
 name = "engine_bench"

--- a/src/tcop/engine.rs
+++ b/src/tcop/engine.rs
@@ -523,6 +523,8 @@ pub(crate) mod ws_native {
         >,
         pub incoming: mpsc::Receiver<String>,
         pub _reader_thread: thread::JoinHandle<()>,
+        /// Cloned TCP stream used to unblock the reader thread via shutdown.
+        pub tcp_shutdown: Option<std::net::TcpStream>,
     }
 
     /// Open a real WebSocket connection. Returns a handle for sending/receiving.
@@ -530,14 +532,25 @@ pub(crate) mod ws_native {
         let (socket, _response) =
             tungstenite::connect(url).map_err(|e| format!("WebSocket connect failed: {e}"))?;
 
+        // Clone the TCP stream so we can shut it down to unblock the reader.
+        let tcp_shutdown = match socket.get_ref() {
+            tungstenite::stream::MaybeTlsStream::Plain(tcp) => tcp.try_clone().ok(),
+            _ => None,
+        };
+
+        // Set socket to non-blocking so the reader thread never holds the
+        // writer lock indefinitely — reads return WouldBlock immediately
+        // when no data is available.
+        if let tungstenite::stream::MaybeTlsStream::Plain(tcp) = socket.get_ref() {
+            let _ = tcp.set_nonblocking(true);
+        }
+
         let writer = Arc::new(Mutex::new(Some(socket)));
         let reader_writer = Arc::clone(&writer);
         let (tx, rx) = mpsc::channel();
 
         let reader_thread = thread::spawn(move || {
             loop {
-                // We need to read from the socket, but the writer lock holds it.
-                // We'll use a pattern where the reader briefly locks to read one message.
                 let msg = {
                     let mut guard = match reader_writer.lock() {
                         Ok(guard) => guard,
@@ -551,6 +564,11 @@ pub(crate) mod ws_native {
                             }
                             Ok(tungstenite::Message::Close(_)) => None,
                             Ok(_) => Some(String::new()), // ping/pong/frame - skip
+                            Err(tungstenite::Error::Io(e))
+                                if e.kind() == std::io::ErrorKind::WouldBlock =>
+                            {
+                                Some(String::new()) // no data yet – yield lock
+                            }
                             Err(_) => None,
                         }
                     } else {
@@ -563,8 +581,13 @@ pub(crate) mod ws_native {
                             break;
                         }
                     }
-                    Some(_) => continue, // empty = ping/pong
-                    None => break,       // closed or error
+                    Some(_) => {
+                        // No data available — sleep briefly to avoid busy-spinning
+                        // while still yielding the lock for writers.
+                        thread::sleep(std::time::Duration::from_millis(10));
+                        continue;
+                    }
+                    None => break, // closed or error
                 }
             }
         });
@@ -573,6 +596,7 @@ pub(crate) mod ws_native {
             writer,
             incoming: rx,
             _reader_thread: reader_thread,
+            tcp_shutdown,
         })
     }
 
@@ -582,25 +606,34 @@ pub(crate) mod ws_native {
             .lock()
             .map_err(|_| "WebSocket writer lock poisoned".to_string())?;
         if let Some(ref mut ws) = *guard {
-            ws.write(tungstenite::Message::Text(msg.to_string().into()))
-                .map_err(|e| format!("WebSocket send failed: {e}"))?;
-            ws.flush()
-                .map_err(|e| format!("WebSocket flush failed: {e}"))?;
-            Ok(())
+            // Temporarily switch to blocking mode for reliable writes.
+            if let tungstenite::stream::MaybeTlsStream::Plain(tcp) = ws.get_ref() {
+                let _ = tcp.set_nonblocking(false);
+            }
+            let result = ws
+                .write(tungstenite::Message::Text(msg.to_string().into()))
+                .and_then(|()| ws.flush());
+            // Restore non-blocking mode for the reader thread.
+            if let tungstenite::stream::MaybeTlsStream::Plain(tcp) = ws.get_ref() {
+                let _ = tcp.set_nonblocking(true);
+            }
+            result.map_err(|e| format!("WebSocket send failed: {e}"))
         } else {
             Err("connection already closed".to_string())
         }
     }
 
     pub fn close_connection(handle: &NativeWsHandle) -> Result<(), String> {
+        // Shut down the underlying TCP socket to unblock the reader thread's
+        // ws.read() call, so we can acquire the writer lock promptly.
+        if let Some(ref tcp) = handle.tcp_shutdown {
+            let _ = tcp.shutdown(std::net::Shutdown::Both);
+        }
+
         let mut guard = handle
             .writer
             .lock()
             .map_err(|_| "WebSocket writer lock poisoned".to_string())?;
-        if let Some(ref mut ws) = *guard {
-            let _ = ws.close(None);
-            let _ = ws.flush();
-        }
         *guard = None;
         Ok(())
     }

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -1,0 +1,325 @@
+//! WebSocket integration tests — exercises the ws extension against a real echo server.
+
+use openassay::tcop::engine::{restore_state, snapshot_state};
+use openassay::tcop::postgres::{BackendMessage, FrontendMessage, PostgresSession};
+use std::net::TcpListener;
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/// Serialize all WS integration tests — they share global engine state.
+fn ws_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Start a WebSocket echo server on an ephemeral port. Returns the port.
+/// The server runs in a background thread and echoes every text message back.
+fn start_echo_server() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            thread::spawn(move || {
+                let Ok(mut ws) = tungstenite::accept(stream) else {
+                    return;
+                };
+                loop {
+                    match ws.read() {
+                        Ok(tungstenite::Message::Text(msg)) => {
+                            if ws.write(tungstenite::Message::Text(msg)).is_err() {
+                                break;
+                            }
+                            if ws.flush().is_err() {
+                                break;
+                            }
+                        }
+                        Ok(tungstenite::Message::Close(_)) | Err(_) => break,
+                        _ => {}
+                    }
+                }
+            });
+        }
+    });
+
+    port
+}
+
+/// Run a SQL query and return all backend messages.
+fn sql(session: &mut PostgresSession, query: &str) -> Vec<BackendMessage> {
+    session.run_sync([FrontendMessage::Query {
+        sql: query.to_string(),
+    }])
+}
+
+/// Get the first column value from the first DataRow (handles both text and binary encoding).
+/// Returns `None` when the result is NULL or there are no data rows.
+fn first_val(msgs: &[BackendMessage]) -> Option<String> {
+    for m in msgs {
+        match m {
+            BackendMessage::DataRow { values } if !values.is_empty() => {
+                return Some(values[0].clone());
+            }
+            BackendMessage::DataRowBinary { values } if !values.is_empty() => {
+                return values[0]
+                    .as_ref()
+                    .map(|v| String::from_utf8_lossy(v).to_string());
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Check if any backend message is an ErrorResponse.
+fn has_error(msgs: &[BackendMessage]) -> bool {
+    msgs.iter()
+        .any(|m| matches!(m, BackendMessage::ErrorResponse { .. }))
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn ws_connect_real_server() {
+    let _g = ws_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let port = start_echo_server();
+
+    let mut s = PostgresSession::new();
+    sql(&mut s, "SELECT 1");
+    let clean = snapshot_state();
+
+    sql(&mut s, "CREATE EXTENSION ws");
+    let out = sql(
+        &mut s,
+        &format!("SELECT ws.connect('ws://127.0.0.1:{port}')"),
+    );
+    assert!(!has_error(&out), "ws.connect should succeed: {out:?}");
+    assert_eq!(first_val(&out), Some("1".to_string()));
+
+    // Real connection → state "open"
+    let out = sql(&mut s, "SELECT state FROM ws.connections WHERE id = 1");
+    assert_eq!(first_val(&out), Some("open".to_string()));
+
+    sql(&mut s, "SELECT ws.close(1)");
+    sql(&mut s, "DROP EXTENSION ws");
+    restore_state(clean);
+}
+
+#[test]
+fn ws_send_recv_echo() {
+    let _g = ws_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let port = start_echo_server();
+
+    let mut s = PostgresSession::new();
+    sql(&mut s, "SELECT 1");
+    let clean = snapshot_state();
+
+    sql(&mut s, "CREATE EXTENSION ws");
+    sql(
+        &mut s,
+        &format!("SELECT ws.connect('ws://127.0.0.1:{port}')"),
+    );
+
+    let out = sql(&mut s, "SELECT ws.send(1, 'hello world')");
+    assert!(!has_error(&out), "ws.send should succeed: {out:?}");
+
+    thread::sleep(Duration::from_millis(200));
+
+    let out = sql(&mut s, "SELECT ws.recv(1)");
+    assert_eq!(first_val(&out), Some("hello world".to_string()));
+
+    sql(&mut s, "SELECT ws.close(1)");
+    sql(&mut s, "DROP EXTENSION ws");
+    restore_state(clean);
+}
+
+#[test]
+fn ws_multiple_messages_roundtrip() {
+    let _g = ws_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let port = start_echo_server();
+
+    let mut s = PostgresSession::new();
+    sql(&mut s, "SELECT 1");
+    let clean = snapshot_state();
+
+    sql(&mut s, "CREATE EXTENSION ws");
+    sql(
+        &mut s,
+        &format!("SELECT ws.connect('ws://127.0.0.1:{port}')"),
+    );
+
+    for i in 1..=3 {
+        sql(&mut s, &format!("SELECT ws.send(1, 'msg{i}')"));
+    }
+    thread::sleep(Duration::from_millis(300));
+
+    assert_eq!(
+        first_val(&sql(&mut s, "SELECT ws.recv(1)")),
+        Some("msg1".to_string())
+    );
+    assert_eq!(
+        first_val(&sql(&mut s, "SELECT ws.recv(1)")),
+        Some("msg2".to_string())
+    );
+    assert_eq!(
+        first_val(&sql(&mut s, "SELECT ws.recv(1)")),
+        Some("msg3".to_string())
+    );
+
+    // Queue empty → NULL
+    assert_eq!(first_val(&sql(&mut s, "SELECT ws.recv(1)")), None);
+
+    sql(&mut s, "SELECT ws.close(1)");
+    sql(&mut s, "DROP EXTENSION ws");
+    restore_state(clean);
+}
+
+#[test]
+fn ws_close_real_connection() {
+    let _g = ws_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let port = start_echo_server();
+
+    let mut s = PostgresSession::new();
+    sql(&mut s, "SELECT 1");
+    let clean = snapshot_state();
+
+    sql(&mut s, "CREATE EXTENSION ws");
+    sql(
+        &mut s,
+        &format!("SELECT ws.connect('ws://127.0.0.1:{port}')"),
+    );
+
+    let out = sql(&mut s, "SELECT ws.close(1)");
+    assert!(!has_error(&out), "ws.close should succeed: {out:?}");
+    assert_eq!(first_val(&out), Some("t".to_string()));
+
+    let out = sql(&mut s, "SELECT state FROM ws.connections WHERE id = 1");
+    assert_eq!(first_val(&out), Some("closed".to_string()));
+
+    sql(&mut s, "DROP EXTENSION ws");
+    restore_state(clean);
+}
+
+#[test]
+fn ws_connection_refused() {
+    let _g = ws_lock().lock().unwrap_or_else(|e| e.into_inner());
+
+    // Bind then drop to get a port that is definitely not listening.
+    let port = {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.local_addr().unwrap().port()
+    };
+
+    let mut s = PostgresSession::new();
+    sql(&mut s, "SELECT 1");
+    let clean = snapshot_state();
+
+    sql(&mut s, "CREATE EXTENSION ws");
+    let out = sql(
+        &mut s,
+        &format!("SELECT ws.connect('ws://127.0.0.1:{port}')"),
+    );
+    assert!(
+        !has_error(&out),
+        "connect should succeed in simulated mode: {out:?}"
+    );
+
+    // Falls back to simulated mode → state "connecting"
+    let out = sql(&mut s, "SELECT state FROM ws.connections WHERE id = 1");
+    assert_eq!(first_val(&out), Some("connecting".to_string()));
+
+    sql(&mut s, "DROP EXTENSION ws");
+    restore_state(clean);
+}
+
+#[test]
+fn ws_invalid_url() {
+    let _g = ws_lock().lock().unwrap_or_else(|e| e.into_inner());
+
+    let mut s = PostgresSession::new();
+    sql(&mut s, "SELECT 1");
+    let clean = snapshot_state();
+
+    sql(&mut s, "CREATE EXTENSION ws");
+    let out = sql(&mut s, "SELECT ws.connect('not-a-valid-url')");
+    assert!(
+        !has_error(&out),
+        "connect should succeed in simulated mode: {out:?}"
+    );
+
+    let out = sql(&mut s, "SELECT state FROM ws.connections WHERE id = 1");
+    assert_eq!(first_val(&out), Some("connecting".to_string()));
+
+    sql(&mut s, "DROP EXTENSION ws");
+    restore_state(clean);
+}
+
+#[test]
+fn ws_concurrent_connections() {
+    let _g = ws_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let port = start_echo_server();
+
+    let mut s = PostgresSession::new();
+    sql(&mut s, "SELECT 1");
+    let clean = snapshot_state();
+
+    let url = format!("ws://127.0.0.1:{port}");
+    sql(&mut s, "CREATE EXTENSION ws");
+    sql(&mut s, &format!("SELECT ws.connect('{url}')"));
+    sql(&mut s, &format!("SELECT ws.connect('{url}')"));
+
+    // Both connections open
+    let out = sql(
+        &mut s,
+        "SELECT count(*) FROM ws.connections WHERE state = 'open'",
+    );
+    assert_eq!(first_val(&out), Some("2".to_string()));
+
+    // Send on each, verify independent echoes
+    sql(&mut s, "SELECT ws.send(1, 'from-conn-1')");
+    sql(&mut s, "SELECT ws.send(2, 'from-conn-2')");
+    thread::sleep(Duration::from_millis(300));
+
+    assert_eq!(
+        first_val(&sql(&mut s, "SELECT ws.recv(1)")),
+        Some("from-conn-1".to_string())
+    );
+    assert_eq!(
+        first_val(&sql(&mut s, "SELECT ws.recv(2)")),
+        Some("from-conn-2".to_string())
+    );
+
+    sql(&mut s, "SELECT ws.close(1)");
+    sql(&mut s, "SELECT ws.close(2)");
+    sql(&mut s, "DROP EXTENSION ws");
+    restore_state(clean);
+}
+
+#[test]
+fn ws_send_on_closed_real_connection_errors() {
+    let _g = ws_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let port = start_echo_server();
+
+    let mut s = PostgresSession::new();
+    sql(&mut s, "SELECT 1");
+    let clean = snapshot_state();
+
+    sql(&mut s, "CREATE EXTENSION ws");
+    sql(
+        &mut s,
+        &format!("SELECT ws.connect('ws://127.0.0.1:{port}')"),
+    );
+    sql(&mut s, "SELECT ws.close(1)");
+
+    let out = sql(&mut s, "SELECT ws.send(1, 'should fail')");
+    assert!(
+        has_error(&out),
+        "send on closed connection should produce an error"
+    );
+
+    sql(&mut s, "DROP EXTENSION ws");
+    restore_state(clean);
+}


### PR DESCRIPTION
Fixes #118

## WebSocket improvements
- Reader thread uses non-blocking mode to avoid holding writer lock
- Writes temporarily switch to blocking for reliability  
- Close shuts down TCP socket to unblock reader thread
- Prevents deadlocks between reader/writer lock contention

## Integration tests
- `tests/ws_integration.rs` — self-contained WebSocket test suite with embedded test server
- Tests cover: connect, send/recv, close, error handling

All 814 tests pass.