### PR TITLE
Optimize columnar execution hot paths

### DIFF
--- a/src/bin/profile_clickbench.rs
+++ b/src/bin/profile_clickbench.rs
@@ -1,0 +1,223 @@
+use std::env;
+use std::time::Instant;
+
+use openassay::executor::profiling;
+use openassay::tcop::postgres::{BackendMessage, FrontendMessage, PostgresSession};
+
+const CLICKBENCH_SCHEMA: &str = r"
+CREATE TABLE hits (
+    WatchID              BIGINT NOT NULL,
+    JavaEnable           SMALLINT NOT NULL,
+    Title                TEXT NOT NULL,
+    GoodEvent            SMALLINT NOT NULL,
+    EventTime            TIMESTAMP NOT NULL,
+    EventDate            DATE NOT NULL,
+    CounterID            INTEGER NOT NULL,
+    ClientIP             INTEGER NOT NULL,
+    RegionID             INTEGER NOT NULL,
+    UserID               BIGINT NOT NULL,
+    CounterClass         SMALLINT NOT NULL,
+    OS                   SMALLINT NOT NULL,
+    UserAgent            SMALLINT NOT NULL,
+    URL                  TEXT NOT NULL,
+    Referer              TEXT NOT NULL,
+    IsRefresh            SMALLINT NOT NULL,
+    RefererCategoryID    SMALLINT NOT NULL,
+    RefererRegionID      INTEGER NOT NULL,
+    URLCategoryID        SMALLINT NOT NULL,
+    URLRegionID          INTEGER NOT NULL,
+    ResolutionWidth      SMALLINT NOT NULL,
+    ResolutionHeight     SMALLINT NOT NULL,
+    ResolutionDepth      SMALLINT NOT NULL,
+    FlashMajor           SMALLINT NOT NULL,
+    FlashMinor           SMALLINT NOT NULL,
+    FlashMinor2          TEXT NOT NULL,
+    NetMajor             SMALLINT NOT NULL,
+    NetMinor             SMALLINT NOT NULL,
+    UserAgentMajor       SMALLINT NOT NULL,
+    UserAgentMinor       VARCHAR(255) NOT NULL,
+    CookieEnable         SMALLINT NOT NULL,
+    JavascriptEnable     SMALLINT NOT NULL,
+    IsMobile             SMALLINT NOT NULL,
+    MobilePhone          SMALLINT NOT NULL,
+    MobilePhoneModel     TEXT NOT NULL,
+    Params               TEXT NOT NULL,
+    IPNetworkID          INTEGER NOT NULL,
+    TraficSourceID       SMALLINT NOT NULL,
+    SearchEngineID       SMALLINT NOT NULL,
+    SearchPhrase         TEXT NOT NULL,
+    AdvEngineID          SMALLINT NOT NULL,
+    IsArtifical          SMALLINT NOT NULL,
+    WindowClientWidth    SMALLINT NOT NULL,
+    WindowClientHeight   SMALLINT NOT NULL,
+    ClientTimeZone       SMALLINT NOT NULL,
+    ClientEventTime      TIMESTAMP NOT NULL,
+    SilverlightVersion1  SMALLINT NOT NULL,
+    SilverlightVersion2  SMALLINT NOT NULL,
+    SilverlightVersion3  INTEGER NOT NULL,
+    SilverlightVersion4  SMALLINT NOT NULL,
+    PageCharset          TEXT NOT NULL,
+    CodeVersion          INTEGER NOT NULL,
+    IsLink               SMALLINT NOT NULL,
+    IsDownload           SMALLINT NOT NULL,
+    IsNotBounce          SMALLINT NOT NULL,
+    FUniqID              BIGINT NOT NULL,
+    OriginalURL          TEXT NOT NULL,
+    HID                  INTEGER NOT NULL,
+    IsOldCounter         SMALLINT NOT NULL,
+    IsEvent              SMALLINT NOT NULL,
+    IsParameter          SMALLINT NOT NULL,
+    DontCountHits        SMALLINT NOT NULL,
+    WithHash             SMALLINT NOT NULL,
+    HitColor             CHAR NOT NULL,
+    LocalEventTime       TIMESTAMP NOT NULL,
+    Age                  SMALLINT NOT NULL,
+    Sex                  SMALLINT NOT NULL,
+    Income               SMALLINT NOT NULL,
+    Interests            SMALLINT NOT NULL,
+    Robotness            SMALLINT NOT NULL,
+    RemoteIP             INTEGER NOT NULL,
+    WindowName           INTEGER NOT NULL,
+    OpenerName           INTEGER NOT NULL,
+    HistoryLength        SMALLINT NOT NULL,
+    BrowserLanguage      TEXT NOT NULL,
+    BrowserCountry       TEXT NOT NULL,
+    SocialNetwork        TEXT NOT NULL,
+    SocialAction         TEXT NOT NULL,
+    HTTPError            SMALLINT NOT NULL,
+    SendTiming           INTEGER NOT NULL,
+    DNSTiming            INTEGER NOT NULL,
+    ConnectTiming        INTEGER NOT NULL,
+    ResponseStartTiming  INTEGER NOT NULL,
+    ResponseEndTiming    INTEGER NOT NULL,
+    FetchTiming          INTEGER NOT NULL,
+    SocialSourceNetworkID SMALLINT NOT NULL,
+    SocialSourcePage     TEXT NOT NULL,
+    ParamPrice           BIGINT NOT NULL,
+    ParamOrderID         TEXT NOT NULL,
+    ParamCurrency        TEXT NOT NULL,
+    ParamCurrencyID      SMALLINT NOT NULL,
+    OpenstatServiceName  TEXT NOT NULL,
+    OpenstatCampaignID   TEXT NOT NULL,
+    OpenstatAdID         TEXT NOT NULL,
+    OpenstatSourceID     TEXT NOT NULL,
+    UTMSource            TEXT NOT NULL,
+    UTMMedium            TEXT NOT NULL,
+    UTMCampaign          TEXT NOT NULL,
+    UTMContent           TEXT NOT NULL,
+    UTMTerm              TEXT NOT NULL,
+    FromTag              TEXT NOT NULL,
+    HasGCLID             SMALLINT NOT NULL,
+    RefererHash          BIGINT NOT NULL,
+    URLHash              BIGINT NOT NULL,
+    CLID                 INTEGER NOT NULL
+);
+";
+
+const QUERIES: [(&str, &str); 4] = [
+    (
+        "q20",
+        "SELECT COUNT(*) FROM hits WHERE URL LIKE '%example%'",
+    ),
+    (
+        "q21",
+        "SELECT SearchPhrase, MIN(URL), COUNT(*) AS c FROM hits WHERE URL LIKE '%example%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10",
+    ),
+    (
+        "q22",
+        "SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Analytics%' AND URL NOT LIKE '%.internal%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10",
+    ),
+    (
+        "q23",
+        "SELECT * FROM hits WHERE URL LIKE '%widget%' ORDER BY EventTime LIMIT 10",
+    ),
+];
+
+fn assert_ok(out: &[BackendMessage]) {
+    for msg in out {
+        if let BackendMessage::ErrorResponse { message, code, .. } = msg {
+            panic!("query produced error [{code}]: {message}");
+        }
+    }
+}
+
+fn exec(session: &mut PostgresSession, sql: &str) {
+    let out = session.run_sync([FrontendMessage::Query {
+        sql: sql.to_string(),
+    }]);
+    assert_ok(&out);
+}
+
+fn count_data_rows(out: &[BackendMessage]) -> usize {
+    out.iter()
+        .filter(|m| matches!(m, BackendMessage::DataRow { .. }))
+        .count()
+}
+
+fn load_clickbench_data(session: &mut PostgresSession) {
+    let data_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/data/clickbench/hits_subset.tsv"
+    );
+    let data = std::fs::read(data_path).unwrap_or_else(|error| {
+        panic!("Failed to read {data_path}: {error}");
+    });
+
+    let out = session.run_sync([FrontendMessage::Query {
+        sql: "COPY hits FROM STDIN".to_string(),
+    }]);
+    let got_copy_in = out
+        .iter()
+        .any(|message| matches!(message, BackendMessage::CopyInResponse { .. }));
+    assert!(got_copy_in, "Expected CopyInResponse, got: {out:?}");
+
+    let out = session.run_sync([
+        FrontendMessage::CopyData { data },
+        FrontendMessage::CopyDone,
+    ]);
+    assert_ok(&out);
+}
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let label = args.next().unwrap_or_else(|| "q20".to_string());
+    let iterations = args
+        .next()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(50);
+    let sql = if let Some(raw_sql) = label.strip_prefix("sql:") {
+        raw_sql.to_string()
+    } else {
+        QUERIES
+            .iter()
+            .find_map(|(query_label, query_sql)| (*query_label == label).then_some(*query_sql))
+            .unwrap_or_else(|| panic!("unknown query label: {label}"))
+            .to_string()
+    };
+
+    let total_start = Instant::now();
+    let mut session = PostgresSession::new();
+    exec(&mut session, "DROP TABLE IF EXISTS hits");
+    exec(&mut session, CLICKBENCH_SCHEMA);
+    load_clickbench_data(&mut session);
+
+    profiling::reset();
+    eprintln!("ready query={label} iterations={iterations}");
+
+    let query_start = Instant::now();
+    let mut last_row_count = 0usize;
+    for _ in 0..iterations {
+        let out = session.run_sync([FrontendMessage::Query { sql: sql.clone() }]);
+        assert_ok(&out);
+        last_row_count = count_data_rows(&out);
+    }
+    let query_elapsed = query_start.elapsed();
+    let total_elapsed = total_start.elapsed();
+
+    eprintln!(
+        "done query={label} iterations={iterations} rows={last_row_count} query_secs={:.3} total_secs={:.3}",
+        query_elapsed.as_secs_f64(),
+        total_elapsed.as_secs_f64()
+    );
+    println!("{}", profiling::report());
+}

--- a/src/executor/bytecode_expr.rs
+++ b/src/executor/bytecode_expr.rs
@@ -1,0 +1,739 @@
+use crate::executor::exec_expr::{
+    EvalScope, eval_between_predicate, eval_binary, eval_cast_scalar, eval_is_distinct_from,
+    eval_like_predicate, eval_unary, parse_param,
+};
+use crate::parser::ast::{BooleanTestType, Expr};
+use crate::storage::tuple::ScalarValue;
+use crate::tcop::engine::EngineError;
+
+const FLAG_WIDE_OPERAND: u8 = 0x01;
+const FLAG_NEGATED: u8 = 0x02;
+const FLAG_CASE_INSENSITIVE: u8 = 0x04;
+const FLAG_HAS_ESCAPE: u8 = 0x08;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub(crate) struct Instruction {
+    opcode: u8,
+    flags: u8,
+    operand: u16,
+}
+
+#[derive(Debug, Clone)]
+enum Constant {
+    Scalar(ScalarValue),
+    Identifier(Vec<String>),
+    TypeName(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Opcode {
+    Halt = 0x00,
+    LoadConst = 0x10,
+    LoadIdentifier = 0x11,
+    LoadParameter = 0x12,
+    MakeArray = 0x13,
+    MakeRecord = 0x14,
+    ApplyUnary = 0x20,
+    ApplyBinary = 0x21,
+    Between = 0x30,
+    Like = 0x31,
+    IsNull = 0x32,
+    BooleanTest = 0x33,
+    IsDistinctFrom = 0x34,
+    Cast = 0x35,
+}
+
+impl TryFrom<u8> for Opcode {
+    type Error = EngineError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(Self::Halt),
+            0x10 => Ok(Self::LoadConst),
+            0x11 => Ok(Self::LoadIdentifier),
+            0x12 => Ok(Self::LoadParameter),
+            0x13 => Ok(Self::MakeArray),
+            0x14 => Ok(Self::MakeRecord),
+            0x20 => Ok(Self::ApplyUnary),
+            0x21 => Ok(Self::ApplyBinary),
+            0x30 => Ok(Self::Between),
+            0x31 => Ok(Self::Like),
+            0x32 => Ok(Self::IsNull),
+            0x33 => Ok(Self::BooleanTest),
+            0x34 => Ok(Self::IsDistinctFrom),
+            0x35 => Ok(Self::Cast),
+            _ => Err(EngineError {
+                message: format!("unsupported bytecode opcode {value}"),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CompiledExpr {
+    instructions: Vec<Instruction>,
+    constants: Vec<Constant>,
+    wide_operands: Vec<u32>,
+}
+
+impl CompiledExpr {
+    pub(crate) fn evaluate(
+        &self,
+        scope: &EvalScope,
+        params: &[Option<String>],
+    ) -> Result<ScalarValue, EngineError> {
+        let mut ip = 0usize;
+        let mut stack = Vec::with_capacity(self.instructions.len().max(1));
+
+        while let Some(instruction) = self.instructions.get(ip).copied() {
+            match Opcode::try_from(instruction.opcode)? {
+                Opcode::Halt => {
+                    return match stack.len() {
+                        1 => stack.pop().ok_or_else(|| EngineError {
+                            message: "bytecode stack underflow".to_string(),
+                        }),
+                        _ => Err(EngineError {
+                            message: "bytecode program ended with invalid stack state".to_string(),
+                        }),
+                    };
+                }
+                Opcode::LoadConst => {
+                    let index = self.operand_as_index(instruction)?;
+                    let value = match self.constant(index)? {
+                        Constant::Scalar(value) => value.clone(),
+                        _ => {
+                            return Err(EngineError {
+                                message: "bytecode constant type mismatch".to_string(),
+                            });
+                        }
+                    };
+                    stack.push(value);
+                }
+                Opcode::LoadIdentifier => {
+                    let index = self.operand_as_index(instruction)?;
+                    let parts = match self.constant(index)? {
+                        Constant::Identifier(parts) => parts,
+                        _ => {
+                            return Err(EngineError {
+                                message: "bytecode constant type mismatch".to_string(),
+                            });
+                        }
+                    };
+                    stack.push(scope.lookup_identifier(parts)?);
+                }
+                Opcode::LoadParameter => {
+                    let param_index =
+                        i32::try_from(self.resolve_operand(instruction)?).map_err(|_| {
+                            EngineError {
+                                message: "bytecode parameter index overflow".to_string(),
+                            }
+                        })?;
+                    stack.push(parse_param(param_index, params)?);
+                }
+                Opcode::MakeArray => {
+                    let len = self.operand_as_index(instruction)?;
+                    let values = pop_many(&mut stack, len)?;
+                    stack.push(ScalarValue::Array(values));
+                }
+                Opcode::MakeRecord => {
+                    let len = self.operand_as_index(instruction)?;
+                    let values = pop_many(&mut stack, len)?;
+                    stack.push(ScalarValue::Record(values));
+                }
+                Opcode::ApplyUnary => {
+                    let value = pop_value(&mut stack)?;
+                    let opcode = self.operand_as_index(instruction)?;
+                    let value = eval_unary(decode_unary(opcode)?, value)?;
+                    stack.push(value);
+                }
+                Opcode::ApplyBinary => {
+                    let right = pop_value(&mut stack)?;
+                    let left = pop_value(&mut stack)?;
+                    let opcode = self.operand_as_index(instruction)?;
+                    stack.push(eval_binary(decode_binary(opcode)?, left, right)?);
+                }
+                Opcode::Between => {
+                    let high = pop_value(&mut stack)?;
+                    let low = pop_value(&mut stack)?;
+                    let value = pop_value(&mut stack)?;
+                    stack.push(eval_between_predicate(
+                        value,
+                        low,
+                        high,
+                        instruction.flags & FLAG_NEGATED != 0,
+                    )?);
+                }
+                Opcode::Like => {
+                    let escape = if instruction.flags & FLAG_HAS_ESCAPE != 0 {
+                        Some(pop_value(&mut stack)?)
+                    } else {
+                        None
+                    };
+                    let pattern = pop_value(&mut stack)?;
+                    let value = pop_value(&mut stack)?;
+                    stack.push(eval_like_predicate(
+                        value,
+                        pattern,
+                        instruction.flags & FLAG_CASE_INSENSITIVE != 0,
+                        instruction.flags & FLAG_NEGATED != 0,
+                        escape,
+                    )?);
+                }
+                Opcode::IsNull => {
+                    let value = pop_value(&mut stack)?;
+                    let is_null = matches!(value, ScalarValue::Null);
+                    stack.push(ScalarValue::Bool(
+                        if instruction.flags & FLAG_NEGATED != 0 {
+                            !is_null
+                        } else {
+                            is_null
+                        },
+                    ));
+                }
+                Opcode::BooleanTest => {
+                    let value = pop_value(&mut stack)?;
+                    let test_type = decode_boolean_test(self.operand_as_index(instruction)?)?;
+                    let result = match (test_type, &value) {
+                        (BooleanTestType::True, ScalarValue::Bool(true)) => true,
+                        (BooleanTestType::True, _) => false,
+                        (BooleanTestType::False, ScalarValue::Bool(false)) => true,
+                        (BooleanTestType::False, _) => false,
+                        (BooleanTestType::Unknown, ScalarValue::Null) => true,
+                        (BooleanTestType::Unknown, _) => false,
+                    };
+                    stack.push(ScalarValue::Bool(
+                        if instruction.flags & FLAG_NEGATED != 0 {
+                            !result
+                        } else {
+                            result
+                        },
+                    ));
+                }
+                Opcode::IsDistinctFrom => {
+                    let right = pop_value(&mut stack)?;
+                    let left = pop_value(&mut stack)?;
+                    stack.push(eval_is_distinct_from(
+                        left,
+                        right,
+                        instruction.flags & FLAG_NEGATED != 0,
+                    )?);
+                }
+                Opcode::Cast => {
+                    let value = pop_value(&mut stack)?;
+                    let index = self.operand_as_index(instruction)?;
+                    let type_name = match self.constant(index)? {
+                        Constant::TypeName(type_name) => type_name,
+                        _ => {
+                            return Err(EngineError {
+                                message: "bytecode constant type mismatch".to_string(),
+                            });
+                        }
+                    };
+                    stack.push(eval_cast_scalar(value, type_name)?);
+                }
+            }
+            ip += 1;
+        }
+
+        Err(EngineError {
+            message: "bytecode program terminated without halt".to_string(),
+        })
+    }
+
+    fn resolve_operand(&self, instruction: Instruction) -> Result<u32, EngineError> {
+        if instruction.flags & FLAG_WIDE_OPERAND == 0 {
+            return Ok(u32::from(instruction.operand));
+        }
+        let index = usize::from(instruction.operand);
+        self.wide_operands
+            .get(index)
+            .copied()
+            .ok_or_else(|| EngineError {
+                message: "bytecode wide operand out of bounds".to_string(),
+            })
+    }
+
+    fn operand_as_index(&self, instruction: Instruction) -> Result<usize, EngineError> {
+        usize::try_from(self.resolve_operand(instruction)?).map_err(|_| EngineError {
+            message: "bytecode operand does not fit in usize".to_string(),
+        })
+    }
+
+    fn constant(&self, index: usize) -> Result<&Constant, EngineError> {
+        self.constants.get(index).ok_or_else(|| EngineError {
+            message: "bytecode constant out of bounds".to_string(),
+        })
+    }
+}
+
+pub(crate) fn try_compile_expr(expr: &Expr) -> Result<Option<CompiledExpr>, EngineError> {
+    let mut compiler = Compiler::default();
+    if !compiler.compile_expr(expr)? {
+        return Ok(None);
+    }
+    compiler.emit(Opcode::Halt, 0, 0);
+    Ok(Some(CompiledExpr {
+        instructions: compiler.instructions,
+        constants: compiler.constants,
+        wide_operands: compiler.wide_operands,
+    }))
+}
+
+#[derive(Default)]
+struct Compiler {
+    instructions: Vec<Instruction>,
+    constants: Vec<Constant>,
+    wide_operands: Vec<u32>,
+}
+
+impl Compiler {
+    fn compile_expr(&mut self, expr: &Expr) -> Result<bool, EngineError> {
+        match expr {
+            Expr::Null => {
+                let index = self.push_constant(Constant::Scalar(ScalarValue::Null))?;
+                self.emit(Opcode::LoadConst, 0, index);
+                Ok(true)
+            }
+            Expr::Boolean(value) => {
+                let index = self.push_constant(Constant::Scalar(ScalarValue::Bool(*value)))?;
+                self.emit(Opcode::LoadConst, 0, index);
+                Ok(true)
+            }
+            Expr::Integer(value) => {
+                let index = self.push_constant(Constant::Scalar(ScalarValue::Int(*value)))?;
+                self.emit(Opcode::LoadConst, 0, index);
+                Ok(true)
+            }
+            Expr::Float(value) => {
+                let scalar = compile_float_literal(value)?;
+                let index = self.push_constant(Constant::Scalar(scalar))?;
+                self.emit(Opcode::LoadConst, 0, index);
+                Ok(true)
+            }
+            Expr::String(value) => {
+                let index =
+                    self.push_constant(Constant::Scalar(ScalarValue::Text(value.clone())))?;
+                self.emit(Opcode::LoadConst, 0, index);
+                Ok(true)
+            }
+            Expr::TypedLiteral { type_name, value } => {
+                let index =
+                    self.push_constant(Constant::Scalar(ScalarValue::Text(value.clone())))?;
+                self.emit(Opcode::LoadConst, 0, index);
+                let type_index = self.push_constant(Constant::TypeName(type_name.clone()))?;
+                self.emit(Opcode::Cast, 0, type_index);
+                Ok(true)
+            }
+            Expr::Parameter(index) => {
+                self.emit(
+                    Opcode::LoadParameter,
+                    0,
+                    u32::try_from(*index).map_err(|_| EngineError {
+                        message: format!("invalid parameter reference ${index}"),
+                    })?,
+                );
+                Ok(true)
+            }
+            Expr::Identifier(parts) => {
+                let index = self.push_constant(Constant::Identifier(parts.clone()))?;
+                self.emit(Opcode::LoadIdentifier, 0, index);
+                Ok(true)
+            }
+            Expr::Unary { op, expr } => {
+                if !self.compile_expr(expr)? {
+                    return Ok(false);
+                }
+                self.emit(Opcode::ApplyUnary, 0, encode_unary(op)?);
+                Ok(true)
+            }
+            Expr::Binary { left, op, right } => {
+                if !self.compile_expr(left)? || !self.compile_expr(right)? {
+                    return Ok(false);
+                }
+                self.emit(Opcode::ApplyBinary, 0, encode_binary(op)?);
+                Ok(true)
+            }
+            Expr::ArrayConstructor(items) => {
+                for item in items {
+                    if !self.compile_expr(item)? {
+                        return Ok(false);
+                    }
+                }
+                self.emit(
+                    Opcode::MakeArray,
+                    0,
+                    u32::try_from(items.len()).map_err(|_| EngineError {
+                        message: "array constructor too large for bytecode evaluator".to_string(),
+                    })?,
+                );
+                Ok(true)
+            }
+            Expr::RowConstructor(fields) => {
+                for field in fields {
+                    if !self.compile_expr(field)? {
+                        return Ok(false);
+                    }
+                }
+                self.emit(
+                    Opcode::MakeRecord,
+                    0,
+                    u32::try_from(fields.len()).map_err(|_| EngineError {
+                        message: "row constructor too large for bytecode evaluator".to_string(),
+                    })?,
+                );
+                Ok(true)
+            }
+            Expr::Between {
+                expr,
+                low,
+                high,
+                negated,
+            } => {
+                if !self.compile_expr(expr)?
+                    || !self.compile_expr(low)?
+                    || !self.compile_expr(high)?
+                {
+                    return Ok(false);
+                }
+                self.emit(Opcode::Between, flag_if(*negated, FLAG_NEGATED), 0);
+                Ok(true)
+            }
+            Expr::Like {
+                expr,
+                pattern,
+                case_insensitive,
+                negated,
+                escape,
+            } => {
+                if !self.compile_expr(expr)? || !self.compile_expr(pattern)? {
+                    return Ok(false);
+                }
+                let mut flags = 0;
+                if *case_insensitive {
+                    flags |= FLAG_CASE_INSENSITIVE;
+                }
+                if *negated {
+                    flags |= FLAG_NEGATED;
+                }
+                if let Some(escape) = escape {
+                    if !self.compile_expr(escape)? {
+                        return Ok(false);
+                    }
+                    flags |= FLAG_HAS_ESCAPE;
+                }
+                self.emit(Opcode::Like, flags, 0);
+                Ok(true)
+            }
+            Expr::IsNull { expr, negated } => {
+                if !self.compile_expr(expr)? {
+                    return Ok(false);
+                }
+                self.emit(Opcode::IsNull, flag_if(*negated, FLAG_NEGATED), 0);
+                Ok(true)
+            }
+            Expr::BooleanTest {
+                expr,
+                test_type,
+                negated,
+            } => {
+                if !self.compile_expr(expr)? {
+                    return Ok(false);
+                }
+                self.emit(
+                    Opcode::BooleanTest,
+                    flag_if(*negated, FLAG_NEGATED),
+                    encode_boolean_test(test_type),
+                );
+                Ok(true)
+            }
+            Expr::IsDistinctFrom {
+                left,
+                right,
+                negated,
+            } => {
+                if !self.compile_expr(left)? || !self.compile_expr(right)? {
+                    return Ok(false);
+                }
+                self.emit(Opcode::IsDistinctFrom, flag_if(*negated, FLAG_NEGATED), 0);
+                Ok(true)
+            }
+            Expr::Cast { expr, type_name } => {
+                if !self.compile_expr(expr)? {
+                    return Ok(false);
+                }
+                let index = self.push_constant(Constant::TypeName(type_name.clone()))?;
+                self.emit(Opcode::Cast, 0, index);
+                Ok(true)
+            }
+            Expr::Default
+            | Expr::MultiColumnSubqueryRef { .. }
+            | Expr::FunctionCall { .. }
+            | Expr::Wildcard
+            | Expr::QualifiedWildcard(_)
+            | Expr::AnyAll { .. }
+            | Expr::Exists(_)
+            | Expr::ScalarSubquery(_)
+            | Expr::ArraySubquery(_)
+            | Expr::InList { .. }
+            | Expr::InSubquery { .. }
+            | Expr::CaseSimple { .. }
+            | Expr::CaseSearched { .. }
+            | Expr::ArraySubscript { .. }
+            | Expr::ArraySlice { .. } => Ok(false),
+        }
+    }
+
+    fn push_constant(&mut self, constant: Constant) -> Result<u32, EngineError> {
+        let index = u32::try_from(self.constants.len()).map_err(|_| EngineError {
+            message: "bytecode constant pool overflow".to_string(),
+        })?;
+        self.constants.push(constant);
+        Ok(index)
+    }
+
+    fn emit(&mut self, opcode: Opcode, mut flags: u8, operand: u32) {
+        let encoded = if let Ok(value) = u16::try_from(operand) {
+            value
+        } else {
+            flags |= FLAG_WIDE_OPERAND;
+            let index = self.wide_operands.len();
+            self.wide_operands.push(operand);
+            u16::try_from(index).expect("wide operand index should fit into u16")
+        };
+        self.instructions.push(Instruction {
+            opcode: opcode as u8,
+            flags,
+            operand: encoded,
+        });
+    }
+}
+
+fn flag_if(enabled: bool, flag: u8) -> u8 {
+    if enabled { flag } else { 0 }
+}
+
+fn compile_float_literal(value: &str) -> Result<ScalarValue, EngineError> {
+    if let Ok(decimal) = value.parse::<rust_decimal::Decimal>() {
+        return Ok(ScalarValue::Numeric(decimal));
+    }
+    let parsed = value.parse::<f64>().map_err(|_| EngineError {
+        message: format!("invalid float literal \"{value}\""),
+    })?;
+    Ok(ScalarValue::Float(parsed))
+}
+
+fn encode_unary(op: &crate::parser::ast::UnaryOp) -> Result<u32, EngineError> {
+    match op {
+        crate::parser::ast::UnaryOp::Plus => Ok(0),
+        crate::parser::ast::UnaryOp::Minus => Ok(1),
+        crate::parser::ast::UnaryOp::Not => Ok(2),
+    }
+}
+
+fn decode_unary(code: usize) -> Result<crate::parser::ast::UnaryOp, EngineError> {
+    match code {
+        0 => Ok(crate::parser::ast::UnaryOp::Plus),
+        1 => Ok(crate::parser::ast::UnaryOp::Minus),
+        2 => Ok(crate::parser::ast::UnaryOp::Not),
+        _ => Err(EngineError {
+            message: format!("unsupported bytecode unary opcode {code}"),
+        }),
+    }
+}
+
+fn encode_binary(op: &crate::parser::ast::BinaryOp) -> Result<u32, EngineError> {
+    use crate::parser::ast::BinaryOp;
+
+    match op {
+        BinaryOp::Or => Ok(0),
+        BinaryOp::And => Ok(1),
+        BinaryOp::Eq => Ok(2),
+        BinaryOp::NotEq => Ok(3),
+        BinaryOp::Lt => Ok(4),
+        BinaryOp::Lte => Ok(5),
+        BinaryOp::Gt => Ok(6),
+        BinaryOp::Gte => Ok(7),
+        BinaryOp::Add => Ok(8),
+        BinaryOp::Sub => Ok(9),
+        BinaryOp::Mul => Ok(10),
+        BinaryOp::Div => Ok(11),
+        BinaryOp::Mod => Ok(12),
+        BinaryOp::Pow => Ok(13),
+        BinaryOp::ShiftLeft => Ok(14),
+        BinaryOp::ShiftRight => Ok(15),
+        BinaryOp::JsonGet => Ok(16),
+        BinaryOp::JsonGetText => Ok(17),
+        BinaryOp::JsonPath => Ok(18),
+        BinaryOp::JsonPathText => Ok(19),
+        BinaryOp::JsonConcat => Ok(20),
+        BinaryOp::JsonContains => Ok(21),
+        BinaryOp::JsonContainedBy => Ok(22),
+        BinaryOp::JsonPathExists => Ok(23),
+        BinaryOp::JsonPathMatch => Ok(24),
+        BinaryOp::JsonHasKey => Ok(25),
+        BinaryOp::JsonHasAny => Ok(26),
+        BinaryOp::JsonHasAll => Ok(27),
+        BinaryOp::JsonDelete => Ok(28),
+        BinaryOp::JsonDeletePath => Ok(29),
+        BinaryOp::ArrayContains => Ok(30),
+        BinaryOp::ArrayContainedBy => Ok(31),
+        BinaryOp::ArrayOverlap => Ok(32),
+        BinaryOp::ArrayConcat => Ok(33),
+        BinaryOp::VectorL2Distance => Ok(34),
+        BinaryOp::VectorInnerProduct => Ok(35),
+        BinaryOp::VectorCosineDistance => Ok(36),
+    }
+}
+
+fn decode_binary(code: usize) -> Result<crate::parser::ast::BinaryOp, EngineError> {
+    use crate::parser::ast::BinaryOp;
+
+    match code {
+        0 => Ok(BinaryOp::Or),
+        1 => Ok(BinaryOp::And),
+        2 => Ok(BinaryOp::Eq),
+        3 => Ok(BinaryOp::NotEq),
+        4 => Ok(BinaryOp::Lt),
+        5 => Ok(BinaryOp::Lte),
+        6 => Ok(BinaryOp::Gt),
+        7 => Ok(BinaryOp::Gte),
+        8 => Ok(BinaryOp::Add),
+        9 => Ok(BinaryOp::Sub),
+        10 => Ok(BinaryOp::Mul),
+        11 => Ok(BinaryOp::Div),
+        12 => Ok(BinaryOp::Mod),
+        13 => Ok(BinaryOp::Pow),
+        14 => Ok(BinaryOp::ShiftLeft),
+        15 => Ok(BinaryOp::ShiftRight),
+        16 => Ok(BinaryOp::JsonGet),
+        17 => Ok(BinaryOp::JsonGetText),
+        18 => Ok(BinaryOp::JsonPath),
+        19 => Ok(BinaryOp::JsonPathText),
+        20 => Ok(BinaryOp::JsonConcat),
+        21 => Ok(BinaryOp::JsonContains),
+        22 => Ok(BinaryOp::JsonContainedBy),
+        23 => Ok(BinaryOp::JsonPathExists),
+        24 => Ok(BinaryOp::JsonPathMatch),
+        25 => Ok(BinaryOp::JsonHasKey),
+        26 => Ok(BinaryOp::JsonHasAny),
+        27 => Ok(BinaryOp::JsonHasAll),
+        28 => Ok(BinaryOp::JsonDelete),
+        29 => Ok(BinaryOp::JsonDeletePath),
+        30 => Ok(BinaryOp::ArrayContains),
+        31 => Ok(BinaryOp::ArrayContainedBy),
+        32 => Ok(BinaryOp::ArrayOverlap),
+        33 => Ok(BinaryOp::ArrayConcat),
+        34 => Ok(BinaryOp::VectorL2Distance),
+        35 => Ok(BinaryOp::VectorInnerProduct),
+        36 => Ok(BinaryOp::VectorCosineDistance),
+        _ => Err(EngineError {
+            message: format!("unsupported bytecode binary opcode {code}"),
+        }),
+    }
+}
+
+fn encode_boolean_test(test_type: &BooleanTestType) -> u32 {
+    match test_type {
+        BooleanTestType::True => 0,
+        BooleanTestType::False => 1,
+        BooleanTestType::Unknown => 2,
+    }
+}
+
+fn decode_boolean_test(code: usize) -> Result<BooleanTestType, EngineError> {
+    match code {
+        0 => Ok(BooleanTestType::True),
+        1 => Ok(BooleanTestType::False),
+        2 => Ok(BooleanTestType::Unknown),
+        _ => Err(EngineError {
+            message: format!("unsupported bytecode boolean test {code}"),
+        }),
+    }
+}
+
+fn pop_value(stack: &mut Vec<ScalarValue>) -> Result<ScalarValue, EngineError> {
+    stack.pop().ok_or_else(|| EngineError {
+        message: "bytecode stack underflow".to_string(),
+    })
+}
+
+fn pop_many(stack: &mut Vec<ScalarValue>, len: usize) -> Result<Vec<ScalarValue>, EngineError> {
+    if stack.len() < len {
+        return Err(EngineError {
+            message: "bytecode stack underflow".to_string(),
+        });
+    }
+    let start = stack.len() - len;
+    Ok(stack.drain(start..).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Instruction, try_compile_expr};
+    use crate::executor::exec_expr::{EvalScope, eval_expr};
+    use crate::parser::ast::{BinaryOp, Expr};
+    use crate::storage::tuple::ScalarValue;
+
+    #[test]
+    fn instruction_layout_is_four_bytes() {
+        assert_eq!(std::mem::size_of::<Instruction>(), 4);
+    }
+
+    #[tokio::test]
+    async fn compiled_expr_matches_tree_walk_for_filter_shape() {
+        let expr = Expr::Binary {
+            left: Box::new(Expr::Like {
+                expr: Box::new(Expr::Identifier(vec!["name".to_string()])),
+                pattern: Box::new(Expr::String("a%".to_string())),
+                case_insensitive: true,
+                negated: false,
+                escape: None,
+            }),
+            op: BinaryOp::And,
+            right: Box::new(Expr::Binary {
+                left: Box::new(Expr::Cast {
+                    expr: Box::new(Expr::Identifier(vec!["qty".to_string()])),
+                    type_name: "int4".to_string(),
+                }),
+                op: BinaryOp::Gt,
+                right: Box::new(Expr::Integer(2)),
+            }),
+        };
+        let compiled = try_compile_expr(&expr)
+            .expect("bytecode compilation should succeed")
+            .expect("expression should be supported");
+        let mut scope = EvalScope::default();
+        scope.insert_unqualified("name", ScalarValue::Text("Alice".to_string()));
+        scope.insert_unqualified("qty", ScalarValue::Text("3".to_string()));
+
+        let compiled_value = compiled
+            .evaluate(&scope, &[])
+            .expect("compiled evaluation should succeed");
+        let tree_value = eval_expr(&expr, &scope, &[])
+            .await
+            .expect("tree evaluation should succeed");
+
+        assert_eq!(compiled_value, tree_value);
+    }
+
+    #[test]
+    fn unsupported_expression_falls_back() {
+        let expr = Expr::FunctionCall {
+            name: vec!["lower".to_string()],
+            args: vec![Expr::String("abc".to_string())],
+            distinct: false,
+            order_by: Vec::new(),
+            within_group: Vec::new(),
+            filter: None,
+            over: None,
+        };
+
+        assert!(
+            try_compile_expr(&expr)
+                .expect("compilation should not error")
+                .is_none()
+        );
+    }
+}

--- a/src/executor/column_batch.rs
+++ b/src/executor/column_batch.rs
@@ -2,6 +2,7 @@ use arrow::array::{Array, BooleanArray, Date32Array, Float64Array, Int64Array, R
 use arrow::compute::filter_record_batch;
 use rust_decimal::Decimal;
 
+use crate::executor::profiling;
 use crate::storage::tuple::{ScalarValue, arrow_value_to_scalar_value};
 use crate::utils::adt::datetime::{datetime_from_epoch_seconds, format_date};
 
@@ -58,6 +59,7 @@ impl ColumnBatch {
         column_names: &[String],
         projected_columns: Option<&[usize]>,
     ) -> Self {
+        let _span = profiling::span("column_batch_from_record_batch_projected");
         let projected_batch = projected_columns.and_then(|projection| rb.project(projection).ok());
         let source_batch = projected_batch.as_ref().unwrap_or(rb);
         let projected_names = match projected_columns {
@@ -77,6 +79,35 @@ impl ColumnBatch {
             column_names: projected_names,
             row_count: source_batch.num_rows(),
             record_batch: Some(source_batch.clone()),
+        }
+    }
+
+    pub fn from_record_batch_projected_selected(
+        rb: &RecordBatch,
+        column_names: &[String],
+        projected_columns: Option<&[usize]>,
+        selected_rows: &[usize],
+    ) -> Self {
+        let _span = profiling::span("column_batch_from_record_batch_projected_selected");
+        let projected_batch = projected_columns.and_then(|projection| rb.project(projection).ok());
+        let source_batch = projected_batch.as_ref().unwrap_or(rb);
+        let projected_names = match projected_columns {
+            Some(projection) => projection
+                .iter()
+                .filter_map(|idx| column_names.get(*idx).cloned())
+                .collect(),
+            None => column_names.to_vec(),
+        };
+
+        Self {
+            columns: source_batch
+                .columns()
+                .iter()
+                .map(|column| typed_column_from_array_selected(column.as_ref(), selected_rows))
+                .collect(),
+            column_names: projected_names,
+            row_count: selected_rows.len(),
+            record_batch: None,
         }
     }
 
@@ -102,6 +133,7 @@ impl ColumnBatch {
     }
 
     pub fn to_rows(&self) -> Vec<Vec<ScalarValue>> {
+        let _span = profiling::span("column_batch_to_rows");
         let mut rows = Vec::with_capacity(self.row_count);
         for row_idx in 0..self.row_count {
             let mut row = Vec::with_capacity(self.columns.len());
@@ -128,6 +160,7 @@ impl ColumnBatch {
     }
 
     pub fn filter(&self, mask: &[bool]) -> Self {
+        let _span = profiling::span("column_batch_filter");
         let row_count = self.row_count.min(mask.len());
         if let Some(record_batch) = &self.record_batch {
             let arrow_mask = mask
@@ -158,6 +191,7 @@ impl ColumnBatch {
     }
 
     pub fn project(&self, indices: &[usize]) -> Self {
+        let _span = profiling::span("column_batch_project");
         let column_names = indices
             .iter()
             .filter_map(|idx| self.column_names.get(*idx).cloned())
@@ -530,6 +564,59 @@ fn typed_column_from_array(array: &dyn Array, row_count: usize) -> TypedColumn {
 
     let values = (0..row_count)
         .map(|row_idx| arrow_value_to_scalar_value(array, row_idx))
+        .collect::<Vec<_>>();
+    typed_column_from_scalars(values)
+}
+
+fn typed_column_from_array_selected(array: &dyn Array, selected_rows: &[usize]) -> TypedColumn {
+    if let Some(values) = array.as_any().downcast_ref::<BooleanArray>() {
+        let mut out = Vec::with_capacity(selected_rows.len());
+        let mut nulls = Vec::with_capacity(selected_rows.len());
+        for &row_idx in selected_rows {
+            let is_null = values.is_null(row_idx);
+            nulls.push(is_null);
+            out.push(if is_null {
+                false
+            } else {
+                values.value(row_idx)
+            });
+        }
+        return TypedColumn::Bool(out, nulls);
+    }
+    if let Some(values) = array.as_any().downcast_ref::<Int64Array>() {
+        let mut out = Vec::with_capacity(selected_rows.len());
+        let mut nulls = Vec::with_capacity(selected_rows.len());
+        for &row_idx in selected_rows {
+            let is_null = values.is_null(row_idx);
+            nulls.push(is_null);
+            out.push(if is_null { 0 } else { values.value(row_idx) });
+        }
+        return TypedColumn::Int64(out, nulls);
+    }
+    if let Some(values) = array.as_any().downcast_ref::<Float64Array>() {
+        let mut out = Vec::with_capacity(selected_rows.len());
+        let mut nulls = Vec::with_capacity(selected_rows.len());
+        for &row_idx in selected_rows {
+            let is_null = values.is_null(row_idx);
+            nulls.push(is_null);
+            out.push(if is_null { 0.0 } else { values.value(row_idx) });
+        }
+        return TypedColumn::Float64(out, nulls);
+    }
+    if let Some(values) = array.as_any().downcast_ref::<Date32Array>() {
+        let mut out = Vec::with_capacity(selected_rows.len());
+        let mut nulls = Vec::with_capacity(selected_rows.len());
+        for &row_idx in selected_rows {
+            let is_null = values.is_null(row_idx);
+            nulls.push(is_null);
+            out.push(if is_null { 0 } else { values.value(row_idx) });
+        }
+        return TypedColumn::Date(out, nulls);
+    }
+
+    let values = selected_rows
+        .iter()
+        .map(|row_idx| arrow_value_to_scalar_value(array, *row_idx))
         .collect::<Vec<_>>();
     typed_column_from_scalars(values)
 }

--- a/src/executor/column_filter.rs
+++ b/src/executor/column_filter.rs
@@ -6,6 +6,7 @@ use arrow::compute::{and_kleene, ilike, like, nilike, nlike, not, or_kleene};
 
 use crate::executor::column_batch::{ColumnBatch, TypedColumn};
 use crate::executor::exec_expr::like_match;
+use crate::executor::profiling;
 use crate::parser::ast::{BinaryOp, Expr, UnaryOp};
 use crate::storage::tuple::ScalarValue;
 use crate::utils::adt::misc::compare_values_for_predicate;
@@ -40,6 +41,7 @@ impl LikeLiteralMatcher {
 }
 
 pub(crate) fn eval_columnar_predicate(expr: &Expr, batch: &ColumnBatch) -> Option<Vec<bool>> {
+    let _span = profiling::span("eval_columnar_predicate");
     eval_predicate(expr, batch).map(|truths| {
         truths
             .into_iter()

--- a/src/executor/columnar_agg.rs
+++ b/src/executor/columnar_agg.rs
@@ -5,6 +5,7 @@ use std::hash::{Hash, Hasher};
 use rust_decimal::Decimal;
 
 use crate::executor::column_batch::{ColumnBatch, TypedColumn, typed_column_from_scalars};
+use crate::executor::profiling;
 use crate::storage::tuple::ScalarValue;
 use crate::tcop::engine::EngineError;
 use crate::utils::adt::datetime::{datetime_from_epoch_seconds, format_date};
@@ -137,12 +138,35 @@ impl ColumnarAggregator {
     }
 
     pub(crate) fn push_batch(&mut self, batch: &ColumnBatch) -> Result<(), EngineError> {
+        let _span = profiling::span("columnar_aggregator_push_batch");
         if batch.row_count == 0 {
             return Ok(());
         }
 
-        let mut group_indices = Vec::with_capacity(batch.row_count);
-        for row_idx in 0..batch.row_count {
+        let row_indices = (0..batch.row_count).collect::<Vec<_>>();
+        self.push_rows(batch, &row_indices)
+    }
+
+    pub(crate) fn push_selected_rows(
+        &mut self,
+        batch: &ColumnBatch,
+        row_indices: &[usize],
+    ) -> Result<(), EngineError> {
+        let _span = profiling::span("columnar_aggregator_push_selected_rows");
+        if row_indices.is_empty() {
+            return Ok(());
+        }
+
+        self.push_rows(batch, row_indices)
+    }
+
+    fn push_rows(&mut self, batch: &ColumnBatch, row_indices: &[usize]) -> Result<(), EngineError> {
+        if row_indices.is_empty() {
+            return Ok(());
+        }
+
+        let mut group_indices = Vec::with_capacity(row_indices.len());
+        for &row_idx in row_indices {
             let hash = hash_group_key_for_row(batch, &self.group_key_indices, row_idx);
             let group_idx = self
                 .find_group_for_row(batch, row_idx, hash)
@@ -151,13 +175,14 @@ impl ColumnarAggregator {
         }
 
         for accumulator in &mut self.accumulators {
-            accumulator.update_batch(batch, &group_indices)?;
+            accumulator.update_rows(batch, Some(row_indices), &group_indices)?;
         }
 
         Ok(())
     }
 
     pub(crate) fn finish(mut self) -> Result<ColumnBatch, EngineError> {
+        let _span = profiling::span("columnar_aggregator_finish");
         if self.group_count == 0 && self.group_key_indices.is_empty() {
             self.ensure_group(Vec::new());
         }
@@ -403,9 +428,10 @@ impl AggAccumulator {
         }
     }
 
-    fn update_batch(
+    fn update_rows(
         &mut self,
         batch: &ColumnBatch,
+        row_indices: Option<&[usize]>,
         group_indices: &[usize],
     ) -> Result<(), EngineError> {
         match self {
@@ -413,9 +439,9 @@ impl AggAccumulator {
                 counts,
                 column_index: None,
             } => {
-                for &group_idx in group_indices {
+                for_each_row_group(row_indices, group_indices, |_, group_idx| {
                     counts[group_idx] += 1;
-                }
+                });
                 Ok(())
             }
             Self::Count {
@@ -423,68 +449,145 @@ impl AggAccumulator {
                 column_index: Some(column_index),
             } => {
                 let column = &batch.columns[*column_index];
-                for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+                for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                     if !is_null_at(column, row_idx) {
                         counts[group_idx] += 1;
                     }
-                }
+                });
                 Ok(())
             }
             Self::CountDistinctInt {
                 counts,
                 seen,
                 column_index,
-            } => update_count_distinct_int(batch, group_indices, *column_index, counts, seen),
+            } => update_count_distinct_int(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                counts,
+                seen,
+            ),
             Self::CountDistinctText {
                 counts,
                 seen,
                 column_index,
-            } => update_count_distinct_text(batch, group_indices, *column_index, counts, seen),
+            } => update_count_distinct_text(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                counts,
+                seen,
+            ),
             Self::SumInt {
                 sums,
                 saw_non_null,
                 column_index,
-            } => update_sum_int(batch, group_indices, *column_index, sums, saw_non_null),
+            } => update_sum_int(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                sums,
+                saw_non_null,
+            ),
             Self::SumFloat {
                 sums,
                 saw_non_null,
                 column_index,
-            } => update_sum_float(batch, group_indices, *column_index, sums, saw_non_null),
+            } => update_sum_float(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                sums,
+                saw_non_null,
+            ),
             Self::SumNumeric {
                 sums,
                 saw_non_null,
                 column_index,
-            } => update_sum_numeric(batch, group_indices, *column_index, sums, saw_non_null),
+            } => update_sum_numeric(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                sums,
+                saw_non_null,
+            ),
             Self::AvgInt {
                 sums,
                 counts,
                 column_index,
-            } => update_avg_int(batch, group_indices, *column_index, sums, counts),
+            } => update_avg_int(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                sums,
+                counts,
+            ),
             Self::AvgFloat {
                 sums,
                 counts,
                 column_index,
-            } => update_avg_float(batch, group_indices, *column_index, sums, counts),
+            } => update_avg_float(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                sums,
+                counts,
+            ),
             Self::AvgNumericInt {
                 sums,
                 counts,
                 column_index,
-            } => update_avg_numeric_int(batch, group_indices, *column_index, sums, counts),
+            } => update_avg_numeric_int(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                sums,
+                counts,
+            ),
             Self::AvgNumeric {
                 sums,
                 counts,
                 column_index,
-            } => update_avg_numeric(batch, group_indices, *column_index, sums, counts),
+            } => update_avg_numeric(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                sums,
+                counts,
+            ),
             Self::MinMaxDate {
                 values,
                 column_index,
                 is_min,
-            } => update_min_max_date(batch, group_indices, *column_index, values, *is_min),
+            } => update_min_max_date(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                values,
+                *is_min,
+            ),
             Self::MinMaxScalar {
                 values,
                 column_index,
                 is_min,
-            } => update_min_max(batch, group_indices, *column_index, values, *is_min),
+            } => update_min_max(
+                batch,
+                row_indices,
+                group_indices,
+                *column_index,
+                values,
+                *is_min,
+            ),
         }
     }
 
@@ -565,8 +668,29 @@ impl AggAccumulator {
     }
 }
 
+fn for_each_row_group(
+    row_indices: Option<&[usize]>,
+    group_indices: &[usize],
+    mut callback: impl FnMut(usize, usize),
+) {
+    match row_indices {
+        Some(row_indices) => {
+            debug_assert_eq!(row_indices.len(), group_indices.len());
+            for (&row_idx, &group_idx) in row_indices.iter().zip(group_indices.iter()) {
+                callback(row_idx, group_idx);
+            }
+        }
+        None => {
+            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+                callback(row_idx, group_idx);
+            }
+        }
+    }
+}
+
 fn update_count_distinct_int(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     counts: &mut [i64],
@@ -574,14 +698,14 @@ fn update_count_distinct_int(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Int64(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 if seen.insert((group_idx, values[row_idx])) {
                     counts[group_idx] += 1;
                 }
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -592,6 +716,7 @@ fn update_count_distinct_int(
 
 fn update_count_distinct_text(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     counts: &mut [i64],
@@ -599,15 +724,15 @@ fn update_count_distinct_text(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Text(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 let group_seen = seen.entry(group_idx).or_default();
                 if group_seen.insert(values[row_idx].clone()) {
                     counts[group_idx] += 1;
                 }
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -618,6 +743,7 @@ fn update_count_distinct_text(
 
 fn update_sum_int(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     sums: &mut [i128],
@@ -625,13 +751,13 @@ fn update_sum_int(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Int64(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 sums[group_idx] += i128::from(values[row_idx]);
                 saw_non_null[group_idx] = true;
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -642,6 +768,7 @@ fn update_sum_int(
 
 fn update_sum_float(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     sums: &mut [f64],
@@ -649,13 +776,13 @@ fn update_sum_float(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Float64(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 sums[group_idx] += values[row_idx];
                 saw_non_null[group_idx] = true;
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -666,6 +793,7 @@ fn update_sum_float(
 
 fn update_sum_numeric(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     sums: &mut [Decimal],
@@ -673,13 +801,13 @@ fn update_sum_numeric(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Numeric(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 sums[group_idx] += values[row_idx];
                 saw_non_null[group_idx] = true;
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -690,6 +818,7 @@ fn update_sum_numeric(
 
 fn update_avg_int(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     sums: &mut [i128],
@@ -697,13 +826,13 @@ fn update_avg_int(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Int64(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 sums[group_idx] += i128::from(values[row_idx]);
                 counts[group_idx] += 1;
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -714,6 +843,7 @@ fn update_avg_int(
 
 fn update_avg_float(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     sums: &mut [f64],
@@ -721,13 +851,13 @@ fn update_avg_float(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Float64(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 sums[group_idx] += values[row_idx];
                 counts[group_idx] += 1;
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -738,6 +868,7 @@ fn update_avg_float(
 
 fn update_avg_numeric(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     sums: &mut [Decimal],
@@ -745,13 +876,13 @@ fn update_avg_numeric(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Numeric(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 sums[group_idx] += values[row_idx];
                 counts[group_idx] += 1;
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -762,6 +893,7 @@ fn update_avg_numeric(
 
 fn update_avg_numeric_int(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     sums: &mut [i128],
@@ -769,13 +901,13 @@ fn update_avg_numeric_int(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Int64(values, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 sums[group_idx] += i128::from(values[row_idx]);
                 counts[group_idx] += 1;
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -787,20 +919,31 @@ fn update_avg_numeric_int(
 
 fn update_min_max(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     values: &mut [Option<ScalarValue>],
     is_min: bool,
 ) -> Result<(), EngineError> {
-    for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+    let mut error = None;
+    for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
+        if error.is_some() {
+            return;
+        }
         let value = scalar_value_at(&batch.columns[column_index], row_idx);
         if matches!(value, ScalarValue::Null) {
-            continue;
+            return;
         }
         match &values[group_idx] {
             None => values[group_idx] = Some(value),
             Some(existing) => {
-                let cmp = compare_values_for_predicate(&value, existing)?;
+                let cmp = match compare_values_for_predicate(&value, existing) {
+                    Ok(cmp) => cmp,
+                    Err(err) => {
+                        error = Some(err);
+                        return;
+                    }
+                };
                 let take = if is_min {
                     cmp == Ordering::Less
                 } else {
@@ -811,12 +954,16 @@ fn update_min_max(
                 }
             }
         }
+    });
+    if let Some(error) = error {
+        return Err(error);
     }
     Ok(())
 }
 
 fn update_min_max_date(
     batch: &ColumnBatch,
+    row_indices: Option<&[usize]>,
     group_indices: &[usize],
     column_index: usize,
     values: &mut [Option<i32>],
@@ -824,9 +971,9 @@ fn update_min_max_date(
 ) -> Result<(), EngineError> {
     match &batch.columns[column_index] {
         TypedColumn::Date(days, nulls) => {
-            for (row_idx, &group_idx) in group_indices.iter().enumerate() {
+            for_each_row_group(row_indices, group_indices, |row_idx, group_idx| {
                 if nulls[row_idx] {
-                    continue;
+                    return;
                 }
                 let candidate = days[row_idx];
                 match values[group_idx] {
@@ -842,7 +989,7 @@ fn update_min_max_date(
                         }
                     }
                 }
-            }
+            });
             Ok(())
         }
         _ => Err(EngineError {
@@ -1253,6 +1400,40 @@ mod tests {
                 ScalarValue::Int(1),
                 ScalarValue::Numeric(Decimal::new(250, 2)),
             ]]
+        );
+    }
+
+    #[test]
+    fn aggregates_selected_rows_without_filter_materialization() {
+        let batch = ColumnBatch::from_rows(
+            &[
+                vec![ScalarValue::Text("a".to_string()), ScalarValue::Int(1)],
+                vec![ScalarValue::Text("skip".to_string()), ScalarValue::Int(20)],
+                vec![ScalarValue::Text("a".to_string()), ScalarValue::Int(3)],
+                vec![ScalarValue::Text("b".to_string()), ScalarValue::Int(4)],
+            ],
+            &["dept".to_string(), "salary".to_string()],
+        );
+        let mut aggregator = ColumnarAggregator::new(
+            vec![0],
+            vec![AggSpec {
+                kind: AggKind::SumInt { column_index: 1 },
+            }],
+            vec![OutputExpr::GroupKey(0), OutputExpr::Aggregate(0)],
+            vec!["dept".to_string(), "sum".to_string()],
+        );
+
+        aggregator
+            .push_selected_rows(&batch, &[0, 2, 3])
+            .expect("selected rows should aggregate");
+        let output = aggregator.finish().expect("finish should succeed");
+
+        assert_eq!(
+            output.to_rows(),
+            vec![
+                vec![ScalarValue::Text("a".to_string()), ScalarValue::Int(4)],
+                vec![ScalarValue::Text("b".to_string()), ScalarValue::Int(4)],
+            ]
         );
     }
 

--- a/src/executor/exec_expr.rs
+++ b/src/executor/exec_expr.rs
@@ -7,6 +7,7 @@ use crate::executor::exec_main::{
     compare_order_keys, eval_aggregate_function, execute_query_with_outer, is_aggregate_function,
     parse_non_negative_int, row_key,
 };
+use crate::executor::profiling;
 use crate::extensions::pgcrypto::eval_pgcrypto_function;
 use crate::extensions::pgvector::{eval_pgvector_function, eval_vector_distance_operator};
 use crate::extensions::uuid_ossp::eval_uuid_ossp_function;
@@ -71,6 +72,7 @@ impl EvalScope {
     }
 
     pub(crate) fn from_output_row(columns: &[String], row: &[ScalarValue]) -> Self {
+        let _span = profiling::span("eval_scope_from_output_row");
         let mut scope = Self::default();
         for (col, value) in columns.iter().zip(row.iter()) {
             scope.insert_unqualified(col, value.clone());
@@ -97,6 +99,7 @@ impl EvalScope {
     }
 
     pub(crate) fn lookup_identifier(&self, parts: &[String]) -> Result<ScalarValue, EngineError> {
+        let _span = profiling::span("eval_scope_lookup_identifier");
         if parts.is_empty() {
             return Err(EngineError {
                 message: "empty identifier".to_string(),
@@ -2261,6 +2264,7 @@ pub(crate) fn eval_cast_scalar(
 }
 
 pub(crate) fn like_match(value: &str, pattern: &str, escape: Option<char>) -> bool {
+    let _span = profiling::span("like_match");
     if let Some(matched) = like_match_fast_path(value, pattern, escape) {
         return matched;
     }
@@ -2380,7 +2384,10 @@ fn like_match_recursive(
     result
 }
 
-fn parse_param(index: i32, params: &[Option<String>]) -> Result<ScalarValue, EngineError> {
+pub(crate) fn parse_param(
+    index: i32,
+    params: &[Option<String>],
+) -> Result<ScalarValue, EngineError> {
     if index <= 0 {
         return Err(EngineError {
             message: format!("invalid parameter reference ${index}"),

--- a/src/executor/exec_main/aggregation.rs
+++ b/src/executor/exec_main/aggregation.rs
@@ -1,14 +1,47 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use crate::executor::profiling;
 
-pub(super) async fn project_select_row(
+pub(super) fn compile_exprs(exprs: &[Expr]) -> Result<Vec<Option<CompiledExpr>>, EngineError> {
+    exprs.iter().map(try_compile_expr).collect()
+}
+
+pub(super) fn compile_select_targets(
     targets: &[crate::parser::ast::SelectItem],
+) -> Result<Vec<Option<CompiledExpr>>, EngineError> {
+    targets
+        .iter()
+        .map(|target| match &target.expr {
+            Expr::Wildcard | Expr::QualifiedWildcard(_) => Ok(None),
+            expr => try_compile_expr(expr),
+        })
+        .collect()
+}
+
+pub(super) async fn eval_expr_maybe_compiled(
+    expr: &Expr,
+    compiled: Option<&CompiledExpr>,
+    scope: &EvalScope,
+    params: &[Option<String>],
+) -> Result<ScalarValue, EngineError> {
+    if let Some(compiled) = compiled {
+        let _span = profiling::span("compiled_expr_eval");
+        compiled.evaluate(scope, params)
+    } else {
+        let _span = profiling::span("tree_expr_eval");
+        eval_expr(expr, scope, params).await
+    }
+}
+
+pub(super) async fn project_select_row_compiled(
+    targets: &[crate::parser::ast::SelectItem],
+    compiled_targets: &[Option<CompiledExpr>],
     scope: &EvalScope,
     params: &[Option<String>],
     wildcard_columns: Option<&[ExpandedFromColumn]>,
 ) -> Result<Vec<ScalarValue>, EngineError> {
     let mut row = Vec::new();
-    for target in targets {
+    for (index, target) in targets.iter().enumerate() {
         if matches!(target.expr, Expr::Wildcard) {
             let Some(expanded) = wildcard_columns else {
                 return Err(EngineError {
@@ -29,7 +62,15 @@ pub(super) async fn project_select_row(
             expand_qualified_wildcard(qualifier, expanded, scope, &mut row)?;
             continue;
         }
-        row.push(eval_expr(&target.expr, scope, params).await?);
+        row.push(
+            eval_expr_maybe_compiled(
+                &target.expr,
+                compiled_targets.get(index).and_then(Option::as_ref),
+                scope,
+                params,
+            )
+            .await?,
+        );
     }
     Ok(row)
 }

--- a/src/executor/exec_main/mod.rs
+++ b/src/executor/exec_main/mod.rs
@@ -13,6 +13,7 @@ use std::arch::x86_64::{
 };
 
 use crate::catalog::{SearchPath, TableKind, TypeSignature, with_catalog_read};
+use crate::executor::bytecode_expr::{CompiledExpr, try_compile_expr};
 use crate::executor::column_filter::eval_columnar_predicate;
 use crate::executor::exec_expr::{
     EngineFuture, EvalScope, eval_any_all, eval_between_predicate, eval_binary, eval_cast_scalar,
@@ -70,9 +71,10 @@ pub(crate) use set_operations::row_key;
 pub(crate) use table_functions::json_value_to_scalar;
 
 use aggregation::{
-    GroupingContext, collect_grouping_identifiers, contains_aggregate_expr, contains_window_expr,
-    eval_group_expr, expand_grouping_sets, group_by_contains_window_expr, group_by_exprs,
-    identifier_key, project_select_row, project_select_row_with_window, resolve_group_by_alias,
+    GroupingContext, collect_grouping_identifiers, compile_exprs, compile_select_targets,
+    contains_aggregate_expr, contains_window_expr, eval_expr_maybe_compiled, eval_group_expr,
+    expand_grouping_sets, group_by_contains_window_expr, group_by_exprs, identifier_key,
+    project_select_row_compiled, project_select_row_with_window, resolve_group_by_alias,
 };
 use from_clause::{
     collect_referenced_columns, decompose_and_conjuncts, evaluate_from_clause_with_pushdown,

--- a/src/executor/exec_main/order_limit.rs
+++ b/src/executor/exec_main/order_limit.rs
@@ -1,6 +1,9 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
-use crate::executor::column_batch::{ColumnBatch, TypedColumn};
+use crate::executor::column_batch::ColumnBatch;
+use crate::executor::profiling;
+use crate::storage::tuple::arrow_value_to_scalar_value;
+use arrow::array::{Array, Float64Array, Int64Array, RecordBatch, TimestampMicrosecondArray};
 use std::collections::BinaryHeap;
 
 pub(super) struct QueryRowCollector {
@@ -122,6 +125,7 @@ impl QueryRowCollector {
         row: Vec<ScalarValue>,
         params: &[Option<String>],
     ) -> Result<bool, EngineError> {
+        let _span = profiling::span("query_row_collector_push_row");
         match &mut self.strategy {
             RowCollectionStrategy::All { rows, order_by, .. } => {
                 let keys = if order_by.is_empty() {
@@ -265,6 +269,7 @@ impl SimpleTopNCollector {
     }
 
     pub(super) fn push_batch(&mut self, batch: &ColumnBatch) {
+        let _span = profiling::span("simple_topn_push_batch");
         if self.capacity == 0 {
             return;
         }
@@ -275,6 +280,7 @@ impl SimpleTopNCollector {
     }
 
     pub(super) fn push_selected_rows(&mut self, batch: &ColumnBatch, row_indices: &[usize]) {
+        let _span = profiling::span("simple_topn_push_selected_rows");
         if self.capacity == 0 {
             return;
         }
@@ -347,22 +353,13 @@ impl OffsetTopNCollector {
         }))
     }
 
-    pub(super) fn push_batch(&mut self, batch: &ColumnBatch, offsets: &[usize]) {
-        if self.capacity == 0 {
-            return;
-        }
-
-        for (row_idx, row_offset) in offsets.iter().copied().enumerate().take(batch.row_count) {
-            self.push_row(batch, row_idx, row_offset);
-        }
-    }
-
     pub(super) fn push_selected_rows(
         &mut self,
         batch: &ColumnBatch,
         row_indices: &[usize],
         offsets: &[usize],
     ) {
+        let _span = profiling::span("offset_topn_push_selected_rows");
         if self.capacity == 0 {
             return;
         }
@@ -372,27 +369,20 @@ impl OffsetTopNCollector {
         }
     }
 
-    pub(super) fn push_matching_text_rows<F>(
+    pub(super) fn push_record_batch_selected_rows(
         &mut self,
-        batch: &ColumnBatch,
-        column_idx: usize,
+        batch: &RecordBatch,
+        projected_columns: &[usize],
+        row_indices: &[usize],
         offsets: &[usize],
-        mut matches: F,
-    ) where
-        F: FnMut(&str) -> bool,
-    {
-        let Some(TypedColumn::Text(values, nulls)) = batch.columns.get(column_idx) else {
+    ) {
+        let _span = profiling::span("offset_topn_push_record_batch_selected_rows");
+        if self.capacity == 0 {
             return;
-        };
-        for (row_idx, ((value, is_null), row_offset)) in values
-            .iter()
-            .zip(nulls.iter().copied())
-            .zip(offsets.iter().copied())
-            .enumerate()
-        {
-            if !is_null && matches(value) {
-                self.push_row(batch, row_idx, row_offset);
-            }
+        }
+
+        for (&row_idx, &row_offset) in row_indices.iter().zip(offsets.iter()) {
+            self.push_record_batch_row(batch, projected_columns, row_idx, row_offset);
         }
     }
 
@@ -421,6 +411,39 @@ impl OffsetTopNCollector {
         }
     }
 
+    pub(super) fn push_record_batch_row(
+        &mut self,
+        batch: &RecordBatch,
+        projected_columns: &[usize],
+        row_idx: usize,
+        row_offset: usize,
+    ) {
+        if self.capacity == 0 || row_idx >= batch.num_rows() {
+            return;
+        }
+
+        let mut keys = Vec::with_capacity(self.order_indices.len());
+        for column_idx in &self.order_indices {
+            let Some(projected_idx) = projected_columns.get(*column_idx) else {
+                return;
+            };
+            let Some(column) = batch.columns().get(*projected_idx) else {
+                return;
+            };
+            keys.push(arrow_order_key_to_scalar_value(column.as_ref(), row_idx));
+        }
+
+        let probe = OffsetTopNEntry::new(keys, &self.order_by, row_offset, self.sequence);
+        self.sequence += 1;
+
+        if self.heap.len() < self.capacity {
+            self.heap.push(probe);
+        } else if self.heap.peek().is_some_and(|worst| probe < *worst) {
+            let _ = self.heap.pop();
+            self.heap.push(probe);
+        }
+    }
+
     pub(super) fn finish(self) -> Vec<usize> {
         let mut offsets = self
             .heap
@@ -431,6 +454,22 @@ impl OffsetTopNCollector {
         apply_offset_limit_items(&mut offsets, self.offset, Some(self.limit));
         offsets
     }
+}
+
+fn arrow_order_key_to_scalar_value(array: &dyn Array, index: usize) -> ScalarValue {
+    if array.is_null(index) {
+        return ScalarValue::Null;
+    }
+    if let Some(array) = array.as_any().downcast_ref::<Int64Array>() {
+        return ScalarValue::Int(array.value(index));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<Float64Array>() {
+        return ScalarValue::Float(array.value(index));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<TimestampMicrosecondArray>() {
+        return ScalarValue::Int(array.value(index));
+    }
+    arrow_value_to_scalar_value(array, index)
 }
 
 impl TopNEntry {
@@ -539,6 +578,7 @@ async fn resolve_order_keys(
     row: &[ScalarValue],
     params: &[Option<String>],
 ) -> Result<Vec<ScalarValue>, EngineError> {
+    let _span = profiling::span("resolve_order_keys");
     let scope = EvalScope::from_output_row(columns, row);
     let mut keys = Vec::with_capacity(order_by.len());
     for spec in order_by {
@@ -574,23 +614,32 @@ fn apply_offset_limit_to_rows(
 /// Collect identifiers from ORDER BY that are not present in the SELECT output columns.
 /// These need to be temporarily added to the SELECT for sorting.
 pub(super) fn collect_extra_order_by_columns(query: &Query) -> Vec<Expr> {
-    let select_columns: HashSet<String> = match &query.body {
-        QueryExpr::Select(select) => select
-            .targets
-            .iter()
-            .filter_map(|target| {
-                if let Some(alias) = &target.alias {
-                    return Some(alias.to_ascii_lowercase());
+    let select_columns: HashSet<String> =
+        match &query.body {
+            QueryExpr::Select(select) => {
+                if select.targets.iter().any(|target| {
+                    matches!(target.expr, Expr::Wildcard | Expr::QualifiedWildcard(_))
+                }) {
+                    return Vec::new();
                 }
-                if let Expr::Identifier(parts) = &target.expr {
-                    parts.last().map(|p| p.to_ascii_lowercase())
-                } else {
-                    None
-                }
-            })
-            .collect(),
-        _ => return Vec::new(),
-    };
+
+                select
+                    .targets
+                    .iter()
+                    .filter_map(|target| {
+                        if let Some(alias) = &target.alias {
+                            return Some(alias.to_ascii_lowercase());
+                        }
+                        if let Expr::Identifier(parts) = &target.expr {
+                            parts.last().map(|p| p.to_ascii_lowercase())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            }
+            _ => return Vec::new(),
+        };
 
     let mut extras = Vec::new();
     for spec in &query.order_by {
@@ -785,5 +834,39 @@ pub fn parse_non_negative_int(value: &ScalarValue, what: &str) -> Result<usize, 
         _ => Err(EngineError {
             message: format!("{what} must be a non-negative integer"),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wildcard_select_does_not_add_hidden_order_by_columns() {
+        let query = Query {
+            with: None,
+            body: QueryExpr::Select(SelectStatement {
+                targets: vec![SelectItem {
+                    expr: Expr::Wildcard,
+                    alias: None,
+                }],
+                from: Vec::new(),
+                where_clause: None,
+                group_by: Vec::new(),
+                having: None,
+                quantifier: None,
+                distinct_on: Vec::new(),
+                window_definitions: Vec::new(),
+            }),
+            order_by: vec![OrderByExpr {
+                expr: Expr::Identifier(vec!["eventtime".to_string()]),
+                ascending: Some(true),
+                using_operator: None,
+            }],
+            limit: Some(Expr::Integer(10)),
+            offset: None,
+        };
+
+        assert!(collect_extra_order_by_columns(&query).is_empty());
     }
 }

--- a/src/executor/exec_main/query_pipeline.rs
+++ b/src/executor/exec_main/query_pipeline.rs
@@ -4,15 +4,19 @@ use super::*;
 use crate::executor::column_batch::{ColumnBatch, TypedColumn};
 use crate::executor::columnar_agg::{AggKind, AggSpec, ColumnarAggregator, OutputExpr};
 use crate::executor::pipeline::{
-    AggregateSink, BatchCollector, FilterStage, LimitStage, PipelineStage, ProjectStage,
+    BatchCollector, FilterStage, LimitStage, PipelineStage, ProjectStage,
 };
+use crate::executor::profiling;
 use crate::executor::window_eval::{
     WindowArgumentKind, WindowColumnPlan, WindowPartitions, eval_window_function_columnar,
     expr_references_columns, resolve_window_spec,
 };
 use crate::parser::ast::WindowSpec;
-use crate::storage::heap::{ColumnAggregateOp, ColumnAggregateRequest, ScanPredicate};
+use crate::storage::heap::{
+    ColumnAggregateOp, ColumnAggregateRequest, ScanPredicate, ScanPredicateOp,
+};
 use crate::tcop::engine::with_storage_write;
+use arrow::array::{Array, StringArray};
 use std::collections::BTreeSet;
 
 pub async fn execute_query(
@@ -452,6 +456,98 @@ impl SimpleLikeMatcher {
             Self::Prefix(literal) => value.starts_with(literal),
             Self::Suffix(literal) => value.ends_with(literal),
             Self::Contains(literal) => value.contains(literal),
+        }
+    }
+}
+
+fn for_each_matching_text_row(
+    values: &StringArray,
+    deleted_rows: Option<&[bool]>,
+    matcher: &SimpleLikeMatcher,
+    mut callback: impl FnMut(usize),
+) {
+    let has_nulls = values.null_count() > 0;
+    match matcher {
+        SimpleLikeMatcher::Exact(literal) => {
+            for_each_matching_text_row_with(
+                values,
+                deleted_rows,
+                has_nulls,
+                |value| value == literal,
+                &mut callback,
+            );
+        }
+        SimpleLikeMatcher::Prefix(literal) => {
+            for_each_matching_text_row_with(
+                values,
+                deleted_rows,
+                has_nulls,
+                |value| value.starts_with(literal),
+                &mut callback,
+            );
+        }
+        SimpleLikeMatcher::Suffix(literal) => {
+            for_each_matching_text_row_with(
+                values,
+                deleted_rows,
+                has_nulls,
+                |value| value.ends_with(literal),
+                &mut callback,
+            );
+        }
+        SimpleLikeMatcher::Contains(literal) => {
+            for_each_matching_text_row_with(
+                values,
+                deleted_rows,
+                has_nulls,
+                |value| value.contains(literal),
+                &mut callback,
+            );
+        }
+    }
+}
+
+fn for_each_matching_text_row_with(
+    values: &StringArray,
+    deleted_rows: Option<&[bool]>,
+    has_nulls: bool,
+    mut matches: impl FnMut(&str) -> bool,
+    callback: &mut impl FnMut(usize),
+) {
+    match (deleted_rows, has_nulls) {
+        (None, false) => {
+            for row_idx in 0..values.len() {
+                if matches(values.value(row_idx)) {
+                    callback(row_idx);
+                }
+            }
+        }
+        (None, true) => {
+            for row_idx in 0..values.len() {
+                if !values.is_null(row_idx) && matches(values.value(row_idx)) {
+                    callback(row_idx);
+                }
+            }
+        }
+        (Some(deleted_rows), false) => {
+            for (row_idx, deleted) in deleted_rows.iter().copied().enumerate().take(values.len()) {
+                if deleted {
+                    continue;
+                }
+                if matches(values.value(row_idx)) {
+                    callback(row_idx);
+                }
+            }
+        }
+        (Some(deleted_rows), true) => {
+            for (row_idx, deleted) in deleted_rows.iter().copied().enumerate().take(values.len()) {
+                if deleted || values.is_null(row_idx) {
+                    continue;
+                }
+                if matches(values.value(row_idx)) {
+                    callback(row_idx);
+                }
+            }
         }
     }
 }
@@ -1339,6 +1435,49 @@ fn classify_simple_like_predicate(
     None
 }
 
+fn simple_like_matcher_from_pattern(pattern: String) -> Option<SimpleLikeMatcher> {
+    if pattern.contains('_') {
+        return None;
+    }
+    if let Some(literal) = pattern
+        .strip_prefix('%')
+        .and_then(|value| value.strip_suffix('%'))
+        && !literal.contains('%')
+    {
+        return Some(SimpleLikeMatcher::Contains(literal.to_string()));
+    }
+    if let Some(literal) = pattern.strip_prefix('%')
+        && !literal.contains('%')
+    {
+        return Some(SimpleLikeMatcher::Suffix(literal.to_string()));
+    }
+    if let Some(literal) = pattern.strip_suffix('%')
+        && !literal.contains('%')
+    {
+        return Some(SimpleLikeMatcher::Prefix(literal.to_string()));
+    }
+    if !pattern.contains('%') {
+        return Some(SimpleLikeMatcher::Exact(pattern));
+    }
+    None
+}
+
+fn classify_simple_like_scan_predicate(
+    predicates: &[ScanPredicate],
+) -> Option<(usize, SimpleLikeMatcher)> {
+    let [predicate] = predicates else {
+        return None;
+    };
+    if predicate.escape.is_some() || predicate.op != ScanPredicateOp::Like {
+        return None;
+    }
+    let pattern = match &predicate.value {
+        ScalarValue::Text(text) => text.clone(),
+        other => other.render(),
+    };
+    simple_like_matcher_from_pattern(pattern).map(|matcher| (predicate.column_index, matcher))
+}
+
 async fn try_execute_simple_columnar_select(
     select: &SelectStatement,
     query: Option<&Query>,
@@ -1348,6 +1487,7 @@ async fn try_execute_simple_columnar_select(
     columns: &[String],
     _outer_scope: Option<&EvalScope>,
 ) -> Result<Option<QueryResult>, EngineError> {
+    let _span = profiling::span("try_execute_simple_columnar_select");
     let Some(scan_plan) = prepare_columnar_relation_scan(rel, relation_predicates, params).await?
     else {
         return Ok(None);
@@ -1378,53 +1518,259 @@ async fn try_execute_simple_columnar_select(
         if let Some(mut offset_collector) =
             OffsetTopNCollector::new(query, &topn_columns, params).await?
         {
+            let pushed_simple_like = scan_plan
+                .remaining_predicate
+                .is_none()
+                .then(|| classify_simple_like_scan_predicate(&scan_plan.scan_predicates))
+                .flatten();
             let simple_like = scan_plan
                 .remaining_predicate
                 .as_ref()
                 .and_then(|predicate| classify_simple_like_predicate(predicate, &topn_batch));
+            if let Some((source_column_idx, matcher)) = &pushed_simple_like {
+                with_storage_write(|storage| {
+                    storage.scan_record_batches_for_table(
+                        scan_plan.table.oid(),
+                        &mut |batch, deleted_rows, batch_start| {
+                            let _span = profiling::span("columnar_offset_topn_pushed_like_stream");
+                            let Some(values) = batch
+                                .columns()
+                                .get(*source_column_idx)
+                                .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+                            else {
+                                return Ok(true);
+                            };
+                            let deleted_rows = deleted_rows
+                                .iter()
+                                .any(|deleted| *deleted)
+                                .then_some(deleted_rows);
+                            for_each_matching_text_row(values, deleted_rows, matcher, |row_idx| {
+                                offset_collector.push_record_batch_row(
+                                    batch,
+                                    &topn_projection,
+                                    row_idx,
+                                    batch_start + row_idx,
+                                );
+                            });
+                            Ok(true)
+                        },
+                    )
+                })
+                .map_err(|message| EngineError { message })?;
+
+                let offsets = offset_collector.finish();
+                let rows = with_storage_write(|storage| {
+                    storage.scan_rows_for_table(scan_plan.table.oid(), Some(&offsets), &[], None)
+                })
+                .map_err(|message| EngineError { message })?;
+                return Ok(Some(QueryResult {
+                    columns: columns.to_vec(),
+                    rows_affected: rows.len() as u64,
+                    rows,
+                    command_tag: "SELECT".to_string(),
+                }));
+            }
+            if let Some((column_idx, matcher)) = &simple_like {
+                let source_column_idx = topn_projection[*column_idx];
+                with_storage_write(|storage| {
+                    if scan_plan.scan_predicates.is_empty() {
+                        storage.scan_record_batches_for_table(
+                            scan_plan.table.oid(),
+                            &mut |batch, deleted_rows, batch_start| {
+                                let _span =
+                                    profiling::span("columnar_offset_topn_simple_like_stream");
+                                let Some(values) =
+                                    batch.columns().get(source_column_idx).and_then(|column| {
+                                        column.as_any().downcast_ref::<StringArray>()
+                                    })
+                                else {
+                                    return Ok(true);
+                                };
+                                let deleted_rows = deleted_rows
+                                    .iter()
+                                    .any(|deleted| *deleted)
+                                    .then_some(deleted_rows);
+                                for_each_matching_text_row(
+                                    values,
+                                    deleted_rows,
+                                    matcher,
+                                    |row_idx| {
+                                        offset_collector.push_record_batch_row(
+                                            batch,
+                                            &topn_projection,
+                                            row_idx,
+                                            batch_start + row_idx,
+                                        );
+                                    },
+                                );
+                                Ok(true)
+                            },
+                        )
+                    } else {
+                        storage.scan_selected_offsets_for_table(
+                            scan_plan.table.oid(),
+                            &scan_plan.scan_predicates,
+                            &mut |batch, selected_rows, offsets| {
+                                let _span = profiling::span("columnar_offset_topn_simple_like_raw");
+                                let Some(values) =
+                                    batch.columns().get(source_column_idx).and_then(|column| {
+                                        column.as_any().downcast_ref::<StringArray>()
+                                    })
+                                else {
+                                    return Ok(true);
+                                };
+                                let mut matched_rows = Vec::new();
+                                let mut matched_offsets = Vec::new();
+                                for (&row_idx, &row_offset) in
+                                    selected_rows.iter().zip(offsets.iter())
+                                {
+                                    if !values.is_null(row_idx)
+                                        && matcher.matches(values.value(row_idx))
+                                    {
+                                        matched_rows.push(row_idx);
+                                        matched_offsets.push(row_offset);
+                                    }
+                                }
+                                offset_collector.push_record_batch_selected_rows(
+                                    batch,
+                                    &topn_projection,
+                                    &matched_rows,
+                                    &matched_offsets,
+                                );
+                                Ok(true)
+                            },
+                        )
+                    }
+                })
+                .map_err(|message| EngineError { message })?;
+
+                let offsets = offset_collector.finish();
+                let rows = with_storage_write(|storage| {
+                    storage.scan_rows_for_table(scan_plan.table.oid(), Some(&offsets), &[], None)
+                })
+                .map_err(|message| EngineError { message })?;
+                return Ok(Some(QueryResult {
+                    columns: columns.to_vec(),
+                    rows_affected: rows.len() as u64,
+                    rows,
+                    command_tag: "SELECT".to_string(),
+                }));
+            }
+            if scan_plan.remaining_predicate.is_none() {
+                with_storage_write(|storage| {
+                    if scan_plan.scan_predicates.is_empty() {
+                        storage.scan_record_batches_for_table(
+                            scan_plan.table.oid(),
+                            &mut |batch, deleted_rows, batch_start| {
+                                for row_idx in 0..batch.num_rows() {
+                                    if deleted_rows.get(row_idx).copied().unwrap_or(false) {
+                                        continue;
+                                    }
+                                    offset_collector.push_record_batch_row(
+                                        batch,
+                                        &topn_projection,
+                                        row_idx,
+                                        batch_start + row_idx,
+                                    );
+                                }
+                                Ok(true)
+                            },
+                        )
+                    } else {
+                        storage.scan_selected_offsets_for_table(
+                            scan_plan.table.oid(),
+                            &scan_plan.scan_predicates,
+                            &mut |batch, selected_rows, offsets| {
+                                offset_collector.push_record_batch_selected_rows(
+                                    batch,
+                                    &topn_projection,
+                                    &selected_rows,
+                                    &offsets,
+                                );
+                                Ok(true)
+                            },
+                        )
+                    }
+                })
+                .map_err(|message| EngineError { message })?;
+
+                let offsets = offset_collector.finish();
+                let rows = with_storage_write(|storage| {
+                    storage.scan_rows_for_table(scan_plan.table.oid(), Some(&offsets), &[], None)
+                })
+                .map_err(|message| EngineError { message })?;
+                return Ok(Some(QueryResult {
+                    columns: columns.to_vec(),
+                    rows_affected: rows.len() as u64,
+                    rows,
+                    command_tag: "SELECT".to_string(),
+                }));
+            }
             with_storage_write(|storage| {
-                    storage.scan_batches_for_table_with_offsets(
+                    storage.scan_selected_batches_for_table_with_offsets(
                         scan_plan.table.oid(),
                         &scan_plan.scan_predicates,
                         Some(topn_projection.as_slice()),
-                        &mut |batch, offsets| {
+                        &mut |batch, selected_rows, offsets| {
                             if let Some((column_idx, matcher)) = &simple_like {
-                                offset_collector.push_matching_text_rows(
-                                    &batch,
-                                    *column_idx,
-                                    &offsets,
-                                    |value| matcher.matches(value),
+                                let _span = profiling::span(
+                                    "columnar_offset_topn_simple_like_match",
                                 );
+                                let mut matched_rows = Vec::new();
+                                let mut matched_offsets = Vec::new();
+                                if let Some(TypedColumn::Text(values, nulls)) =
+                                    batch.columns.get(*column_idx)
+                                {
+                                    for (&row_idx, &row_offset) in
+                                        selected_rows.iter().zip(offsets.iter())
+                                    {
+                                        if !nulls[row_idx] && matcher.matches(&values[row_idx]) {
+                                            matched_rows.push(row_idx);
+                                            matched_offsets.push(row_offset);
+                                        }
+                                    }
+                                }
+                                if !matched_rows.is_empty() {
+                                    offset_collector.push_selected_rows(
+                                        &batch,
+                                        &matched_rows,
+                                        &matched_offsets,
+                                    );
+                                }
                                 return Ok(true);
                             }
                             if let Some(predicate) = &scan_plan.remaining_predicate {
+                                let _span = profiling::span(
+                                    "columnar_offset_topn_predicate_filter",
+                                );
                                 let Some(mask) = eval_columnar_predicate(predicate, &batch) else {
                                     return Err(
                                         "columnar predicate could not be evaluated in fused wildcard pipeline"
                                             .to_string(),
                                     );
                                 };
-                                let selected_rows = mask
-                                    .iter()
-                                    .enumerate()
-                                    .filter_map(|(row_idx, selected)| selected.then_some(row_idx))
-                                    .collect::<Vec<_>>();
-                                let filtered_offsets = offsets
-                                    .iter()
-                                    .zip(mask.iter().copied())
-                                    .filter_map(|(offset, selected)| selected.then_some(*offset))
-                                    .collect::<Vec<_>>();
+                                let mut filtered_rows = Vec::new();
+                                let mut filtered_offsets = Vec::new();
+                                for (&row_idx, &row_offset) in
+                                    selected_rows.iter().zip(offsets.iter())
+                                {
+                                    if mask.get(row_idx).copied().unwrap_or(false) {
+                                        filtered_rows.push(row_idx);
+                                        filtered_offsets.push(row_offset);
+                                    }
+                                }
                                 offset_collector.push_selected_rows(
                                     &batch,
-                                    &selected_rows,
+                                    &filtered_rows,
                                     &filtered_offsets,
                                 );
                                 return Ok(true);
                             }
-                            if batch.row_count == 0 {
+                            if selected_rows.is_empty() {
                                 return Ok(true);
                             }
-                            offset_collector.push_batch(&batch, &offsets);
+                            let _span = profiling::span("columnar_offset_topn_push_selected_rows");
+                            offset_collector.push_selected_rows(&batch, &selected_rows, &offsets);
                             Ok(true)
                         },
                     )
@@ -1474,54 +1820,58 @@ async fn try_execute_simple_columnar_select(
                 .as_ref()
                 .and_then(|predicate| classify_simple_like_predicate(predicate, &topn_batch));
             with_storage_write(|storage| {
-                storage.scan_batches_for_table(
+                storage.scan_selected_batches_for_table(
                     scan_plan.table.oid(),
                     &scan_plan.scan_predicates,
                     Some(topn_projection.as_slice()),
-                    &mut |batch| {
+                    &mut |batch, selected_rows| {
                         if let Some((column_idx, matcher)) = &simple_like {
-                            let selected_rows = if let Some(TypedColumn::Text(values, nulls)) =
+                            let _span = profiling::span("columnar_topn_simple_like_match");
+                            let matched_rows = if let Some(TypedColumn::Text(values, nulls)) =
                                 batch.columns.get(*column_idx)
                             {
-                                values
+                                selected_rows
                                     .iter()
-                                    .zip(nulls.iter().copied())
-                                    .enumerate()
-                                    .filter_map(|(row_idx, (value, is_null))| {
-                                        (!is_null && matcher.matches(value)).then_some(row_idx)
+                                    .copied()
+                                    .filter(|row_idx| {
+                                        !nulls[*row_idx] && matcher.matches(&values[*row_idx])
                                     })
                                     .collect::<Vec<_>>()
                             } else {
                                 Vec::new()
                             };
-                            if selected_rows.is_empty() {
+                            if matched_rows.is_empty() {
                                 return Ok(true);
                             }
-                            topn_collector.push_selected_rows(&batch, &selected_rows);
+                            let _span = profiling::span("columnar_topn_push_selected_rows");
+                            topn_collector.push_selected_rows(&batch, &matched_rows);
                             return Ok(true);
                         }
                         if let Some(predicate) = &scan_plan.remaining_predicate {
+                            let _span = profiling::span("columnar_topn_predicate_filter");
                             let Some(mask) = eval_columnar_predicate(predicate, &batch) else {
                                 return Err(
                                     "columnar predicate could not be evaluated in fused projected pipeline"
                                         .to_string(),
                                 );
                             };
-                            let selected_rows = mask
+                            let filtered_rows = selected_rows
                                 .iter()
-                                .enumerate()
-                                .filter_map(|(row_idx, selected)| selected.then_some(row_idx))
+                                .copied()
+                                .filter(|row_idx| mask.get(*row_idx).copied().unwrap_or(false))
                                 .collect::<Vec<_>>();
-                            if selected_rows.is_empty() {
+                            if filtered_rows.is_empty() {
                                 return Ok(true);
                             }
-                            topn_collector.push_selected_rows(&batch, &selected_rows);
+                            let _span = profiling::span("columnar_topn_push_selected_rows");
+                            topn_collector.push_selected_rows(&batch, &filtered_rows);
                             return Ok(true);
                         }
-                        if batch.row_count == 0 {
+                        if selected_rows.is_empty() {
                             return Ok(true);
                         }
-                        topn_collector.push_batch(&batch);
+                        let _span = profiling::span("columnar_topn_push_selected_rows");
+                        topn_collector.push_selected_rows(&batch, &selected_rows);
                         Ok(true)
                     },
                 )
@@ -1557,6 +1907,7 @@ async fn try_execute_simple_columnar_select(
                 None,
                 &mut |batch| {
                     let filtered = if let Some(predicate) = &scan_plan.remaining_predicate {
+                        let _span = profiling::span("columnar_select_filter_batch");
                         let Some(mask) = eval_columnar_predicate(predicate, &batch) else {
                             return Err(
                                 "columnar predicate could not be evaluated in fused pipeline"
@@ -1574,6 +1925,7 @@ async fn try_execute_simple_columnar_select(
                     if projected.row_count == 0 {
                         return Ok(true);
                     }
+                    let _span = profiling::span("columnar_select_topn_push_batch");
                     topn_collector.push_batch(&projected);
                     Ok(true)
                 },
@@ -1658,6 +2010,7 @@ async fn try_execute_columnar_aggregation(
     columns: &[String],
     _outer_scope: Option<&EvalScope>,
 ) -> Result<Option<QueryResult>, EngineError> {
+    let _span = profiling::span("try_execute_columnar_aggregation");
     let Some(scan_plan) = prepare_columnar_relation_scan(rel, relation_predicates, params).await?
     else {
         return Ok(None);
@@ -1711,32 +2064,47 @@ async fn try_execute_columnar_aggregation(
             plan.output_exprs,
             plan.intermediate_columns.clone(),
         );
-        let mut pipeline: Box<dyn PipelineStage> = Box::new(AggregateSink::new(aggregator));
-        if let Some(predicate) = scan_plan.remaining_predicate.clone() {
-            if eval_columnar_predicate(&predicate, &scan_plan.schema_batch).is_none() {
-                return Ok(None);
-            }
-            pipeline = Box::new(FilterStage::new(predicate, pipeline));
+        let mut aggregator = aggregator;
+        if let Some(predicate) = scan_plan.remaining_predicate.clone()
+            && eval_columnar_predicate(&predicate, &scan_plan.schema_batch).is_none()
+        {
+            return Ok(None);
         }
 
         with_storage_write(|storage| {
-            storage.scan_batches_for_table(
+            storage.scan_selected_batches_for_table(
                 scan_plan.table.oid(),
                 &scan_plan.scan_predicates,
                 Some(projected_columns.as_slice()),
-                &mut |batch| {
-                    pipeline
-                        .push_batch(&batch)
-                        .map(|_| true)
+                &mut |batch, selected_rows| {
+                    let selected_rows = if let Some(predicate) = &scan_plan.remaining_predicate {
+                        let Some(mask) = eval_columnar_predicate(predicate, &batch) else {
+                            return Err(
+                                "columnar predicate could not be evaluated in grouped aggregation"
+                                    .to_string(),
+                            );
+                        };
+                        selected_rows
+                            .iter()
+                            .copied()
+                            .filter(|row_idx| mask.get(*row_idx).copied().unwrap_or(false))
+                            .collect::<Vec<_>>()
+                    } else {
+                        selected_rows
+                    };
+                    if selected_rows.is_empty() {
+                        return Ok(true);
+                    }
+                    aggregator
+                        .push_selected_rows(&batch, &selected_rows)
+                        .map(|()| true)
                         .map_err(|err| err.message)
                 },
             )
         })
         .map_err(|message| EngineError { message })?;
 
-        pipeline
-            .finish()?
-            .unwrap_or_else(|| ColumnBatch::empty(plan.intermediate_columns.clone()))
+        aggregator.finish()?
     };
 
     if let Some(projection_indices) =
@@ -1777,11 +2145,13 @@ async fn try_execute_columnar_aggregation(
     }
 
     let mut rows = Vec::with_capacity(result_batch.row_count);
+    let compiled_final_targets = compile_exprs(&plan.final_target_exprs)?;
     for row in result_batch.to_rows() {
         let scope = EvalScope::from_output_row(&plan.intermediate_columns, &row);
         let mut projected = Vec::with_capacity(plan.final_target_exprs.len());
-        for expr in &plan.final_target_exprs {
-            projected.push(eval_expr(expr, &scope, params).await?);
+        for (expr, compiled) in plan.final_target_exprs.iter().zip(&compiled_final_targets) {
+            projected
+                .push(eval_expr_maybe_compiled(expr, compiled.as_ref(), &scope, params).await?);
         }
         rows.push(projected);
     }
@@ -1933,6 +2303,7 @@ async fn try_execute_columnar_windows(
     columns: &[String],
     outer_scope: Option<&EvalScope>,
 ) -> Result<Option<QueryResult>, EngineError> {
+    let _span = profiling::span("try_execute_columnar_windows");
     let (table_eval, pushed_predicates) =
         evaluate_relation_with_predicates_columnar(rel, params, outer_scope, relation_predicates)
             .await?;
@@ -2385,6 +2756,7 @@ async fn try_execute_simple_count_star(
     outer_scope: Option<&EvalScope>,
     columns: &[String],
 ) -> Result<Option<QueryResult>, EngineError> {
+    let _span = profiling::span("try_execute_simple_count_star");
     if outer_scope.is_some()
         || select.targets.len() != 1
         || select.from.len() != 1
@@ -2524,6 +2896,7 @@ async fn execute_select_internal(
     params: &[Option<String>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<QueryResult, EngineError> {
+    let _span = profiling::span("execute_select_internal");
     let cte_columns = active_cte_context()
         .into_iter()
         .map(|(name, binding)| (name, binding.columns))
@@ -2711,6 +3084,7 @@ async fn execute_select_internal(
                     )
                     .await?
                     {
+                        profiling::record_duration("select_path_simple_columnar", 1);
                         return Ok(result);
                     }
                     if can_use_columnar_aggregation(select, has_aggregate, has_window, outer_scope)
@@ -2725,6 +3099,7 @@ async fn execute_select_internal(
                         )
                         .await?
                     {
+                        profiling::record_duration("select_path_columnar_aggregation", 1);
                         return Ok(result);
                     }
                     if can_use_columnar_windows(select, has_aggregate, has_window, outer_scope)
@@ -2739,6 +3114,7 @@ async fn execute_select_internal(
                         )
                         .await?
                     {
+                        profiling::record_duration("select_path_columnar_windows", 1);
                         return Ok(result);
                     }
                     let (table_eval, pushed_predicates) = evaluate_relation_with_predicates(
@@ -2797,19 +3173,39 @@ async fn execute_select_internal(
         }
     }
 
+    let compiled_remaining_predicate = remaining_predicate
+        .as_ref()
+        .map(try_compile_expr)
+        .transpose()?
+        .flatten();
+    let compiled_select_targets = compile_select_targets(&select.targets)?;
+
     let supports_direct_streaming =
         row_collector.is_some() && !has_aggregate && !has_window && select.quantifier.is_none();
     let emit_directly_to_collector = row_collector.is_some() && select.quantifier.is_none();
     if supports_direct_streaming {
         for scope in source_rows {
             if let Some(predicate) = &remaining_predicate
-                && !truthy(&eval_expr(predicate, &scope, params).await?)
+                && !truthy(
+                    &eval_expr_maybe_compiled(
+                        predicate,
+                        compiled_remaining_predicate.as_ref(),
+                        &scope,
+                        params,
+                    )
+                    .await?,
+                )
             {
                 continue;
             }
-            let row =
-                project_select_row(&select.targets, &scope, params, wildcard_columns.as_deref())
-                    .await?;
+            let row = project_select_row_compiled(
+                &select.targets,
+                &compiled_select_targets,
+                &scope,
+                params,
+                wildcard_columns.as_deref(),
+            )
+            .await?;
             if !row_collector
                 .as_mut()
                 .ok_or_else(|| EngineError {
@@ -2839,7 +3235,15 @@ async fn execute_select_internal(
     let filtered_rows = if let Some(predicate) = &remaining_predicate {
         let mut rows = Vec::with_capacity(source_rows.len());
         for scope in source_rows {
-            if !truthy(&eval_expr(predicate, &scope, params).await?) {
+            if !truthy(
+                &eval_expr_maybe_compiled(
+                    predicate,
+                    compiled_remaining_predicate.as_ref(),
+                    &scope,
+                    params,
+                )
+                .await?,
+            ) {
                 continue;
             }
             rows.push(scope);
@@ -3006,9 +3410,14 @@ async fn execute_select_internal(
         }
     } else {
         for scope in filtered_rows {
-            let row =
-                project_select_row(&select.targets, &scope, params, wildcard_columns.as_deref())
-                    .await?;
+            let row = project_select_row_compiled(
+                &select.targets,
+                &compiled_select_targets,
+                &scope,
+                params,
+                wildcard_columns.as_deref(),
+            )
+            .await?;
             if emit_directly_to_collector {
                 if !row_collector
                     .as_mut()

--- a/src/executor/exec_main/scope_utils.rs
+++ b/src/executor/exec_main/scope_utils.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use crate::executor::profiling;
 
 pub(super) fn scope_from_row(
     columns: &[String],
@@ -7,6 +8,7 @@ pub(super) fn scope_from_row(
     qualifiers: &[String],
     visible_columns: &[String],
 ) -> EvalScope {
+    let _span = profiling::span("scope_from_row");
     let mut scope = EvalScope::default();
     for (col, value) in columns.iter().zip(row.iter()) {
         scope.insert_unqualified(col, value.clone());

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use crate::executor::profiling;
 
 pub(super) async fn evaluate_table_function(
     function: &TableFunctionRef,
@@ -1222,6 +1223,7 @@ async fn evaluate_relation_with_predicates_impl(
                 .collect::<Vec<_>>();
             let columns = projected_column_names(&all_columns, projected_columns.as_deref());
             let batch = if supports_columnar_batch {
+                let _span = profiling::span("storage_scan_columnar_for_table");
                 Some(
                     crate::tcop::engine::with_storage_write(|storage| {
                         storage.scan_columnar_for_table(
@@ -1237,8 +1239,10 @@ async fn evaluate_relation_with_predicates_impl(
             };
             let rows = if materialize_rows {
                 if let Some(batch) = &batch {
+                    let _span = profiling::span("table_eval_batch_to_rows");
                     batch.to_rows()
                 } else {
+                    let _span = profiling::span("storage_scan_rows_for_table");
                     crate::tcop::engine::with_storage_write(|storage| {
                         storage.scan_rows_for_table(
                             table.oid(),
@@ -1307,8 +1311,11 @@ async fn evaluate_relation_with_predicates_impl(
     }
 
     let mut scoped_rows = Vec::with_capacity(rows.len());
-    for row in &rows {
-        scoped_rows.push(scope_from_row(&columns, row, &qualifiers, &columns));
+    {
+        let _span = profiling::span("table_eval_rows_to_scopes");
+        for row in &rows {
+            scoped_rows.push(scope_from_row(&columns, row, &qualifiers, &columns));
+        }
     }
     let null_values = vec![ScalarValue::Null; columns.len()];
     let null_scope = scope_from_row(&columns, &null_values, &qualifiers, &columns);

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
+pub mod bytecode_expr;
 pub mod column_batch;
 pub mod column_filter;
 pub mod columnar_agg;
@@ -23,6 +24,7 @@ pub mod node_sort;
 pub mod node_subquery;
 pub mod node_window_agg;
 pub mod pipeline;
+pub mod profiling;
 pub mod window_eval;
 
 static COLUMNAR_EXECUTION_ENABLED: AtomicBool = AtomicBool::new(true);

--- a/src/executor/pipeline.rs
+++ b/src/executor/pipeline.rs
@@ -1,6 +1,7 @@
 use crate::executor::column_batch::ColumnBatch;
 use crate::executor::column_filter::eval_columnar_predicate;
 use crate::executor::columnar_agg::ColumnarAggregator;
+use crate::executor::profiling;
 use crate::parser::ast::Expr;
 use crate::tcop::engine::EngineError;
 
@@ -22,6 +23,7 @@ impl FilterStage {
 
 impl PipelineStage for FilterStage {
     fn push_batch(&mut self, batch: &ColumnBatch) -> Result<usize, EngineError> {
+        let _span = profiling::span("pipeline_filter_push_batch");
         let Some(mask) = eval_columnar_predicate(&self.predicate, batch) else {
             return Err(EngineError {
                 message: "columnar predicate could not be evaluated in fused pipeline".to_string(),
@@ -55,6 +57,7 @@ impl ProjectStage {
 
 impl PipelineStage for ProjectStage {
     fn push_batch(&mut self, batch: &ColumnBatch) -> Result<usize, EngineError> {
+        let _span = profiling::span("pipeline_project_push_batch");
         let projected = batch.project(&self.output_indices);
         if projected.row_count == 0 {
             return Ok(0);
@@ -67,18 +70,22 @@ impl PipelineStage for ProjectStage {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct AggregateSink {
     aggregator: ColumnarAggregator,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 impl AggregateSink {
     pub(crate) fn new(aggregator: ColumnarAggregator) -> Self {
         Self { aggregator }
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 impl PipelineStage for AggregateSink {
     fn push_batch(&mut self, batch: &ColumnBatch) -> Result<usize, EngineError> {
+        let _span = profiling::span("pipeline_aggregate_push_batch");
         self.aggregator.push_batch(batch)?;
         Ok(batch.row_count)
     }
@@ -164,6 +171,7 @@ impl BatchCollector {
 
 impl PipelineStage for BatchCollector {
     fn push_batch(&mut self, batch: &ColumnBatch) -> Result<usize, EngineError> {
+        let _span = profiling::span("pipeline_batch_collector_push_batch");
         if let Some(existing) = &mut self.batch {
             existing
                 .append_batch(batch)

--- a/src/executor/profiling.rs
+++ b/src/executor/profiling.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+#[derive(Debug, Clone, Copy, Default)]
+struct Metric {
+    count: u64,
+    nanos: u128,
+}
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static METRICS: OnceLock<Mutex<HashMap<&'static str, Metric>>> = OnceLock::new();
+
+pub struct SpanGuard {
+    name: &'static str,
+    start: Option<Instant>,
+}
+
+pub fn is_enabled() -> bool {
+    *ENABLED.get_or_init(|| std::env::var_os("OPENASSAY_EXEC_PROFILE").is_some())
+}
+
+pub fn span(name: &'static str) -> SpanGuard {
+    if is_enabled() {
+        SpanGuard {
+            name,
+            start: Some(Instant::now()),
+        }
+    } else {
+        SpanGuard { name, start: None }
+    }
+}
+
+pub fn record_duration(name: &'static str, nanos: u128) {
+    if !is_enabled() {
+        return;
+    }
+    let metrics = METRICS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut metrics = metrics.lock().expect("profiling metrics mutex poisoned");
+    let metric = metrics.entry(name).or_default();
+    metric.count += 1;
+    metric.nanos += nanos;
+}
+
+pub fn reset() {
+    if let Some(metrics) = METRICS.get() {
+        metrics
+            .lock()
+            .expect("profiling metrics mutex poisoned")
+            .clear();
+    }
+}
+
+pub fn report() -> String {
+    let Some(metrics) = METRICS.get() else {
+        return "profiling disabled or no metrics recorded".to_string();
+    };
+    let metrics = metrics.lock().expect("profiling metrics mutex poisoned");
+    if metrics.is_empty() {
+        return "no profiling samples recorded".to_string();
+    }
+
+    let total_nanos = metrics.values().map(|metric| metric.nanos).sum::<u128>();
+    let mut rows = metrics
+        .iter()
+        .map(|(name, metric)| (*name, *metric))
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| right.1.nanos.cmp(&left.1.nanos).then(left.0.cmp(right.0)));
+
+    let mut output = String::new();
+    let _ = writeln!(
+        output,
+        "total_profiled_ms={:.3}",
+        total_nanos as f64 / 1_000_000.0
+    );
+    for (name, metric) in rows {
+        let total_ms = metric.nanos as f64 / 1_000_000.0;
+        let avg_us = if metric.count == 0 {
+            0.0
+        } else {
+            metric.nanos as f64 / metric.count as f64 / 1_000.0
+        };
+        let pct = if total_nanos == 0 {
+            0.0
+        } else {
+            metric.nanos as f64 * 100.0 / total_nanos as f64
+        };
+        let _ = writeln!(
+            output,
+            "{name}: total_ms={total_ms:.3} pct={pct:.2} count={} avg_us={avg_us:.3}",
+            metric.count
+        );
+    }
+    output
+}
+
+impl Drop for SpanGuard {
+    fn drop(&mut self) {
+        if let Some(start) = self.start.take() {
+            record_duration(self.name, start.elapsed().as_nanos());
+        }
+    }
+}

--- a/src/storage/heap.rs
+++ b/src/storage/heap.rs
@@ -10,6 +10,7 @@ use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use crate::catalog::oid::Oid;
 use crate::catalog::{TypeSignature, with_catalog_read};
 use crate::executor::column_batch::ColumnBatch;
+use crate::executor::profiling;
 use crate::storage::btree::{BTreeIndex, CompositeKey};
 use crate::storage::tuple::{
     ScalarValue, append_scalar_value_to_builder, arrow_value_to_scalar_value, scalar_values_schema,
@@ -18,6 +19,11 @@ use crate::utils::adt::misc::{compare_values_for_predicate, like_matches};
 
 pub(crate) const DEFAULT_BTREE_ORDER: usize = 48;
 pub(crate) const COLUMNAR_BATCH_SIZE: usize = 1_024;
+
+type SelectedOffsetsBatchCallback<'a> =
+    dyn FnMut(&RecordBatch, Vec<usize>, Vec<usize>) -> Result<bool, String> + 'a;
+type RecordBatchScanCallback<'a> =
+    dyn FnMut(&RecordBatch, &[bool], usize) -> Result<bool, String> + 'a;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ColumnarBatch {
@@ -69,6 +75,71 @@ pub(crate) struct ScanPredicate {
     pub(crate) op: ScanPredicateOp,
     pub(crate) value: ScalarValue,
     pub(crate) escape: Option<char>,
+}
+
+enum LikePredicateMatcher {
+    Exact(String),
+    Prefix(String),
+    Suffix(String),
+    Contains(String),
+    Generic {
+        pattern: String,
+        escape: Option<char>,
+        case_insensitive: bool,
+    },
+}
+
+impl LikePredicateMatcher {
+    fn new(pattern: String, escape: Option<char>, case_insensitive: bool) -> Self {
+        classify_like_pattern(&pattern, escape, case_insensitive).unwrap_or(Self::Generic {
+            pattern,
+            escape,
+            case_insensitive,
+        })
+    }
+
+    fn matches(&self, value: &str) -> bool {
+        match self {
+            Self::Exact(literal) => value == literal,
+            Self::Prefix(literal) => value.starts_with(literal),
+            Self::Suffix(literal) => value.ends_with(literal),
+            Self::Contains(literal) => value.contains(literal),
+            Self::Generic {
+                pattern,
+                escape,
+                case_insensitive,
+            } => {
+                if *case_insensitive {
+                    like_matches(
+                        &value.to_ascii_lowercase(),
+                        &pattern.to_ascii_lowercase(),
+                        *escape,
+                    )
+                } else {
+                    like_matches(value, pattern, *escape)
+                }
+            }
+        }
+    }
+}
+
+enum CompiledScanPredicate<'a> {
+    Int64 {
+        values: &'a Int64Array,
+        op: ScanPredicateOp,
+        literal: i64,
+    },
+    Float64 {
+        values: &'a Float64Array,
+        op: ScanPredicateOp,
+        literal: f64,
+    },
+    Text {
+        values: &'a StringArray,
+        op: ScanPredicateOp,
+        literal: String,
+        like_matcher: Option<LikePredicateMatcher>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -442,6 +513,7 @@ impl InMemoryStorage {
         offsets: Option<&[usize]>,
         predicates: &[ScanPredicate],
     ) -> Result<usize, String> {
+        let _span = profiling::span("storage_count_rows_for_table");
         self.ensure_table(table_oid)?;
         self.flush_pending(table_oid)?;
         let Some(table) = self.columnar_by_table.get(&table_oid) else {
@@ -475,6 +547,7 @@ impl InMemoryStorage {
         table_oid: Oid,
         requests: &[ColumnAggregateRequest],
     ) -> Result<Option<Vec<ScalarValue>>, String> {
+        let _span = profiling::span("storage_aggregate_columns_for_table");
         self.ensure_table(table_oid)?;
         self.flush_pending(table_oid)?;
         let Some(table) = self.columnar_by_table.get(&table_oid) else {
@@ -510,6 +583,7 @@ impl InMemoryStorage {
         group_column_indexes: &[usize],
         requests: &[ColumnAggregateRequest],
     ) -> Result<Option<Vec<(Vec<ScalarValue>, Vec<ScalarValue>)>>, String> {
+        let _span = profiling::span("storage_group_aggregate_columns_for_table");
         self.ensure_table(table_oid)?;
         self.flush_pending(table_oid)?;
         let Some(table) = self.columnar_by_table.get(&table_oid) else {
@@ -576,6 +650,7 @@ impl InMemoryStorage {
         predicates: &[ScanPredicate],
         projected_columns: Option<&[usize]>,
     ) -> Result<ColumnBatch, String> {
+        let _span = profiling::span("storage_scan_columnar_for_table");
         self.ensure_table(table_oid)?;
         self.flush_pending(table_oid)?;
         let Some(table) = self.columnar_by_table.get(&table_oid) else {
@@ -615,6 +690,7 @@ impl InMemoryStorage {
         projected_columns: Option<&[usize]>,
         callback: &mut dyn FnMut(ColumnBatch) -> Result<bool, String>,
     ) -> Result<(), String> {
+        let _span = profiling::span("storage_scan_batches_for_table");
         self.ensure_table(table_oid)?;
         self.flush_pending(table_oid)?;
         let Some(table) = self.columnar_by_table.get(&table_oid) else {
@@ -647,6 +723,7 @@ impl InMemoryStorage {
         Ok(())
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn scan_batches_for_table_with_offsets(
         &mut self,
         table_oid: Oid,
@@ -695,6 +772,142 @@ impl InMemoryStorage {
                 break;
             }
             batch_start += batch_len;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn scan_selected_batches_for_table(
+        &mut self,
+        table_oid: Oid,
+        predicates: &[ScanPredicate],
+        projected_columns: Option<&[usize]>,
+        callback: &mut dyn FnMut(ColumnBatch, Vec<usize>) -> Result<bool, String>,
+    ) -> Result<(), String> {
+        let _span = profiling::span("storage_scan_selected_batches_for_table");
+        self.ensure_table(table_oid)?;
+        self.flush_pending(table_oid)?;
+        let Some(table) = self.columnar_by_table.get(&table_oid) else {
+            return Ok(());
+        };
+        if table.batches.is_empty() {
+            return Ok(());
+        }
+
+        for batch in &table.batches {
+            let selected_rows = matching_row_offsets_in_batch(batch, predicates, None)?;
+            if selected_rows.is_empty() {
+                continue;
+            }
+            let batch_columns = ColumnBatch::from_record_batch_projected_selected(
+                &batch.record_batch,
+                &table.column_names,
+                projected_columns,
+                &selected_rows,
+            );
+            let dense_rows = (0..selected_rows.len()).collect::<Vec<_>>();
+            if !callback(batch_columns, dense_rows)? {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn scan_selected_batches_for_table_with_offsets(
+        &mut self,
+        table_oid: Oid,
+        predicates: &[ScanPredicate],
+        projected_columns: Option<&[usize]>,
+        callback: &mut dyn FnMut(ColumnBatch, Vec<usize>, Vec<usize>) -> Result<bool, String>,
+    ) -> Result<(), String> {
+        let _span = profiling::span("storage_scan_selected_batches_for_table_with_offsets");
+        self.ensure_table(table_oid)?;
+        self.flush_pending(table_oid)?;
+        let Some(table) = self.columnar_by_table.get(&table_oid) else {
+            return Ok(());
+        };
+        if table.batches.is_empty() {
+            return Ok(());
+        }
+
+        let mut batch_start = 0usize;
+        for batch in &table.batches {
+            let batch_len = batch.record_batch.num_rows();
+            let selected_rows = matching_row_offsets_in_batch(batch, predicates, None)?;
+            if !selected_rows.is_empty() {
+                let global_offsets = selected_rows
+                    .iter()
+                    .map(|local_offset| batch_start + local_offset)
+                    .collect::<Vec<_>>();
+                let batch_columns = ColumnBatch::from_record_batch_projected_selected(
+                    &batch.record_batch,
+                    &table.column_names,
+                    projected_columns,
+                    &selected_rows,
+                );
+                let dense_rows = (0..selected_rows.len()).collect::<Vec<_>>();
+                if !callback(batch_columns, dense_rows, global_offsets)? {
+                    break;
+                }
+            }
+            batch_start += batch_len;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn scan_selected_offsets_for_table(
+        &mut self,
+        table_oid: Oid,
+        predicates: &[ScanPredicate],
+        callback: &mut SelectedOffsetsBatchCallback<'_>,
+    ) -> Result<(), String> {
+        let _span = profiling::span("storage_scan_selected_offsets_for_table");
+        self.ensure_table(table_oid)?;
+        self.flush_pending(table_oid)?;
+        let Some(table) = self.columnar_by_table.get(&table_oid) else {
+            return Ok(());
+        };
+        if table.batches.is_empty() {
+            return Ok(());
+        }
+
+        let mut batch_start = 0usize;
+        for batch in &table.batches {
+            let selected_rows = matching_row_offsets_in_batch(batch, predicates, None)?;
+            if !selected_rows.is_empty() {
+                let global_offsets = selected_rows
+                    .iter()
+                    .map(|local_offset| batch_start + local_offset)
+                    .collect::<Vec<_>>();
+                if !callback(&batch.record_batch, selected_rows, global_offsets)? {
+                    break;
+                }
+            }
+            batch_start += batch.record_batch.num_rows();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn scan_record_batches_for_table(
+        &mut self,
+        table_oid: Oid,
+        callback: &mut RecordBatchScanCallback<'_>,
+    ) -> Result<(), String> {
+        let _span = profiling::span("storage_scan_record_batches_for_table");
+        self.ensure_table(table_oid)?;
+        self.flush_pending(table_oid)?;
+        let Some(table) = self.columnar_by_table.get(&table_oid) else {
+            return Ok(());
+        };
+        if table.batches.is_empty() {
+            return Ok(());
+        }
+
+        let mut batch_start = 0usize;
+        for batch in &table.batches {
+            if !callback(&batch.record_batch, &batch.deleted_rows, batch_start)? {
+                break;
+            }
+            batch_start += batch.record_batch.num_rows();
         }
         Ok(())
     }
@@ -856,40 +1069,60 @@ impl InMemoryStorage {
         predicates: &[ScanPredicate],
         projected_columns: Option<&[usize]>,
     ) -> Result<Vec<Vec<ScalarValue>>, String> {
-        let mut rows_by_offset = HashMap::new();
-        let requested_offsets = offsets.iter().copied().collect::<HashSet<_>>();
+        let projected = projected_columns
+            .map(<[usize]>::to_vec)
+            .unwrap_or_else(|| (0..table.column_names.len()).collect());
+        let mut rows_by_request = vec![None; offsets.len()];
         let mut batch_start = 0usize;
 
         for batch in &table.batches {
             let batch_len = batch.record_batch.num_rows();
             let batch_end = batch_start + batch_len;
-            let relevant = requested_offsets
+            let relevant = offsets
                 .iter()
-                .copied()
-                .filter(|offset| *offset >= batch_start && *offset < batch_end)
+                .enumerate()
+                .filter_map(|(request_idx, offset)| {
+                    if *offset >= batch_start && *offset < batch_end {
+                        Some((request_idx, *offset - batch_start))
+                    } else {
+                        None
+                    }
+                })
                 .collect::<Vec<_>>();
             if relevant.is_empty() {
                 batch_start = batch_end;
                 continue;
             }
 
-            let mut selected_rows = vec![false; batch_len];
-            for offset in &relevant {
-                selected_rows[*offset - batch_start] = true;
-            }
-            let (filtered_batch, surviving_local_offsets) =
-                filter_batch(batch, predicates, Some(&selected_rows))?;
-            let batch_rows = record_batch_to_rows(&filtered_batch, projected_columns);
-            for (local_offset, row) in surviving_local_offsets.into_iter().zip(batch_rows) {
-                rows_by_offset.insert(batch_start + local_offset, row);
+            for (request_idx, local_offset) in relevant {
+                if batch
+                    .deleted_rows
+                    .get(local_offset)
+                    .copied()
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                if !predicates.is_empty()
+                    && !record_batch_row_matches_predicates(
+                        &batch.record_batch,
+                        local_offset,
+                        predicates,
+                    )?
+                {
+                    continue;
+                }
+
+                rows_by_request[request_idx] = Some(record_batch_row_to_values(
+                    &batch.record_batch,
+                    local_offset,
+                    &projected,
+                ));
             }
             batch_start = batch_end;
         }
 
-        Ok(offsets
-            .iter()
-            .filter_map(|offset| rows_by_offset.get(offset).cloned())
-            .collect())
+        Ok(rows_by_request.into_iter().flatten().collect())
     }
 
     fn count_all_rows(
@@ -1313,6 +1546,7 @@ fn filter_batch(
     predicates: &[ScanPredicate],
     selected_rows: Option<&[bool]>,
 ) -> Result<(RecordBatch, Vec<usize>), String> {
+    let _span = profiling::span("heap_filter_batch");
     let mask = build_filter_mask(batch, predicates, selected_rows)?;
     let surviving_offsets = mask
         .iter()
@@ -1324,15 +1558,226 @@ fn filter_batch(
     Ok((filtered, surviving_offsets))
 }
 
+fn matching_row_offsets_in_batch(
+    batch: &ColumnarBatch,
+    predicates: &[ScanPredicate],
+    selected_rows: Option<&[bool]>,
+) -> Result<Vec<usize>, String> {
+    let _span = profiling::span("heap_matching_row_offsets_in_batch");
+    if let Some(offsets) = try_matching_row_offsets_fast(batch, predicates, selected_rows)? {
+        return Ok(offsets);
+    }
+    Ok(build_filter_mask(batch, predicates, selected_rows)?
+        .iter()
+        .enumerate()
+        .filter_map(|(row_idx, selected)| matches!(selected, Some(true)).then_some(row_idx))
+        .collect())
+}
+
 fn count_matching_rows_in_batch(
     batch: &ColumnarBatch,
     predicates: &[ScanPredicate],
     selected_rows: Option<&[bool]>,
 ) -> Result<usize, String> {
+    if let Some(offsets) = try_matching_row_offsets_fast(batch, predicates, selected_rows)? {
+        return Ok(offsets.len());
+    }
     Ok(build_filter_mask(batch, predicates, selected_rows)?
         .iter()
         .filter(|selected| matches!(selected, Some(true)))
         .count())
+}
+
+fn try_matching_row_offsets_fast(
+    batch: &ColumnarBatch,
+    predicates: &[ScanPredicate],
+    selected_rows: Option<&[bool]>,
+) -> Result<Option<Vec<usize>>, String> {
+    let _span = profiling::span("heap_matching_row_offsets_fast");
+    let Some(compiled_predicates) = compile_scan_predicates(batch, predicates)? else {
+        return Ok(None);
+    };
+
+    let mut offsets = Vec::new();
+    for row_idx in 0..batch.record_batch.num_rows() {
+        let selected = selected_rows.is_none_or(|rows| rows.get(row_idx).copied().unwrap_or(false));
+        let deleted = batch.deleted_rows.get(row_idx).copied().unwrap_or(false);
+        if !selected || deleted {
+            continue;
+        }
+        if compiled_predicates
+            .iter()
+            .all(|predicate| predicate.matches(row_idx))
+        {
+            offsets.push(row_idx);
+        }
+    }
+    Ok(Some(offsets))
+}
+
+fn compile_scan_predicates<'a>(
+    batch: &'a ColumnarBatch,
+    predicates: &[ScanPredicate],
+) -> Result<Option<Vec<CompiledScanPredicate<'a>>>, String> {
+    let mut compiled = Vec::with_capacity(predicates.len());
+    for predicate in predicates {
+        let Some(column) = batch.record_batch.columns().get(predicate.column_index) else {
+            return Err(format!(
+                "row does not have predicate column offset {}",
+                predicate.column_index
+            ));
+        };
+        let compiled_predicate = if let (Some(values), ScalarValue::Int(literal)) = (
+            column.as_any().downcast_ref::<Int64Array>(),
+            &predicate.value,
+        ) {
+            CompiledScanPredicate::Int64 {
+                values,
+                op: predicate.op,
+                literal: *literal,
+            }
+        } else if let (Some(values), ScalarValue::Float(literal)) = (
+            column.as_any().downcast_ref::<Float64Array>(),
+            &predicate.value,
+        ) {
+            CompiledScanPredicate::Float64 {
+                values,
+                op: predicate.op,
+                literal: *literal,
+            }
+        } else if let Some(values) = column.as_any().downcast_ref::<StringArray>() {
+            let literal = match &predicate.value {
+                ScalarValue::Text(text) => text.clone(),
+                other => other.render(),
+            };
+            let like_matcher = match predicate.op {
+                ScanPredicateOp::Like | ScanPredicateOp::NotLike => Some(
+                    LikePredicateMatcher::new(literal.clone(), predicate.escape, false),
+                ),
+                ScanPredicateOp::ILike | ScanPredicateOp::NotILike => Some(
+                    LikePredicateMatcher::new(literal.clone(), predicate.escape, true),
+                ),
+                _ => None,
+            };
+            CompiledScanPredicate::Text {
+                values,
+                op: predicate.op,
+                literal,
+                like_matcher,
+            }
+        } else {
+            return Ok(None);
+        };
+        compiled.push(compiled_predicate);
+    }
+    Ok(Some(compiled))
+}
+
+impl CompiledScanPredicate<'_> {
+    fn matches(&self, row_idx: usize) -> bool {
+        match self {
+            Self::Int64 {
+                values,
+                op,
+                literal,
+            } => {
+                if values.is_null(row_idx) {
+                    return false;
+                }
+                compare_ordering(values.value(row_idx).cmp(literal), *op)
+            }
+            Self::Float64 {
+                values,
+                op,
+                literal,
+            } => {
+                if values.is_null(row_idx) {
+                    return false;
+                }
+                let value = values.value(row_idx);
+                let ordering = value.partial_cmp(literal).unwrap_or(Ordering::Equal);
+                compare_ordering(ordering, *op)
+            }
+            Self::Text {
+                values,
+                op,
+                literal,
+                like_matcher,
+            } => {
+                if values.is_null(row_idx) {
+                    return false;
+                }
+                let value = values.value(row_idx);
+                match op {
+                    ScanPredicateOp::Eq => value == literal,
+                    ScanPredicateOp::NotEq => value != literal,
+                    ScanPredicateOp::Lt => value < literal.as_str(),
+                    ScanPredicateOp::Lte => value <= literal.as_str(),
+                    ScanPredicateOp::Gt => value > literal.as_str(),
+                    ScanPredicateOp::Gte => value >= literal.as_str(),
+                    ScanPredicateOp::Like | ScanPredicateOp::ILike => like_matcher
+                        .as_ref()
+                        .is_some_and(|matcher| matcher.matches(value)),
+                    ScanPredicateOp::NotLike | ScanPredicateOp::NotILike => like_matcher
+                        .as_ref()
+                        .is_some_and(|matcher| !matcher.matches(value)),
+                }
+            }
+        }
+    }
+}
+
+fn compare_ordering(ordering: Ordering, op: ScanPredicateOp) -> bool {
+    match op {
+        ScanPredicateOp::Eq => ordering == Ordering::Equal,
+        ScanPredicateOp::NotEq => ordering != Ordering::Equal,
+        ScanPredicateOp::Lt => ordering == Ordering::Less,
+        ScanPredicateOp::Lte => matches!(ordering, Ordering::Less | Ordering::Equal),
+        ScanPredicateOp::Gt => ordering == Ordering::Greater,
+        ScanPredicateOp::Gte => matches!(ordering, Ordering::Greater | Ordering::Equal),
+        ScanPredicateOp::Like
+        | ScanPredicateOp::NotLike
+        | ScanPredicateOp::ILike
+        | ScanPredicateOp::NotILike => false,
+    }
+}
+
+fn classify_like_pattern(
+    pattern: &str,
+    escape: Option<char>,
+    case_insensitive: bool,
+) -> Option<LikePredicateMatcher> {
+    if pattern.contains('_') || escape.is_some() {
+        return None;
+    }
+
+    let normalized = if case_insensitive {
+        pattern.to_ascii_lowercase()
+    } else {
+        pattern.to_string()
+    };
+
+    if let Some(literal) = normalized
+        .strip_prefix('%')
+        .and_then(|value| value.strip_suffix('%'))
+        && !literal.contains('%')
+    {
+        return Some(LikePredicateMatcher::Contains(literal.to_string()));
+    }
+    if let Some(literal) = normalized.strip_prefix('%')
+        && !literal.contains('%')
+    {
+        return Some(LikePredicateMatcher::Suffix(literal.to_string()));
+    }
+    if let Some(literal) = normalized.strip_suffix('%')
+        && !literal.contains('%')
+    {
+        return Some(LikePredicateMatcher::Prefix(literal.to_string()));
+    }
+    if !normalized.contains('%') {
+        return Some(LikePredicateMatcher::Exact(normalized));
+    }
+    None
 }
 
 fn build_filter_mask(
@@ -1340,6 +1785,7 @@ fn build_filter_mask(
     predicates: &[ScanPredicate],
     selected_rows: Option<&[bool]>,
 ) -> Result<BooleanArray, String> {
+    let _span = profiling::span("heap_build_filter_mask");
     if let Some(mask) = try_build_arrow_filter_mask(batch, predicates, selected_rows)? {
         return Ok(mask);
     }
@@ -1351,6 +1797,7 @@ fn try_build_arrow_filter_mask(
     predicates: &[ScanPredicate],
     selected_rows: Option<&[bool]>,
 ) -> Result<Option<BooleanArray>, String> {
+    let _span = profiling::span("heap_try_build_arrow_filter_mask");
     let mut mask = visibility_mask(batch, selected_rows);
     for predicate in predicates {
         let Some(column) = batch.record_batch.columns().get(predicate.column_index) else {
@@ -1373,6 +1820,7 @@ fn build_filter_mask_row(
     predicates: &[ScanPredicate],
     selected_rows: Option<&[bool]>,
 ) -> Result<BooleanArray, String> {
+    let _span = profiling::span("heap_build_filter_mask_row");
     let row_count = batch.record_batch.num_rows();
     let values = (0..row_count)
         .map(|row_idx| {
@@ -1478,6 +1926,7 @@ fn record_batch_to_rows(
     batch: &RecordBatch,
     projected_columns: Option<&[usize]>,
 ) -> Vec<Vec<ScalarValue>> {
+    let _span = profiling::span("heap_record_batch_to_rows");
     let projected = projected_columns
         .map(<[usize]>::to_vec)
         .unwrap_or_else(|| (0..batch.num_columns()).collect());
@@ -1492,6 +1941,21 @@ fn record_batch_to_rows(
         rows.push(row);
     }
     rows
+}
+
+fn record_batch_row_to_values(
+    batch: &RecordBatch,
+    row_idx: usize,
+    projected_columns: &[usize],
+) -> Vec<ScalarValue> {
+    let _span = profiling::span("heap_record_batch_row_to_values");
+    let mut row = Vec::with_capacity(projected_columns.len());
+    for column_idx in projected_columns {
+        if let Some(column) = batch.columns().get(*column_idx) {
+            row.push(arrow_value_to_scalar_value(column.as_ref(), row_idx));
+        }
+    }
+    row
 }
 
 fn projected_column_names(columns: &[String], projected_columns: Option<&[usize]>) -> Vec<String> {
@@ -1671,6 +2135,33 @@ mod tests {
     }
 
     #[test]
+    fn scan_rows_for_table_honors_offsets_with_projection() {
+        let mut storage = InMemoryStorage::default();
+        storage
+            .replace_rows_for_table(
+                42,
+                vec![
+                    vec![ScalarValue::Int(1), ScalarValue::Text("a".to_string())],
+                    vec![ScalarValue::Int(2), ScalarValue::Text("b".to_string())],
+                    vec![ScalarValue::Int(3), ScalarValue::Text("c".to_string())],
+                ],
+            )
+            .expect("replace rows");
+
+        let rows = storage
+            .scan_rows_for_table(42, Some(&[2, 1]), &[], Some(&[1]))
+            .expect("scan should succeed");
+
+        assert_eq!(
+            rows,
+            vec![
+                vec![ScalarValue::Text("c".to_string())],
+                vec![ScalarValue::Text("b".to_string())],
+            ]
+        );
+    }
+
+    #[test]
     fn append_flushes_pending_rows_into_record_batches() {
         let mut storage = InMemoryStorage::default();
         storage.rows_by_table.insert(7, Vec::new());
@@ -1778,6 +2269,143 @@ mod tests {
                 vec![ScalarValue::Text("alpha".to_string())],
                 vec![ScalarValue::Text("alphabet".to_string())],
             ]
+        );
+    }
+
+    #[test]
+    fn scan_selected_batches_with_offsets_reports_original_positions() {
+        let mut storage = InMemoryStorage::default();
+        storage
+            .replace_rows_for_table(
+                88,
+                vec![
+                    vec![ScalarValue::Int(1), ScalarValue::Text("a".to_string())],
+                    vec![ScalarValue::Int(2), ScalarValue::Text("b".to_string())],
+                    vec![ScalarValue::Int(3), ScalarValue::Text("c".to_string())],
+                ],
+            )
+            .expect("replace rows");
+
+        let mut seen = Vec::new();
+        storage
+            .scan_selected_batches_for_table_with_offsets(
+                88,
+                &[ScanPredicate {
+                    column_index: 0,
+                    op: ScanPredicateOp::Gt,
+                    value: ScalarValue::Int(1),
+                    escape: None,
+                }],
+                Some(&[1]),
+                &mut |batch, selected_rows, offsets| {
+                    let values = selected_rows
+                        .iter()
+                        .map(|row_idx| batch.columns[0].value_at(*row_idx))
+                        .collect::<Vec<_>>();
+                    seen.push((offsets, values));
+                    Ok(true)
+                },
+            )
+            .expect("selected scan should succeed");
+
+        assert_eq!(
+            seen,
+            vec![(
+                vec![1, 2],
+                vec![
+                    ScalarValue::Text("b".to_string()),
+                    ScalarValue::Text("c".to_string()),
+                ],
+            )]
+        );
+    }
+
+    #[test]
+    fn scan_selected_batches_handles_like_and_not_like_fast_path() {
+        let mut storage = InMemoryStorage::default();
+        storage
+            .replace_rows_for_table(
+                89,
+                vec![
+                    vec![
+                        ScalarValue::Text("https://example.com/widget/a".to_string()),
+                        ScalarValue::Text("keep".to_string()),
+                    ],
+                    vec![
+                        ScalarValue::Text("https://example.com/widget.internal".to_string()),
+                        ScalarValue::Text("drop".to_string()),
+                    ],
+                    vec![
+                        ScalarValue::Text("https://example.com/widget/b".to_string()),
+                        ScalarValue::Text("keep".to_string()),
+                    ],
+                ],
+            )
+            .expect("replace rows");
+
+        let mut rows = Vec::new();
+        storage
+            .scan_selected_batches_for_table(
+                89,
+                &[
+                    ScanPredicate {
+                        column_index: 0,
+                        op: ScanPredicateOp::Like,
+                        value: ScalarValue::Text("%widget%".to_string()),
+                        escape: None,
+                    },
+                    ScanPredicate {
+                        column_index: 0,
+                        op: ScanPredicateOp::NotLike,
+                        value: ScalarValue::Text("%.internal%".to_string()),
+                        escape: None,
+                    },
+                ],
+                Some(&[1]),
+                &mut |batch, selected_rows| {
+                    rows.extend(
+                        selected_rows
+                            .into_iter()
+                            .map(|row_idx| batch.columns[0].value_at(row_idx)),
+                    );
+                    Ok(true)
+                },
+            )
+            .expect("selected batch scan should succeed");
+
+        assert_eq!(
+            rows,
+            vec![
+                ScalarValue::Text("keep".to_string()),
+                ScalarValue::Text("keep".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn scan_record_batches_for_table_reports_batch_start_offsets() {
+        let mut storage = InMemoryStorage::default();
+        let rows = (0..=COLUMNAR_BATCH_SIZE)
+            .map(|idx| vec![ScalarValue::Int(idx as i64)])
+            .collect::<Vec<_>>();
+        storage
+            .replace_rows_for_table(90, rows)
+            .expect("replace rows");
+
+        let mut starts = Vec::new();
+        let mut lengths = Vec::new();
+        storage
+            .scan_record_batches_for_table(90, &mut |batch, deleted_rows, batch_start| {
+                starts.push(batch_start);
+                lengths.push((batch.num_rows(), deleted_rows.len()));
+                Ok(true)
+            })
+            .expect("raw batch scan should succeed");
+
+        assert_eq!(starts, vec![0, COLUMNAR_BATCH_SIZE]);
+        assert_eq!(
+            lengths,
+            vec![(COLUMNAR_BATCH_SIZE, COLUMNAR_BATCH_SIZE), (1, 1)]
         );
     }
 

--- a/src/tcop/engine_tests.rs
+++ b/src/tcop/engine_tests.rs
@@ -189,6 +189,73 @@ fn executes_parameterized_expression() {
 }
 
 #[test]
+fn executes_compiled_filter_and_projection_expressions() {
+    let results = run_batch(&[
+        "CREATE TABLE t (id int8, payload text)",
+        "INSERT INTO t SELECT g, format('row-%s', g) FROM generate_series(1, 150) AS g",
+        "SELECT CAST(id AS int4) + 1 FROM t WHERE payload ILIKE 'row-1%' AND CAST(id AS int4) > 100 LIMIT 3",
+    ]);
+    assert_eq!(
+        results[2].rows,
+        vec![
+            vec![ScalarValue::Int(102)],
+            vec![ScalarValue::Int(103)],
+            vec![ScalarValue::Int(104)],
+        ]
+    );
+}
+
+#[test]
+fn executes_wildcard_filter_order_limit_through_selected_offsets() {
+    let results = run_batch(&[
+        "CREATE TABLE t (id int8, event_time int8, url text)",
+        "INSERT INTO t VALUES (1, 30, 'https://example.com/plain'), (2, 10, 'https://example.com/widget/a'), (3, 20, 'https://example.com/widget/b'), (4, 40, 'https://example.com/widget/c')",
+        "SELECT * FROM t WHERE url LIKE '%widget%' ORDER BY event_time LIMIT 2",
+    ]);
+    assert_eq!(
+        results[2].rows,
+        vec![
+            vec![
+                ScalarValue::Int(2),
+                ScalarValue::Int(10),
+                ScalarValue::Text("https://example.com/widget/a".to_string()),
+            ],
+            vec![
+                ScalarValue::Int(3),
+                ScalarValue::Int(20),
+                ScalarValue::Text("https://example.com/widget/b".to_string()),
+            ],
+        ]
+    );
+}
+
+#[test]
+fn executes_grouped_aggregation_with_storage_selected_rows() {
+    let results = run_batch(&[
+        "CREATE TABLE hits (search_phrase text, url text, user_id int8)",
+        "INSERT INTO hits VALUES ('alpha', 'https://example.com/a', 1), ('alpha', 'https://example.com/b', 2), ('beta', 'https://example.com/c', 2), ('beta', 'https://other.test/d', 3), ('', 'https://example.com/skip', 4)",
+        "SELECT search_phrase, MIN(url), COUNT(*) AS c, COUNT(DISTINCT user_id) FROM hits WHERE url LIKE '%example%' AND search_phrase <> '' GROUP BY search_phrase ORDER BY c DESC, search_phrase",
+    ]);
+    assert_eq!(
+        results[2].rows,
+        vec![
+            vec![
+                ScalarValue::Text("alpha".to_string()),
+                ScalarValue::Text("https://example.com/a".to_string()),
+                ScalarValue::Int(2),
+                ScalarValue::Int(2),
+            ],
+            vec![
+                ScalarValue::Text("beta".to_string()),
+                ScalarValue::Text("https://example.com/c".to_string()),
+                ScalarValue::Int(1),
+                ScalarValue::Int(1),
+            ],
+        ]
+    );
+}
+
+#[test]
 fn exposes_pg_catalog_virtual_relations_for_introspection() {
     let results = run_batch(&[
         "CREATE TABLE users (id int8)",


### PR DESCRIPTION
## Summary
- add a bytecode expression evaluator and wire compiled-expression execution into simple filter/projection and aggregation finalization paths
- add lightweight executor profiling plus a `profile_clickbench` helper binary for repeatable ClickBench profiling
- optimize columnar scan, selected-row, aggregation, and wildcard Top-N execution paths, including the q23 raw wildcard path and direct order-key extraction from record batches

## Validation
- cargo test --lib
- cargo fmt --check
- cargo build --release --bin profile_clickbench
- OPENASSAY_EXEC_PROFILE=1 ./target/release/profile_clickbench q23 20
- cargo test --lib executes_wildcard_filter_order_limit_through_selected_offsets
- cargo test --lib wildcard_select_does_not_add_hidden_order_by_columns
- cargo test --lib executes_grouped_aggregation_with_storage_selected_rows
- cargo test --lib executes_compiled_filter_and_projection_expressions

## Performance
- local q23 baseline before final collector tweak: `0.438s / 20`
- local q23 after final collector tweak: `0.425s / 20`
- hotspot movement on the latest run:
  - `storage_scan_record_batches_for_table`: `18.098ms -> 17.494ms`
  - `columnar_offset_topn_pushed_like_stream`: `17.978ms -> 17.373ms`
