### PR TITLE
feat: pg_catalog canonicalization + parse-time param inference (Phase 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,8 @@ object_store = { workspace = true, features = ["aws", "azure", "gcp", "fs"] }
 criterion.workspace = true
 proptest.workspace = true
 tungstenite.workspace = true
+tokio-postgres.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [[bench]]
 name = "engine_bench"

--- a/TESTKIT_FULL_FIX_PLAN.md
+++ b/TESTKIT_FULL_FIX_PLAN.md
@@ -1,0 +1,570 @@
+# OpenAssay Testkit — Full-Fix Plan
+
+Goal: make OpenAssay a spec-conforming in-process Postgres for unit-testing a
+Postgres-compatible Rust library. Real Postgres is still authoritative for
+integration tests; OpenAssay is for fast, isolated, per-test runs.
+
+Written against the gap list from the tokio-postgres / raw-pgwire audit run on
+2026-04-18. The plan says what "spec-correct" means for each subsystem, what
+specifically changes in the code, rough size, and dependencies. No shortcuts:
+each item lands the behavior you'd actually see talking to Postgres 18.
+
+Exit criterion for *every* phase: the existing 12,329-statement regression suite
+(`tests/regression/pg_compat.rs`) still passes 100%, and the WASM build
+(`scripts/build_wasm.sh`) still succeeds.
+
+Size key: **S** = hours, **M** = a day or two, **L** = a week, **L+** = multi-week.
+
+---
+
+## Phase 1 — Unblock Rust ORMs (no parameterised query works today)
+
+These four together are the reason `client.query(&stmt, &[&42i32])` crashes
+every tokio-postgres/sqlx/diesel-async caller with a stack overflow.
+
+### 1.1 Catalog bootstrap uses fixed, PG-canonical OIDs — **M**
+
+**Gap:** `pg_catalog` and `public` schema OIDs come from `OidGenerator::default()`
+starting at `FIRST_NORMAL_OID = 16_384` (`src/catalog/oid.rs:5`). Meanwhile
+`pg_type` rows hardcode `typnamespace = 11`
+(`src/executor/exec_main/table_functions.rs:1532-1551`). The JOIN
+
+```sql
+SELECT t.typname, t.typtype, ...
+FROM pg_catalog.pg_type t
+INNER JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid
+WHERE t.oid = $1
+```
+
+— exactly the query tokio-postgres runs to resolve an unknown type OID —
+returns zero rows. The client re-queries, nests futures, stack-overflows.
+
+**Spec-correct behavior:** Postgres reserves low OIDs for bootstrap catalog
+objects. `pg_catalog` nspname = 11 (`FirstNormalObjectId` in `access/transam.h`
+is 16384; catalog objects are below it). `public` has OID 2200.
+
+**Change:**
+- `src/catalog/oid.rs`: add `pub const PG_CATALOG_NAMESPACE_OID: Oid = 11;
+  pub const PUBLIC_NAMESPACE_OID: Oid = 2200;`
+- `src/catalog/mod.rs::new_bootstrap`: don't call `create_schema` through the
+  OID generator. Insert `pg_catalog` and `public` with the canonical fixed OIDs
+  directly. The generator stays at `FIRST_NORMAL_OID` for user-created objects.
+- `table_functions.rs` virtual rows for `pg_namespace`, `pg_class`,
+  `pg_attribute`: emit the fixed OIDs for builtins.
+
+Verified before filing: `FIRST_NORMAL_OID` appears only in
+`src/catalog/oid.rs` (constant and default). Nothing downstream assumes
+`pg_catalog` is the first allocated OID, so switching to fixed OIDs is a
+local change.
+
+**Depends on:** nothing. **Unblocks:** 1.2, 1.3.
+
+### 1.2 `pg_type` carries every built-in type the engine can produce — **M**
+
+**Gap:** `pg_type` virtual rows list seven types: bool, int8, text, float8,
+date, timestamp, numeric (`table_functions.rs:1531-1551`). Every client that
+resolves an OID outside this set either recurses or falls back to text. No
+int2, int4, float4, varchar, uuid, bytea, timestamptz, json, jsonb, oid, name,
+void, interval, time, timetz, any array type, any range type.
+
+**Spec-correct behavior:** Postgres ships ~400 entries in `pg_type` at cluster
+init. For a pg-compatible test engine, the shippable subset is the OIDs the
+planner/executor can produce. The canonical OIDs and `typlen`/`typbyval`/
+`typtype`/`typcategory` values are fixed by `src/include/catalog/pg_type.dat` in
+the Postgres source tree.
+
+**Change:**
+- New file `src/catalog/builtin_types.rs`: `pub struct BuiltinType { oid, name,
+  typlen, typbyval, typtype, typcategory, typelem, typarray, typbasetype,
+  typinput, typoutput, typnamespace }` plus a `pub const BUILTIN_TYPES: &[...]`
+  array covering at minimum: bool(16), bytea(17), char(18), name(19), int8(20),
+  int2(21), int4(23), regproc(24), text(25), oid(26), xid(28), cid(29), json(114),
+  xml(142), float4(700), float8(701), unknown(705), varchar(1043), bpchar(1042),
+  date(1082), time(1083), timestamp(1114), timestamptz(1184), interval(1186),
+  timetz(1266), numeric(1700), uuid(2950), jsonb(3802), void(2278),
+  record(2249), anyarray(2277), anyelement(2283), plus the `_`-prefixed array
+  variants (`_int4` = 1007, `_text` = 1009, `_float8` = 1022, etc.), plus
+  the range types from 1.3.
+- `table_functions.rs::virtual_relation_rows` for `pg_type`: iterate
+  `BUILTIN_TYPES` plus any user-created types (enums/domains/composites from
+  the catalog). Emit `typnamespace = PG_CATALOG_NAMESPACE_OID` for builtins,
+  user-schema OID for user types.
+- `system_catalogs.rs::virtual_relation_column_defs` for `pg_type`: extend to
+  list every column a pg-driver actually SELECTs — that full set includes
+  `typrelid`, `typdelim`, `typnotnull`, `typstorage`, `typsend`, `typreceive`,
+  `typmodin`, `typmodout`, `typcollation`, `typdefault`, `typacl`. (tokio-postgres
+  selects `typrelid` and clients like asyncpg select `typreceive`/`typsend`.)
+
+**Depends on:** 1.1. **Unblocks:** 1.3, 3.x.
+
+### 1.3 `pg_range`, `pg_proc`, `pg_operator`, `pg_enum`, `pg_description` virtual relations exist — **M**
+
+**Gap:** `pg_range` isn't listed in
+`is_pg_catalog_virtual_relation` (`system_catalogs.rs:46-67`), so
+`SELECT * FROM pg_catalog.pg_range` errors with `42P01 relation does not
+exist`. This is the *first* thing tokio-postgres hits when resolving a type.
+`pg_proc`, `pg_operator`, `pg_enum`, `pg_description` are listed but their
+`virtual_relation_rows` implementations may be missing or sparse — verify case
+by case.
+
+**Spec-correct behavior:** these relations exist in every Postgres install.
+Even when empty they must respond to `SELECT ... FROM` without error, and they
+must have all the columns drivers reference.
+
+**Change:**
+- `system_catalogs.rs`: add `"pg_range"`, `"pg_enum"`, `"pg_description"`,
+  `"pg_operator"`, `"pg_collation"`, `"pg_language"` to
+  `is_pg_catalog_virtual_relation` and `virtual_relation_column_defs`.
+  Columns for each from the PG source tree (`pg_range.h`, `pg_enum.h`, etc.).
+- `table_functions.rs::virtual_relation_rows`: add cases for each. Minimum
+  rows: `pg_range` has the five canonical ranges (int4range=3904, numrange=3906,
+  tsrange=3908, tstzrange=3910, daterange=3912) plus int8range=3926.
+  `pg_language` has `internal`, `c`, `sql`, `plpgsql`.
+  `pg_enum` returns user-declared enum values.
+
+**Depends on:** 1.1, 1.2.
+
+### 1.4 `Execute` must not emit `RowDescription` — **S**
+
+**Gap:** `src/tcop/postgres/mod.rs:819-824`:
+
+```rust
+if !prev_desc_sent {
+    out.push(BackendMessage::RowDescription { fields: fields.clone() });
+    portal.row_description_sent = true;
+}
+```
+
+PG 18 protocol spec, Message Flow / Extended Query: *"Execute doesn't cause
+ReadyForQuery or RowDescription to be issued."* RowDescription is sent only
+in response to Describe (statement or portal) or as part of the simple-query
+response. tokio-postgres's state machine rejects the unexpected message.
+
+**Spec-correct behavior:** Execute's response is exactly one of
+CommandComplete, DataRow×N + CommandComplete, DataRow×N + PortalSuspended,
+EmptyQueryResponse, or ErrorResponse. Nothing else.
+
+**Change:**
+- `src/tcop/postgres/mod.rs:819-824`: delete the block.
+- `Portal::row_description_sent`: delete the field and its initializer.
+- `src/tcop/postgres/tests.rs:100-126 extended_query_flow_requires_sync_for_ready`:
+  the test asserts `out[3]` is RowDescription after Bind+Execute+Sync with no
+  Describe. That test encodes the bug; rewrite to assert `out[3]` is DataRow
+  directly. Add a new test that sends Parse+Bind+Describe(portal)+Execute+Sync
+  and asserts Describe returns RowDescription exactly once.
+
+Caveat worth flagging before deleting the block: psql's prepared-statement
+flow is Parse → Bind → Describe(portal) → Execute → Sync, so psql *does*
+receive RowDescription via Describe and shouldn't regress. But audit every
+in-tree client/test that goes through the extended protocol and confirm
+each sends Describe before Execute. If any skips Describe and depends on
+the out-of-spec RowDescription, it will silently lose column metadata after
+the fix — update it alongside the removal. `src/tcop/postgres/tests.rs` and
+the `pg_compat.rs` regression harness are the two places to look.
+
+**Depends on:** nothing. **Unblocks:** tokio-postgres's `query()` path for
+already-prepared statements, but on its own it's not sufficient — 1.1/1.2/1.3
+must also land or type-OID lookup still loops.
+
+---
+
+## Phase 2 — Typed parameter binding and result encoding — **L**
+
+### 2.1 Introduce `SqlType` carried separately from `ScalarValue`'s storage
+
+**Gap:** `ScalarValue` (`src/storage/tuple.rs:19-31`) has variants Null, Bool,
+Int(i64), Float(f64), Numeric, Text, Array, Record, Vector. It cannot
+distinguish int2 from int4 from int8, or varchar from text, or timestamp from
+timestamptz (Date/Timestamp are stored as `Text`). The result is that
+`RowDescription` always reports int8 for any integer column and text for any
+date/timestamp/varchar/uuid/bytea/json/jsonb. Any ORM that `try_get::<i32>`s or
+decodes uuid fails.
+
+**Spec-correct behavior:** Every column in `RowDescription` carries a specific
+type OID that matches the declared SQL type of the expression. Per PG docs
+RowDescription fields: *"typeid — the object ID of the field's data type.
+typsize — the data type size … typmod — type modifier …"*. Clients decode the
+value using that OID.
+
+**Design:**
+- Add `pub enum SqlType { Bool, Int2, Int4, Int8, Float4, Float8, Numeric{p:Option<u8>, s:Option<i16>}, Text, Varchar(Option<u32>), BpChar(Option<u32>), Bytea, Uuid, Date, Time, Timetz, Timestamp, Timestamptz, Interval, Json, Jsonb, Oid, Array(Box<SqlType>), Domain{base: Box<SqlType>, oid: Oid}, Enum(Oid), Composite(Oid), Range(Oid), Vector(usize), Unknown }` in `src/types/sql_type.rs`.
+- `impl SqlType { fn oid(&self) -> u32; fn typmod(&self) -> i32; fn typlen(&self) -> i16; }` — computes PG wire-level fields.
+- Storage (`ScalarValue`) stays tagged by *runtime* representation. Type
+  information lives in the column descriptor, not the value.
+- Planner column descriptors (`src/planner/...`) grow a `sql_type: SqlType`
+  field alongside the existing internal representation.
+- Analyzer (`src/analyzer/types.rs`) computes `SqlType` during type inference.
+  `CAST(x AS int4)` yields `SqlType::Int4`; the executor still stores the
+  value as `ScalarValue::Int`, but the descriptor says int4.
+
+**Change scope:**
+- `src/types/sql_type.rs` — new file, ~400 LOC.
+- `src/analyzer/types.rs` — extend inference to produce SqlType for every
+  expression.
+- `src/planner/logical.rs`, `src/planner/physical.rs` — carry SqlType on column
+  descriptors.
+- `src/tcop/postgres/mod.rs` — `describe_fields_for_plan`,
+  `infer_row_description_fields` read SqlType off the plan and emit the
+  correct OID / typmod / typlen.
+- `src/tcop/postgres/encoding.rs::encode_binary_scalar` — extend to every
+  SqlType, not just the 6 OIDs it handles today. Date→days-since-2000 i32,
+  Timestamp→microseconds-since-2000 i64, Timestamptz→same (UTC), UUID→16 bytes,
+  Numeric→PG's binary numeric format, Bytea→raw bytes, Json→text, Jsonb→1-byte
+  version prefix + text, Arrays→recursive binary array format per PG docs.
+
+**Size:** L+ (realistically two to three weeks). `src/analyzer/types.rs`
+plus every `src/planner/` site plus the binary encoders for ~20 types plus
+plumbing SqlType through every executor node is the item most likely to
+balloon. This is the primary risk item in the plan, alongside 3.1.
+
+**Depends on:** 1.1, 1.2 (need the full pg_type to validate against).
+**Unblocks:** 2.2, 2.3, 3.x.
+
+### 2.2 Binary parameter decode stops round-tripping through text — **M**
+
+**Gap:** `src/tcop/postgres/extended_query.rs:298`:
+
+```rust
+Ok(decode_binary_scalar(raw, type_oid, "bind parameter")?.render())
+```
+
+Binary bytes are decoded to a typed value, then `render()`ed back to text,
+then the rest of the pipeline treats the parameter as text. Precision and
+type information are lost at this boundary. Raw-wire probe showed binding
+`42i32` (`0x0000002a` in 4 BE bytes) round-trips through the query pipeline
+and comes back as `0` — the value itself is lost.
+
+**Spec-correct behavior:** Bind decodes bytes using the parameter's declared
+type OID (from Parse or from the Bind message itself) and stores the typed
+value. The executor substitutes that typed value wherever `$n` appears; no
+text re-parsing, no precision loss.
+
+**Change:**
+- `decode_bind_parameter` / `decode_binary_bind_parameter`: return
+  `(ScalarValue, SqlType)`, not `Option<String>`.
+- `Portal::params` changes type from `Vec<Option<String>>` to
+  `Vec<Option<(ScalarValue, SqlType)>>`.
+- Every consumer of `Portal::params` in the executor (primarily parameter
+  substitution in `exec_expr.rs` and the planner's bound-param resolver)
+  reads typed values instead of text.
+- Text-format Bind (`format_code = 0`) still parses the text, but uses the
+  declared type's parser (int4 → i32, not blanket text).
+
+**Depends on:** 2.1. **Size:** M.
+
+### 2.3 `NULL` no longer forces binary encoding for the whole row — **S**
+
+**Gap:** `src/tcop/postgres/encoding.rs:13-14`:
+
+```rust
+let requires_binary = fields.iter().any(|field| field.format_code == 1)
+    || row.iter().any(|value| matches!(value, ScalarValue::Null));
+```
+
+NULL is format-independent at the wire level — `DataRow` encodes NULL as a
+length-prefix of `-1` regardless of the column's format code. Forcing binary
+for any row that contains a NULL means a text-format result with one NULL
+column gets binary-encoded, and clients asking for text get binary bytes.
+
+**Spec-correct behavior:** Format code is per-column, determined by the Bind
+message's `result_format_codes`, not by whether the value is NULL.
+
+**Change:** delete the `|| row.iter().any(...)` disjunct. `encode_result_field`
+already handles NULL correctly (returns `None` → length-prefix `-1`).
+
+**Depends on:** nothing.
+
+---
+
+## Phase 3 — Test isolation: real per-database catalogs — **L+**
+
+### 3.1 `CREATE DATABASE` / `DROP DATABASE` with actual storage isolation
+
+**Gap:** OpenAssay's catalog and heap storage are process-global (see
+`catalog/mod.rs::with_global_state_lock` and the comments in `AGENTS.md`
+about global state). `CREATE DATABASE foo` fails at parse — `CREATE` doesn't
+list `DATABASE` in its alternatives.
+
+For sqlx specifically, `#[sqlx::test]` creates one fresh database per test
+via `CREATE DATABASE _sqlx_test_<n>`, runs migrations into it, hands a pool
+scoped to that database to the test, and drops the DB at teardown. Without
+real per-database isolation, the whole macro is unusable.
+
+**Spec-correct behavior:** A Postgres cluster hosts multiple databases. Each
+database has its own catalog (its own pg_class, pg_attribute, pg_type for
+user-defined types) and its own heap. A connection selects one database at
+startup (`dbname=foo`) and cannot see other databases' user objects.
+`pg_database` lists all databases in the cluster; it is cluster-global.
+
+**Design:**
+- Lift the process-global `CATALOG` and `STORAGE` statics into a
+  `Cluster { databases: HashMap<Oid, Database> }` where each `Database` owns
+  its own `Catalog` and `Storage`.
+- `pg_database` becomes the cluster-level catalog, backed by the set of
+  databases.
+- The pg_server session picks a Database at startup based on the `dbname`
+  parameter and dispatches all work against its catalog + storage.
+- WASM `src/browser.rs` creates a cluster with a single default database.
+  The public signatures `execute_sql`, `execute_sql_json`, `execute_sql_arrow`,
+  `execute_sql_http`, `execute_sql_http_json` and the state-snapshot helpers
+  stay byte-identical — they take `&str` and return `String`, which doesn't
+  change under a Cluster lift. Sub-item to confirm during 3.1: build
+  `scripts/build_wasm.sh` and diff the emitted `.d.ts` against pre-lift; zero
+  diff required to pass this phase.
+- `CREATE DATABASE name [WITH TEMPLATE t]`: parser, analyzer, executor.
+  Creates a new empty Database with its own fresh Catalog/Storage bootstrap.
+- `DROP DATABASE name [WITH (FORCE)]`: removes the Database. Must fail if
+  any connection is currently attached to it (return SQLSTATE 55006
+  `object_in_use`).
+- The "global state lock" pattern used today for test isolation
+  (`with_global_state_lock`) must keep working — test helpers create a
+  scoped cluster and destroy it.
+
+**Files touched:** `src/catalog/mod.rs` (Cluster/Database split),
+`src/tcop/engine.rs` (sessions pick a Database), `src/tcop/postgres/mod.rs`
+(startup message reads dbname, attaches to Database), `src/browser.rs`
+(single-Database shim), `src/parser/sql_parser/admin.rs` (parse CREATE/DROP
+DATABASE), new `src/commands/database.rs`, `src/tcop/utility.rs` (dispatch).
+
+**Size:** L+ (multi-week). Largest item in the plan.
+
+**Depends on:** 1.1-1.4 (so the test suite still runs after the lift).
+
+### 3.2 Per-test transactional fixtures (testkit API surface) — **M**
+
+**Gap:** Even with 3.1 the ergonomics of "start a fresh DB per test, run
+schema, run the test" are slow (CREATE DATABASE + migrations per test). The
+PGlite-style pattern — spin one database with schema pre-loaded, then wrap
+each test in `BEGIN; ... ROLLBACK;` — is 10-100× faster for suites that only
+read/write and don't depend on mid-test committed state.
+
+**Spec-correct behavior:** OpenAssay already supports BEGIN/COMMIT/ROLLBACK
+and SAVEPOINT/ROLLBACK TO (`src/tcop/postgres/transaction.rs`). What's
+missing is a stable Rust API in the `openassay` crate that exposes this
+without needing to go through pgwire over TCP.
+
+**Design:**
+- New module `src/testkit.rs` (feature-gated) exposing:
+  ```rust
+  pub struct TestCluster { /* owns a Cluster */ }
+  impl TestCluster {
+      pub fn new() -> Self;
+      pub fn load_schema(&self, sql: &str) -> Result<()>;
+      pub fn connect(&self) -> TestClient; // tokio_postgres-like handle
+      pub async fn run_in_rollback<F, T>(&self, f: F) -> T; // BEGIN; f; ROLLBACK
+  }
+  ```
+- `TestClient` wraps an in-process session — no sockets. Provides
+  `query`, `execute`, `transaction` with signatures close to
+  `tokio_postgres::Client` so library tests that are written against
+  tokio-postgres compile unchanged or with a single type alias.
+- Documented pattern in `testkit/README.md`: "wrap each test in
+  `run_in_rollback`."
+
+**Size:** M. **Depends on:** 3.1, 5.2 (typed parameters).
+
+---
+
+## Phase 4 — Error-code fidelity — **M**
+
+### 4.1 SQLSTATE on every error path
+
+**Gap:** Syntax errors arrive at the client with no SQLSTATE. CHECK
+constraint violations return `XX000` (internal_error). FK violations return
+`XX000`. Unique violations (`23505`) and NOT NULL violations (`23502`) are
+correctly coded.
+
+**Spec-correct behavior:** Every error has an SQLSTATE. The Postgres source
+tree's `errcodes.txt` is the canonical mapping. For this work the required
+subset is:
+- `42601` syntax_error
+- `42P01` undefined_table
+- `42703` undefined_column
+- `42804` datatype_mismatch
+- `22P02` invalid_text_representation (bad input to a type parser)
+- `23502` not_null_violation (already correct)
+- `23503` foreign_key_violation (currently XX000)
+- `23505` unique_violation (already correct)
+- `23514` check_violation (currently XX000)
+- `25P02` in_failed_sql_transaction
+- `40001` serialization_failure (not reachable yet but reserve)
+- `3D000` invalid_catalog_name
+- `55006` object_in_use (for DROP DATABASE)
+
+**Change:**
+- `EngineError` (`src/tcop/engine.rs`) grows a `sqlstate: Option<&'static str>`
+  field and a `EngineError::with_sqlstate` builder.
+- Every error-raising site in the executor passes the right code. The
+  compiler will help find sites; grep for `EngineError { message:` and fix
+  each. Pay particular attention to constraint-violation paths in
+  `src/executor/`.
+- `src/parser/...` errors need a `ParseError::sqlstate = "42601"` default.
+- `src/tcop/postgres/mod.rs::encode_error_response` reads the code off the
+  error and emits an `S` field (`SQLSTATE`) in the ErrorResponse message.
+  It may already do this for some paths — audit and make it mandatory.
+
+**Size:** M. **Depends on:** nothing (can ship earlier, but 1.x/2.x take
+priority).
+
+### 4.2 Aborted-transaction semantics — **S**
+
+**Gap:** Not audited in this round. The hook exists
+(`is_aborted_transaction_block` in `src/tcop/postgres/mod.rs`) but it hasn't
+been verified that mid-TX errors correctly set the block to aborted, that
+subsequent statements return `25P02`, and that `ROLLBACK TO SAVEPOINT`
+recovers the block to non-aborted state.
+
+**Spec-correct behavior:** Once any statement in an explicit transaction
+errors, all subsequent statements until `ROLLBACK` or `ROLLBACK TO SAVEPOINT`
+return `ERROR: current transaction is aborted, commands ignored until end of
+transaction block` with SQLSTATE `25P02`. After `ROLLBACK TO SAVEPOINT` the
+block returns to a clean state at that savepoint.
+
+**Change:** write a test in `tests/regression/` that drives the extended
+protocol through an erroring statement and asserts the subsequent
+CommandComplete / ErrorResponse sequence. Fix any drift.
+
+**Size:** S.
+
+---
+
+## Phase 5 — Parser holes — **M total**
+
+Each sub-item is S unless noted. All touch `src/parser/sql_parser/*.rs`,
+`src/parser/ast.rs`, and the relevant planner/executor dispatch.
+
+### 5.1 Date/time keyword literals
+`CURRENT_TIMESTAMP`, `CURRENT_DATE`, `CURRENT_TIME`, `LOCALTIMESTAMP`,
+`LOCALTIME`. Per PG these are parsed as special keyword calls (not regular
+functions); lexer recognises them as keywords, parser emits
+`Expr::SpecialFunctionCall { name: CurrentTimestamp, precision: Option<u32> }`.
+Executor dispatches to the same implementation as `now()` / `current_date()`.
+
+### 5.2 `AT TIME ZONE` clause
+`timestamp AT TIME ZONE 'UTC'` is a binary operator in PG's grammar, not a
+function. Parser: new production in expression hierarchy at the same level
+as `::` cast. AST: `Expr::AtTimeZone { value: Box<Expr>, zone: Box<Expr> }`.
+Executor: `timestamp AT TIME ZONE` returns timestamptz, `timestamptz AT TIME
+ZONE` returns timestamp. Implementation exists in `src/utils/adt/datetime.rs`
+— just wire the syntax.
+
+### 5.3 `CREATE TYPE foo AS (col1 type, col2 type)` — composite types — **M**
+Parser: already has `CREATE TYPE ... AS ENUM`; add the composite branch.
+Catalog: new `CompositeType { oid, schema, attributes: Vec<(String, SqlType)> }`
+alongside enums. `pg_type` lists it with `typtype='c'`, `typrelid` points at
+a `pg_class` row of `relkind='c'`. `pg_attribute` lists the attributes.
+Analyzer/executor: values of composite types constructed via `ROW(...)` or
+directly, accessed via `.field`.
+
+### 5.4 `CREATE TYPE foo AS RANGE (subtype=...)` — range types — **M**
+Parser: new branch. Catalog: range entries in `pg_range`.
+Operators: `<@`, `@>`, `&&`, `<<`, `>>`, plus range constructors and
+`lower()`/`upper()`/`isempty()` functions. This is substantial — the range
+algebra is non-trivial. If out of scope, mark explicitly: range types are
+rare in library tests; can be gated on user demand.
+
+### 5.5 `CREATE [OR REPLACE] PROCEDURE` — **L+ if plpgsql, S if SQL-only**
+`CREATE PROCEDURE name(args) LANGUAGE sql AS 'BEGIN ...'` is tractable as a
+prepared-SQL wrapper. `LANGUAGE plpgsql` requires implementing a whole
+procedural language (variables, IF/LOOP/WHILE, EXCEPTION blocks, FOR record
+iteration). **Declared out of scope for testkit v1.** Anything sqlx/Diesel
+do with procedures is usually via raw SQL in migrations; if a user's code
+under test calls plpgsql they must use real Postgres for that test.
+
+### 5.6 `EXCLUDE USING gist (col WITH &&)` — **M, conditional**
+Exclusion constraints with GiST require an actual GiST index. Mark
+out-of-scope for testkit v1; document as "use real Postgres for GiST/GIN
+index tests."
+
+### 5.7 `uuid_generate_v1mc()` — **S**
+Part of the `uuid-ossp` extension. Already registered as a CREATE EXTENSION
+no-op. Implement `uuid_generate_v1()`, `uuid_generate_v1mc()`,
+`uuid_generate_v4()`, `uuid_generate_v5(namespace, name)` in
+`src/utils/adt/` and register in `src/analyzer/functions.rs`. The `uuid`
+crate already has v1/v4/v5 generators.
+
+---
+
+## Phase 6 — Extensions sqlx's `setup.sql` uses — **L total, optional**
+
+Each is independent. Declared optional because library code under test
+usually doesn't use these types — they show up in sqlx's own test fixtures
+but not in application schemas.
+
+- **citext** — M. Case-insensitive text. New type OID reserved by the
+  extension at install; comparisons lowercase both sides. Declare and
+  implement alongside text.
+- **hstore** — L. Key-value map. New type + operators (`->`, `?`, `?&`,
+  `?|`, `||`, `-`) + functions (`hstore_to_json`, `hstore_to_array`, etc.).
+- **ltree** — L. Labeled tree paths. New type + operators (`@>`, `<@`,
+  `~`, `?`, `@`) + GiST index support (without GiST the ops still work,
+  just unindexed).
+- **cube** — L. N-dim cube type. Similar scope to ltree.
+
+Recommendation: ship citext (it's used widely in real apps), defer the
+other three unless a concrete user asks.
+
+---
+
+## Phase 7 — Protocol and misc — **M**
+
+### 7.1 `COPY FROM STDIN` — **S to M, depends on root cause**
+`COPY ci FROM STDIN` returns "unexpected message from server" under
+tokio-postgres. Root cause not yet traced. Likely a CopyInResponse /
+CopyData / CopyDone sequencing bug in `src/tcop/postgres/copy_protocol.rs`.
+Trace via socat and fix. **First: investigate. Estimate locks once root
+cause is known.**
+
+### 7.2 Extended-protocol LISTEN/NOTIFY — **S**
+Simple-query path works. Verify extended-protocol path; tokio-postgres'
+`client.batch_execute("LISTEN ch")` and the notification delivery loop
+should fire. Write a tokio-postgres integration test.
+
+---
+
+## Cross-cutting: regressions and CI
+
+Each phase has a non-negotiable exit check:
+
+- `cargo test` green (unit tests).
+- `cargo test --test regression` green (full 12,329-statement PG compat
+  suite).
+- `cargo clippy -- -D warnings` clean.
+- `scripts/build_wasm.sh` succeeds.
+- New tokio-postgres-targeted test file `tests/tokio_postgres_compat.rs`:
+  one case per gap fixed this phase. It becomes the regression harness for
+  "unit-testing a Postgres-compatible lib works."
+
+---
+
+## Sequencing summary
+
+| Phase | Items | Size | Blocks |
+|-------|-------|------|--------|
+| 1 | Catalog fixed OIDs, full `pg_type`, `pg_range`, Execute-no-RowDesc | M+M+M+S | *anything talking to OpenAssay with params* |
+| 2 | `SqlType` refactor, typed binds, NULL-format fix | L++M+S | ORM decoding correctness |
+| 3 | `CREATE DATABASE` + testkit API | L+ + M | sqlx::test, testkit v1 |
+| 4 | SQLSTATE fidelity + tx-aborted semantics | M+S | client error-matching |
+| 5 | Parser holes (date keywords, AT TIME ZONE, composite, uuid_generate) | S×4 | sqlx setup.sql |
+| 6 | Extensions (citext first, rest optional) | M–L each | app schemas using them |
+| 7 | COPY IN, LISTEN/NOTIFY extended | S–M | protocol completeness |
+
+Phase 1 alone (roughly 3–5 days of focused work) is the "tokio-postgres can
+talk to OpenAssay" milestone. Phase 1+2 is "sqlx/Diesel queries decode
+correctly." Phase 1+2+3 is "`#[sqlx::test]` works." Phase 1–4 is "real
+libraries' existing test suites run against OpenAssay without patching."
+
+## Out of scope for testkit v1 (call out explicitly)
+
+- plpgsql (Phase 5.5)
+- GiST / GIN / SP-GiST indexes and `EXCLUDE USING gist` (Phase 5.6)
+- hstore / ltree / cube (Phase 6 optional)
+- Triggers, RULES, partitioning, inheritance (mentioned in README as
+  out-of-scope; reconfirmed)
+- `PREPARE TRANSACTION` / two-phase commit
+- Replication slots, logical replication as a *source* (current
+  LOGICAL REPLICATION support is as a *sink*)
+
+If a user's test suite hits any of these, the guidance is: use real Postgres
+for that test. Testkit's job is to cover the common path fast; integration
+tests against real Postgres stay the source of truth.

--- a/src/catalog/builtin_types.rs
+++ b/src/catalog/builtin_types.rs
@@ -1,0 +1,427 @@
+//! Canonical Postgres built-in types surfaced through `pg_catalog.pg_type`.
+//!
+//! Clients (tokio-postgres, asyncpg, psycopg, node-postgres, …) resolve
+//! unknown type OIDs by querying `pg_catalog.pg_type`. If the JOIN onto
+//! `pg_namespace` or the expected column set doesn't line up, those clients
+//! fail — often catastrophically, by infinite-retry. This module is the
+//! source of truth for every PG type OID the engine hands out on the wire.
+//!
+//! OID, typlen, typbyval, typtype, typcategory, typelem, and typarray values
+//! come from `src/include/catalog/pg_type.dat` in the Postgres source tree.
+//! We ship the subset the planner/executor can actually produce plus the
+//! pseudo-types every driver expects to find (`void`, `record`, `unknown`).
+
+use super::oid::Oid;
+
+#[derive(Debug, Clone, Copy)]
+pub struct BuiltinType {
+    pub oid: Oid,
+    pub name: &'static str,
+    /// Fixed byte length, or -1 for variable-length.
+    pub typlen: i16,
+    /// True if values are passed by value (fixed-size, register-width).
+    pub typbyval: bool,
+    /// 'b' = base, 'c' = composite, 'd' = domain, 'e' = enum, 'p' = pseudo,
+    /// 'r' = range, 'm' = multirange.
+    pub typtype: char,
+    /// Type category (pg_type.dat's typcategory). Drivers use this to group
+    /// related types ('N' numeric, 'S' string, 'D' date/time, 'B' boolean,
+    /// 'A' array, 'E' enum, 'P' pseudo, 'U' user-defined, 'V' bitstring,
+    /// 'X' unknown, 'Z' internal-use).
+    pub typcategory: char,
+    /// OID of the element type for array types, else 0.
+    pub typelem: Oid,
+    /// OID of the corresponding array type, else 0.
+    pub typarray: Oid,
+    /// Delimiter used by array_in / array_out. Almost always ','.
+    pub typdelim: char,
+    /// Alignment: 'c' char, 's' short (2), 'i' int (4), 'd' double (8).
+    pub typalign: char,
+    /// Storage strategy: 'p' plain, 'e' external, 'm' main, 'x' extended.
+    pub typstorage: char,
+}
+
+const fn base(
+    oid: Oid,
+    name: &'static str,
+    typlen: i16,
+    typbyval: bool,
+    typcategory: char,
+    typarray: Oid,
+    typalign: char,
+    typstorage: char,
+) -> BuiltinType {
+    BuiltinType {
+        oid,
+        name,
+        typlen,
+        typbyval,
+        typtype: 'b',
+        typcategory,
+        typelem: 0,
+        typarray,
+        typdelim: ',',
+        typalign,
+        typstorage,
+    }
+}
+
+const fn array(oid: Oid, name: &'static str, element_oid: Oid, typalign: char) -> BuiltinType {
+    BuiltinType {
+        oid,
+        name,
+        typlen: -1,
+        typbyval: false,
+        typtype: 'b',
+        typcategory: 'A',
+        typelem: element_oid,
+        typarray: 0,
+        typdelim: ',',
+        typalign,
+        typstorage: 'x',
+    }
+}
+
+const fn pseudo(oid: Oid, name: &'static str, typcategory: char) -> BuiltinType {
+    BuiltinType {
+        oid,
+        name,
+        typlen: 4,
+        typbyval: true,
+        typtype: 'p',
+        typcategory,
+        typelem: 0,
+        typarray: 0,
+        typdelim: ',',
+        typalign: 'i',
+        typstorage: 'p',
+    }
+}
+
+/// Built-in types shipped in `pg_catalog.pg_type`. OIDs and ancillary fields
+/// match the stock Postgres bootstrap catalog. Kept sorted by OID so pg_type
+/// scans return a stable, PG-like ordering.
+pub const BUILTIN_TYPES: &[BuiltinType] = &[
+    // Boolean
+    base(16, "bool", 1, true, 'B', 1000, 'c', 'p'),
+    // Binary
+    base(17, "bytea", -1, false, 'U', 1001, 'i', 'x'),
+    // Character types
+    base(18, "char", 1, true, 'S', 1002, 'c', 'p'),
+    base(19, "name", 64, false, 'S', 1003, 'c', 'p'),
+    // Integers
+    base(20, "int8", 8, true, 'N', 1016, 'd', 'p'),
+    base(21, "int2", 2, true, 'N', 1005, 's', 'p'),
+    base(22, "int2vector", -1, false, 'A', 1006, 'i', 'p'),
+    base(23, "int4", 4, true, 'N', 1007, 'i', 'p'),
+    // OID family
+    base(24, "regproc", 4, true, 'N', 1008, 'i', 'p'),
+    base(25, "text", -1, false, 'S', 1009, 'i', 'x'),
+    base(26, "oid", 4, true, 'N', 1028, 'i', 'p'),
+    base(27, "tid", 6, false, 'U', 1010, 's', 'p'),
+    base(28, "xid", 4, true, 'U', 1011, 'i', 'p'),
+    base(29, "cid", 4, true, 'U', 1012, 'i', 'p'),
+    base(30, "oidvector", -1, false, 'A', 1013, 'i', 'p'),
+    // JSON
+    base(114, "json", -1, false, 'U', 199, 'i', 'x'),
+    base(142, "xml", -1, false, 'U', 143, 'i', 'x'),
+    // Arrays of low-OID types (sorted near low OIDs to keep consistency)
+    array(143, "_xml", 142, 'i'),
+    array(199, "_json", 114, 'i'),
+    // Geometric (complete the low-OID block even though the executor doesn't
+    // produce them — drivers still look these up when mapping OIDs).
+    base(600, "point", 16, false, 'G', 1017, 'd', 'p'),
+    base(601, "lseg", 32, false, 'G', 1018, 'd', 'p'),
+    base(602, "path", -1, false, 'G', 1019, 'd', 'x'),
+    base(603, "box", 32, false, 'G', 1020, 'd', 'p'),
+    base(604, "polygon", -1, false, 'G', 1027, 'd', 'x'),
+    base(628, "line", 24, false, 'G', 629, 'd', 'p'),
+    array(629, "_line", 628, 'd'),
+    // Network
+    base(650, "cidr", -1, false, 'I', 651, 'i', 'm'),
+    array(651, "_cidr", 650, 'i'),
+    // Floats
+    base(700, "float4", 4, true, 'N', 1021, 'i', 'p'),
+    base(701, "float8", 8, true, 'N', 1022, 'd', 'p'),
+    base(718, "circle", 24, false, 'G', 719, 'd', 'p'),
+    array(719, "_circle", 718, 'd'),
+    // Money
+    base(790, "money", 8, true, 'N', 791, 'd', 'p'),
+    array(791, "_money", 790, 'd'),
+    // MAC address
+    base(829, "macaddr", 6, false, 'U', 1040, 'i', 'p'),
+    base(869, "inet", -1, false, 'I', 1041, 'i', 'm'),
+    // Low-OID arrays
+    array(1000, "_bool", 16, 'c'),
+    array(1001, "_bytea", 17, 'i'),
+    array(1002, "_char", 18, 'c'),
+    array(1003, "_name", 19, 'c'),
+    array(1005, "_int2", 21, 's'),
+    array(1006, "_int2vector", 22, 'i'),
+    array(1007, "_int4", 23, 'i'),
+    array(1008, "_regproc", 24, 'i'),
+    array(1009, "_text", 25, 'i'),
+    array(1010, "_tid", 27, 's'),
+    array(1011, "_xid", 28, 'i'),
+    array(1012, "_cid", 29, 'i'),
+    array(1013, "_oidvector", 30, 'i'),
+    array(1014, "_bpchar", 1042, 'i'),
+    array(1015, "_varchar", 1043, 'i'),
+    array(1016, "_int8", 20, 'd'),
+    array(1017, "_point", 600, 'd'),
+    array(1018, "_lseg", 601, 'd'),
+    array(1019, "_path", 602, 'd'),
+    array(1020, "_box", 603, 'd'),
+    array(1021, "_float4", 700, 'i'),
+    array(1022, "_float8", 701, 'd'),
+    array(1027, "_polygon", 604, 'd'),
+    array(1028, "_oid", 26, 'i'),
+    // Character types (bpchar / varchar)
+    base(1042, "bpchar", -1, false, 'S', 1014, 'i', 'x'),
+    base(1043, "varchar", -1, false, 'S', 1015, 'i', 'x'),
+    // Date/time
+    base(1082, "date", 4, true, 'D', 1182, 'i', 'p'),
+    base(1083, "time", 8, true, 'D', 1183, 'd', 'p'),
+    base(1114, "timestamp", 8, true, 'D', 1115, 'd', 'p'),
+    array(1115, "_timestamp", 1114, 'd'),
+    array(1182, "_date", 1082, 'i'),
+    array(1183, "_time", 1083, 'd'),
+    base(1184, "timestamptz", 8, true, 'D', 1185, 'd', 'p'),
+    array(1185, "_timestamptz", 1184, 'd'),
+    base(1186, "interval", 16, false, 'T', 1187, 'd', 'p'),
+    array(1187, "_interval", 1186, 'd'),
+    array(1040, "_macaddr", 829, 'i'),
+    array(1041, "_inet", 869, 'i'),
+    base(1266, "timetz", 12, false, 'D', 1270, 'd', 'p'),
+    array(1270, "_timetz", 1266, 'd'),
+    // Bit string
+    base(1560, "bit", -1, false, 'V', 1561, 'i', 'x'),
+    array(1561, "_bit", 1560, 'i'),
+    base(1562, "varbit", -1, false, 'V', 1563, 'i', 'x'),
+    array(1563, "_varbit", 1562, 'i'),
+    // Numeric
+    base(1700, "numeric", -1, false, 'N', 1231, 'i', 'm'),
+    array(1231, "_numeric", 1700, 'i'),
+    // Refcursor
+    base(1790, "refcursor", -1, false, 'U', 2201, 'i', 'x'),
+    array(2201, "_refcursor", 1790, 'i'),
+    // Pseudo-types (needed by many drivers' type-resolution flow)
+    pseudo(2249, "record", 'P'),
+    pseudo(2275, "cstring", 'P'),
+    pseudo(2276, "any", 'P'),
+    pseudo(2277, "anyarray", 'P'),
+    pseudo(2278, "void", 'P'),
+    pseudo(2279, "trigger", 'P'),
+    pseudo(2280, "language_handler", 'P'),
+    pseudo(2281, "internal", 'P'),
+    pseudo(2283, "anyelement", 'P'),
+    pseudo(2776, "anynonarray", 'P'),
+    pseudo(3500, "anyenum", 'P'),
+    pseudo(3831, "anyrange", 'P'),
+    pseudo(4537, "anymultirange", 'P'),
+    // UUID
+    base(2950, "uuid", 16, false, 'U', 2951, 'c', 'p'),
+    array(2951, "_uuid", 2950, 'c'),
+    // Text search
+    base(3614, "tsvector", -1, false, 'U', 3643, 'i', 'x'),
+    array(3643, "_tsvector", 3614, 'i'),
+    base(3615, "tsquery", -1, false, 'U', 3645, 'i', 'x'),
+    array(3645, "_tsquery", 3615, 'i'),
+    // JSONB
+    base(3802, "jsonb", -1, false, 'U', 3807, 'i', 'x'),
+    array(3807, "_jsonb", 3802, 'i'),
+    // Range types
+    BuiltinType {
+        oid: 3904,
+        name: "int4range",
+        typlen: -1,
+        typbyval: false,
+        typtype: 'r',
+        typcategory: 'R',
+        typelem: 0,
+        typarray: 3905,
+        typdelim: ',',
+        typalign: 'i',
+        typstorage: 'x',
+    },
+    array(3905, "_int4range", 3904, 'i'),
+    BuiltinType {
+        oid: 3906,
+        name: "numrange",
+        typlen: -1,
+        typbyval: false,
+        typtype: 'r',
+        typcategory: 'R',
+        typelem: 0,
+        typarray: 3907,
+        typdelim: ',',
+        typalign: 'i',
+        typstorage: 'x',
+    },
+    array(3907, "_numrange", 3906, 'i'),
+    BuiltinType {
+        oid: 3908,
+        name: "tsrange",
+        typlen: -1,
+        typbyval: false,
+        typtype: 'r',
+        typcategory: 'R',
+        typelem: 0,
+        typarray: 3909,
+        typdelim: ',',
+        typalign: 'd',
+        typstorage: 'x',
+    },
+    array(3909, "_tsrange", 3908, 'd'),
+    BuiltinType {
+        oid: 3910,
+        name: "tstzrange",
+        typlen: -1,
+        typbyval: false,
+        typtype: 'r',
+        typcategory: 'R',
+        typelem: 0,
+        typarray: 3911,
+        typdelim: ',',
+        typalign: 'd',
+        typstorage: 'x',
+    },
+    array(3911, "_tstzrange", 3910, 'd'),
+    BuiltinType {
+        oid: 3912,
+        name: "daterange",
+        typlen: -1,
+        typbyval: false,
+        typtype: 'r',
+        typcategory: 'R',
+        typelem: 0,
+        typarray: 3913,
+        typdelim: ',',
+        typalign: 'i',
+        typstorage: 'x',
+    },
+    array(3913, "_daterange", 3912, 'i'),
+    BuiltinType {
+        oid: 3926,
+        name: "int8range",
+        typlen: -1,
+        typbyval: false,
+        typtype: 'r',
+        typcategory: 'R',
+        typelem: 0,
+        typarray: 3927,
+        typdelim: ',',
+        typalign: 'd',
+        typstorage: 'x',
+    },
+    array(3927, "_int8range", 3926, 'd'),
+];
+
+/// Range-type metadata surfaced through `pg_catalog.pg_range`. Each entry's
+/// `rngtypid` matches the corresponding BUILTIN_TYPES row.
+pub struct BuiltinRange {
+    pub rngtypid: Oid,
+    pub rngsubtype: Oid,
+    pub rngmultitypid: Oid,
+}
+
+pub const BUILTIN_RANGES: &[BuiltinRange] = &[
+    BuiltinRange {
+        rngtypid: 3904,
+        rngsubtype: 23,
+        rngmultitypid: 4451,
+    },
+    BuiltinRange {
+        rngtypid: 3906,
+        rngsubtype: 1700,
+        rngmultitypid: 4532,
+    },
+    BuiltinRange {
+        rngtypid: 3908,
+        rngsubtype: 1114,
+        rngmultitypid: 4533,
+    },
+    BuiltinRange {
+        rngtypid: 3910,
+        rngsubtype: 1184,
+        rngmultitypid: 4534,
+    },
+    BuiltinRange {
+        rngtypid: 3912,
+        rngsubtype: 1082,
+        rngmultitypid: 4535,
+    },
+    BuiltinRange {
+        rngtypid: 3926,
+        rngsubtype: 20,
+        rngmultitypid: 4536,
+    },
+];
+
+/// Built-in procedural languages surfaced through `pg_catalog.pg_language`.
+pub struct BuiltinLanguage {
+    pub oid: Oid,
+    pub name: &'static str,
+    pub lanispl: bool,
+    pub lanpltrusted: bool,
+}
+
+pub const BUILTIN_LANGUAGES: &[BuiltinLanguage] = &[
+    BuiltinLanguage {
+        oid: 12,
+        name: "internal",
+        lanispl: false,
+        lanpltrusted: false,
+    },
+    BuiltinLanguage {
+        oid: 13,
+        name: "c",
+        lanispl: false,
+        lanpltrusted: false,
+    },
+    BuiltinLanguage {
+        oid: 14,
+        name: "sql",
+        lanispl: false,
+        lanpltrusted: true,
+    },
+    BuiltinLanguage {
+        oid: 13_288,
+        name: "plpgsql",
+        lanispl: true,
+        lanpltrusted: true,
+    },
+];
+
+/// Built-in collations surfaced through `pg_catalog.pg_collation`.
+pub struct BuiltinCollation {
+    pub oid: Oid,
+    pub name: &'static str,
+    pub encoding: i32,
+    pub collcollate: &'static str,
+    pub collctype: &'static str,
+}
+
+pub const BUILTIN_COLLATIONS: &[BuiltinCollation] = &[
+    BuiltinCollation {
+        oid: 100,
+        name: "default",
+        encoding: -1,
+        collcollate: "",
+        collctype: "",
+    },
+    BuiltinCollation {
+        oid: 950,
+        name: "C",
+        encoding: -1,
+        collcollate: "C",
+        collctype: "C",
+    },
+    BuiltinCollation {
+        oid: 951,
+        name: "POSIX",
+        encoding: -1,
+        collcollate: "POSIX",
+        collctype: "POSIX",
+    },
+];

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -7,6 +7,7 @@ use std::future::Future;
 use std::sync::Mutex;
 use std::sync::{OnceLock, RwLock};
 
+pub mod builtin_types;
 pub mod dependency;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iceberg;
@@ -16,7 +17,7 @@ pub mod search_path;
 pub mod system_catalogs;
 pub mod table;
 
-use oid::{Oid, OidGenerator};
+use oid::{Oid, OidGenerator, PG_CATALOG_NAMESPACE_OID, PUBLIC_NAMESPACE_OID};
 use schema::Schema;
 pub use search_path::SearchPath;
 pub use table::{
@@ -55,10 +56,14 @@ impl Catalog {
             oid_gen: OidGenerator::default(),
             schemas: HashMap::new(),
         };
-        if let Err(error) = catalog.create_schema("pg_catalog") {
+        // Bootstrap schemas get PG-canonical fixed OIDs so catalog JOINs on
+        // `pg_type.typnamespace = pg_namespace.oid` and equivalent match real
+        // Postgres. User-created schemas come from the OID generator, which
+        // starts at FIRST_NORMAL_OID (16384) — well above any bootstrap OID.
+        if let Err(error) = catalog.create_builtin_schema("pg_catalog", PG_CATALOG_NAMESPACE_OID) {
             unreachable!("bootstrap should create pg_catalog: {}", error.message);
         }
-        if let Err(error) = catalog.create_schema("public") {
+        if let Err(error) = catalog.create_builtin_schema("public", PUBLIC_NAMESPACE_OID) {
             unreachable!("bootstrap should create public schema: {}", error.message);
         }
         if let Err(error) = catalog.create_table(
@@ -72,6 +77,18 @@ impl Catalog {
             unreachable!("bootstrap should create pg_catalog.dual: {}", error.message);
         }
         catalog
+    }
+
+    fn create_builtin_schema(&mut self, name: &str, oid: Oid) -> Result<(), CatalogError> {
+        let normalized_name = normalize_name(name)?;
+        if self.schemas.contains_key(&normalized_name) {
+            return Err(CatalogError {
+                message: format!("schema \"{name}\" already exists"),
+            });
+        }
+        self.schemas
+            .insert(normalized_name.clone(), Schema::new(oid, normalized_name));
+        Ok(())
     }
 
     pub fn schemas(&self) -> impl Iterator<Item = &Schema> {

--- a/src/catalog/oid.rs
+++ b/src/catalog/oid.rs
@@ -4,6 +4,16 @@ pub type Oid = u32;
 
 pub const FIRST_NORMAL_OID: Oid = 16_384;
 
+// PG-canonical namespace OIDs. These match Postgres's bootstrap constants so
+// that catalog JOINs like `pg_type.typnamespace = pg_namespace.oid` hit the
+// rows real drivers expect.
+pub const PG_CATALOG_NAMESPACE_OID: Oid = 11;
+pub const PUBLIC_NAMESPACE_OID: Oid = 2_200;
+pub const INFORMATION_SCHEMA_NAMESPACE_OID: Oid = 13_000;
+
+// Superuser-role OID used wherever pg_catalog rows need an owner.
+pub const BOOTSTRAP_SUPERUSER_OID: Oid = 10;
+
 #[derive(Debug, Clone)]
 pub struct OidGenerator {
     next: Oid,

--- a/src/catalog/system_catalogs.rs
+++ b/src/catalog/system_catalogs.rs
@@ -63,6 +63,16 @@ fn is_pg_catalog_virtual_relation(relation: &str) -> bool {
             | "pg_inherits"
             | "pg_am"
             | "pg_statistic"
+            | "pg_range"
+            | "pg_enum"
+            | "pg_description"
+            | "pg_operator"
+            | "pg_collation"
+            | "pg_language"
+            | "pg_auth_members"
+            | "pg_authid"
+            | "pg_trigger"
+            | "pg_rewrite"
     )
 }
 
@@ -194,12 +204,424 @@ fn virtual_relation_column_defs(
                 type_oid: PG_TEXT_OID,
             },
             VirtualRelationColumnDef {
+                name: "typcategory".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typispreferred".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typisdefined".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typdelim".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typrelid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
                 name: "typelem".to_string(),
                 type_oid: PG_INT8_OID,
             },
             VirtualRelationColumnDef {
                 name: "typarray".to_string(),
                 type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typinput".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typoutput".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typreceive".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typsend".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typmodin".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typmodout".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typanalyze".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typalign".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typstorage".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typnotnull".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typbasetype".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typtypmod".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typndims".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typcollation".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "typdefault".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+        ],
+        ("pg_catalog", "pg_range") => vec![
+            VirtualRelationColumnDef {
+                name: "rngtypid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rngsubtype".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rngmultitypid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rngcollation".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rngsubopc".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rngcanonical".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rngsubdiff".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+        ],
+        ("pg_catalog", "pg_enum") => vec![
+            VirtualRelationColumnDef {
+                name: "oid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "enumtypid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "enumsortorder".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "enumlabel".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+        ],
+        ("pg_catalog", "pg_description") => vec![
+            VirtualRelationColumnDef {
+                name: "objoid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "classoid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "objsubid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "description".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+        ],
+        ("pg_catalog", "pg_operator") => vec![
+            VirtualRelationColumnDef {
+                name: "oid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprname".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprnamespace".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprowner".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprkind".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprcanmerge".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprcanhash".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprleft".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprright".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprresult".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprcom".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprnegate".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprcode".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprrest".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "oprjoin".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+        ],
+        ("pg_catalog", "pg_collation") => vec![
+            VirtualRelationColumnDef {
+                name: "oid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collname".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collnamespace".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collowner".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collprovider".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collisdeterministic".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collencoding".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collcollate".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collctype".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "collversion".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+        ],
+        ("pg_catalog", "pg_language") => vec![
+            VirtualRelationColumnDef {
+                name: "oid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "lanname".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "lanowner".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "lanispl".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "lanpltrusted".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "lanplcallfoid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "laninline".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "lanvalidator".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+        ],
+        ("pg_catalog", "pg_auth_members") => vec![
+            VirtualRelationColumnDef {
+                name: "roleid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "member".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "grantor".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "admin_option".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+        ],
+        ("pg_catalog", "pg_authid") => vec![
+            VirtualRelationColumnDef {
+                name: "oid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolname".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolsuper".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolinherit".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolcreaterole".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolcreatedb".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolcanlogin".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolreplication".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolbypassrls".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolconnlimit".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolpassword".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rolvaliduntil".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+        ],
+        ("pg_catalog", "pg_trigger") => vec![
+            VirtualRelationColumnDef {
+                name: "oid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "tgrelid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "tgparentid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "tgname".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "tgfoid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "tgtype".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "tgenabled".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "tgisinternal".to_string(),
+                type_oid: PG_BOOL_OID,
+            },
+        ],
+        ("pg_catalog", "pg_rewrite") => vec![
+            VirtualRelationColumnDef {
+                name: "oid".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "rulename".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "ev_class".to_string(),
+                type_oid: PG_INT8_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "ev_type".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "ev_enabled".to_string(),
+                type_oid: PG_TEXT_OID,
+            },
+            VirtualRelationColumnDef {
+                name: "is_instead".to_string(),
+                type_oid: PG_BOOL_OID,
             },
         ],
         ("information_schema", "tables") => vec![

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -1,5 +1,11 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use crate::catalog::builtin_types::{
+    BUILTIN_COLLATIONS, BUILTIN_LANGUAGES, BUILTIN_RANGES, BUILTIN_TYPES,
+};
+use crate::catalog::oid::{
+    BOOTSTRAP_SUPERUSER_OID, PG_CATALOG_NAMESPACE_OID, PUBLIC_NAMESPACE_OID,
+};
 use crate::executor::profiling;
 
 pub(super) async fn evaluate_table_function(
@@ -1446,7 +1452,7 @@ pub(super) fn virtual_relation_rows(
                     vec![
                         ScalarValue::Int(oid as i64),
                         ScalarValue::Text(name),
-                        ScalarValue::Int(10), // nspowner: superuser OID
+                        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
                     ]
                 })
                 .collect())
@@ -1478,8 +1484,8 @@ pub(super) fn virtual_relation_rows(
                         ScalarValue::Text(relname),
                         ScalarValue::Int(relnamespace as i64),
                         ScalarValue::Text(relkind),
-                        ScalarValue::Int(10), // relowner: superuser OID
-                        ScalarValue::Int(0),  // reltoastrelid
+                        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
+                        ScalarValue::Int(0), // reltoastrelid
                         ScalarValue::Bool(relhasindex),
                         ScalarValue::Bool(false), // relhasrules
                         ScalarValue::Bool(false), // relhastriggers
@@ -1526,59 +1532,115 @@ pub(super) fn virtual_relation_rows(
                 .collect())
         }
         ("pg_catalog", "pg_type") => {
-            // typnamespace 11 = pg_catalog OID, typowner 10 = superuser
-            // typlen: -1 = variable, otherwise fixed byte length
-            let mut entries = vec![
-                (16u32, "bool", 11u32, 10u32, 1i64, false, "b", 0u32, 0u32),
-                (20u32, "int8", 11u32, 10u32, 8i64, true, "b", 0u32, 0u32),
-                (25u32, "text", 11u32, 10u32, -1i64, false, "b", 0u32, 0u32),
-                (701u32, "float8", 11u32, 10u32, 8i64, true, "b", 0u32, 0u32),
-                (1082u32, "date", 11u32, 10u32, 4i64, true, "b", 0u32, 0u32),
-                (
-                    1114u32,
-                    "timestamp",
-                    11u32,
-                    10u32,
-                    8i64,
-                    true,
-                    "b",
-                    0u32,
-                    0u32,
-                ),
-                (
-                    1700u32, "numeric", 11u32, 10u32, -1i64, false, "b", 0u32, 0u32,
-                ),
-            ];
-            entries.sort_by_key(|a| a.0);
-            Ok(entries
-                .into_iter()
-                .map(
-                    |(
-                        oid,
-                        typname,
-                        typnamespace,
-                        typowner,
-                        typlen,
-                        typbyval,
-                        typtype,
-                        typelem,
-                        typarray,
-                    )| {
-                        vec![
-                            ScalarValue::Int(oid as i64),
-                            ScalarValue::Text(typname.to_string()),
-                            ScalarValue::Int(typnamespace as i64),
-                            ScalarValue::Int(typowner as i64),
-                            ScalarValue::Int(typlen),
-                            ScalarValue::Bool(typbyval),
-                            ScalarValue::Text(typtype.to_string()),
-                            ScalarValue::Int(typelem as i64),
-                            ScalarValue::Int(typarray as i64),
-                        ]
-                    },
-                )
+            // Source of truth: src/catalog/builtin_types.rs. Column set and
+            // order must match system_catalogs.rs pg_type column defs.
+            Ok(BUILTIN_TYPES
+                .iter()
+                .map(|t| {
+                    vec![
+                        ScalarValue::Int(t.oid as i64),
+                        ScalarValue::Text(t.name.to_string()),
+                        ScalarValue::Int(PG_CATALOG_NAMESPACE_OID as i64),
+                        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
+                        ScalarValue::Int(t.typlen as i64),
+                        ScalarValue::Bool(t.typbyval),
+                        ScalarValue::Text(t.typtype.to_string()),
+                        ScalarValue::Text(t.typcategory.to_string()),
+                        ScalarValue::Bool(false), // typispreferred
+                        ScalarValue::Bool(true),  // typisdefined
+                        ScalarValue::Text(t.typdelim.to_string()),
+                        ScalarValue::Int(0), // typrelid (0 for non-composite)
+                        ScalarValue::Int(t.typelem as i64),
+                        ScalarValue::Int(t.typarray as i64),
+                        ScalarValue::Int(0), // typinput regproc
+                        ScalarValue::Int(0), // typoutput regproc
+                        ScalarValue::Int(0), // typreceive regproc
+                        ScalarValue::Int(0), // typsend regproc
+                        ScalarValue::Int(0), // typmodin regproc
+                        ScalarValue::Int(0), // typmodout regproc
+                        ScalarValue::Int(0), // typanalyze regproc
+                        ScalarValue::Text(t.typalign.to_string()),
+                        ScalarValue::Text(t.typstorage.to_string()),
+                        ScalarValue::Bool(false), // typnotnull
+                        ScalarValue::Int(0),      // typbasetype (0 for non-domain)
+                        ScalarValue::Int(-1),     // typtypmod
+                        ScalarValue::Int(0),      // typndims
+                        ScalarValue::Int(0),      // typcollation (0 = not collatable)
+                        ScalarValue::Null,        // typdefault
+                    ]
+                })
                 .collect())
         }
+        ("pg_catalog", "pg_range") => Ok(BUILTIN_RANGES
+            .iter()
+            .map(|r| {
+                vec![
+                    ScalarValue::Int(r.rngtypid as i64),
+                    ScalarValue::Int(r.rngsubtype as i64),
+                    ScalarValue::Int(r.rngmultitypid as i64),
+                    ScalarValue::Int(0), // rngcollation
+                    ScalarValue::Int(0), // rngsubopc
+                    ScalarValue::Int(0), // rngcanonical regproc
+                    ScalarValue::Int(0), // rngsubdiff regproc
+                ]
+            })
+            .collect()),
+        ("pg_catalog", "pg_enum") => {
+            // No user-defined enums surfaced yet. When CREATE TYPE ... AS ENUM
+            // lands (Phase 5), populate from catalog.
+            Ok(Vec::new())
+        }
+        ("pg_catalog", "pg_description") => Ok(Vec::new()),
+        ("pg_catalog", "pg_operator") => Ok(Vec::new()),
+        ("pg_catalog", "pg_collation") => Ok(BUILTIN_COLLATIONS
+            .iter()
+            .map(|c| {
+                vec![
+                    ScalarValue::Int(c.oid as i64),
+                    ScalarValue::Text(c.name.to_string()),
+                    ScalarValue::Int(PG_CATALOG_NAMESPACE_OID as i64),
+                    ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
+                    ScalarValue::Text("d".to_string()), // collprovider: 'd' default
+                    ScalarValue::Bool(true),            // collisdeterministic
+                    ScalarValue::Int(c.encoding as i64),
+                    ScalarValue::Text(c.collcollate.to_string()),
+                    ScalarValue::Text(c.collctype.to_string()),
+                    ScalarValue::Null, // collversion
+                ]
+            })
+            .collect()),
+        ("pg_catalog", "pg_language") => Ok(BUILTIN_LANGUAGES
+            .iter()
+            .map(|l| {
+                vec![
+                    ScalarValue::Int(l.oid as i64),
+                    ScalarValue::Text(l.name.to_string()),
+                    ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
+                    ScalarValue::Bool(l.lanispl),
+                    ScalarValue::Bool(l.lanpltrusted),
+                    ScalarValue::Int(0), // lanplcallfoid
+                    ScalarValue::Int(0), // laninline
+                    ScalarValue::Int(0), // lanvalidator
+                ]
+            })
+            .collect()),
+        ("pg_catalog", "pg_auth_members") => Ok(Vec::new()),
+        ("pg_catalog", "pg_authid") => Ok(vec![vec![
+            ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
+            ScalarValue::Text("postgres".to_string()),
+            ScalarValue::Bool(true), // rolsuper
+            ScalarValue::Bool(true), // rolinherit
+            ScalarValue::Bool(true), // rolcreaterole
+            ScalarValue::Bool(true), // rolcreatedb
+            ScalarValue::Bool(true), // rolcanlogin
+            ScalarValue::Bool(true), // rolreplication
+            ScalarValue::Bool(true), // rolbypassrls
+            ScalarValue::Int(-1),    // rolconnlimit
+            ScalarValue::Null,       // rolpassword
+            ScalarValue::Null,       // rolvaliduntil
+        ]]),
+        ("pg_catalog", "pg_trigger") => Ok(Vec::new()),
+        ("pg_catalog", "pg_rewrite") => Ok(Vec::new()),
         ("information_schema", "tables") => {
             let mut entries = with_catalog_read(|catalog| {
                 let mut out = Vec::new();
@@ -1919,8 +1981,10 @@ pub(super) fn virtual_relation_rows(
                         vec![
                             ScalarValue::Int(90000 + i as i64),
                             ScalarValue::Text(f.name.last().cloned().unwrap_or_default()),
-                            ScalarValue::Int(0),  // pronamespace placeholder
-                            ScalarValue::Int(10), // proowner: superuser
+                            // User-declared functions default to `public`.
+                            // Schema-qualified declarations are a Phase 5 concern.
+                            ScalarValue::Int(PUBLIC_NAMESPACE_OID as i64),
+                            ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
                             ScalarValue::Int(14), // prolang: 14 = sql
                             ScalarValue::Text(f.body.clone()), // prosrc
                             ScalarValue::Text(proargnames),

--- a/src/tcop/postgres/extended_query.rs
+++ b/src/tcop/postgres/extended_query.rs
@@ -1,5 +1,7 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use crate::parser::sql_parser::parse_statement;
+use crate::tcop::pquery::infer_statement_parameter_types;
 
 impl PostgresSession {
     pub(super) fn exec_parse_message(
@@ -19,6 +21,18 @@ impl PostgresSession {
         }
 
         let parameter_types = resolve_parse_parameter_types(query_string, parameter_types)?;
+        // Fill in any slots still marked unknown (0) by walking the AST and
+        // inferring from context (casts, comparisons, DML targets). Without
+        // this, drivers like tokio-postgres recurse trying to resolve OID 0
+        // through pg_type.
+        let parameter_types = if parameter_types.contains(&0) {
+            match parse_statement(query_string) {
+                Ok(stmt) => infer_statement_parameter_types(&stmt, parameter_types),
+                Err(_) => parameter_types,
+            }
+        } else {
+            parameter_types
+        };
         let prepared = PreparedStatement {
             operation,
             parameter_types,
@@ -103,7 +117,6 @@ impl PostgresSession {
             result_format_codes: normalized_result_formats,
             result_cache: None,
             cursor: 0,
-            row_description_sent: false,
         };
 
         let key = portal_key(portal_name);
@@ -122,7 +135,7 @@ impl PostgresSession {
         self.start_xact_command();
 
         let key = portal_key(portal_name);
-        let (operation, params, result_formats, cached_result, cursor, row_desc_sent) = {
+        let (operation, params, result_formats, cached_result, cursor) = {
             let portal = self.portals.get(&key).ok_or_else(|| SessionError {
                 message: format!("portal \"{portal_name}\" does not exist"),
             })?;
@@ -132,7 +145,6 @@ impl PostgresSession {
                 portal.result_format_codes.clone(),
                 portal.result_cache.clone(),
                 portal.cursor,
-                portal.row_description_sent,
             )
         };
 
@@ -168,7 +180,7 @@ impl PostgresSession {
             out,
             outcome,
             max_rows,
-            Some((portal, cursor, row_desc_sent)),
+            Some((portal, cursor)),
             row_description.as_deref(),
         )?;
 

--- a/src/tcop/postgres/mod.rs
+++ b/src/tcop/postgres/mod.rs
@@ -232,7 +232,6 @@ pub(super) struct Portal {
     result_format_codes: Vec<i16>,
     result_cache: Option<QueryResult>,
     cursor: usize,
-    row_description_sent: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -797,7 +796,7 @@ impl PostgresSession {
         out: &mut Vec<BackendMessage>,
         outcome: ExecutionOutcome,
         max_rows: i64,
-        portal_state: Option<(&mut Portal, usize, bool)>,
+        portal_state: Option<(&mut Portal, usize)>,
         row_description: Option<&[RowDescriptionField]>,
     ) -> Result<(), SessionError> {
         match outcome {
@@ -809,19 +808,18 @@ impl PostgresSession {
                 Ok(())
             }
             ExecutionOutcome::Query(result) => {
-                if let Some((portal, prev_cursor, prev_desc_sent)) = portal_state {
+                if let Some((portal, prev_cursor)) = portal_state {
+                    // Execute MUST NOT emit RowDescription. Per PG protocol spec
+                    // (Message Flow / Extended Query): "Execute doesn't cause
+                    // ReadyForQuery or RowDescription to be issued." RowDescription
+                    // is sent only in response to Describe; clients that want
+                    // column metadata must send Describe before Execute.
                     let fields = row_description
                         .filter(|f| !f.is_empty())
                         .map(|fields| fields.to_vec())
                         .unwrap_or_else(|| {
                             infer_row_description_fields(&result.columns, &result.rows)
                         });
-                    if !prev_desc_sent {
-                        out.push(BackendMessage::RowDescription {
-                            fields: fields.clone(),
-                        });
-                        portal.row_description_sent = true;
-                    }
 
                     let limit = if max_rows <= 0 {
                         usize::MAX

--- a/src/tcop/postgres/tests.rs
+++ b/src/tcop/postgres/tests.rs
@@ -97,7 +97,9 @@ fn simple_query_cache_clears_after_non_select_execution() {
 }
 
 #[test]
-fn extended_query_flow_requires_sync_for_ready() {
+fn extended_query_flow_without_describe_omits_row_description() {
+    // PG wire spec: Execute MUST NOT emit RowDescription. When the client skips
+    // Describe, it simply won't receive column metadata.
     let out = with_isolated_state(|| {
         let mut session = PostgresSession::new();
         session.run_sync(parse_bind_execute_sync_flow())
@@ -111,17 +113,74 @@ fn extended_query_flow_requires_sync_for_ready() {
     );
     assert!(matches!(out[1], BackendMessage::ParseComplete));
     assert!(matches!(out[2], BackendMessage::BindComplete));
-    assert!(matches!(out[3], BackendMessage::RowDescription { .. }));
-    assert!(matches!(out[4], BackendMessage::DataRow { .. }));
+    assert!(matches!(out[3], BackendMessage::DataRow { .. }));
     assert!(matches!(
-        out[5],
+        out[4],
         BackendMessage::CommandComplete { ref tag, .. } if tag == "SELECT"
     ));
     assert_eq!(
-        out[6],
+        out[5],
         BackendMessage::ReadyForQuery {
             status: ReadyForQueryStatus::Idle
         }
+    );
+    assert!(
+        !out.iter()
+            .any(|msg| matches!(msg, BackendMessage::RowDescription { .. })),
+        "Execute must not emit RowDescription when Describe was not issued"
+    );
+}
+
+#[test]
+fn extended_query_flow_with_describe_portal_emits_row_description_once() {
+    // Spec-correct path used by psql, tokio-postgres, and friends:
+    // Parse → Bind → Describe(portal) → Execute → Sync produces one
+    // RowDescription (from Describe) followed by DataRow+CommandComplete.
+    let out = with_isolated_state(|| {
+        let mut session = PostgresSession::new();
+        session.run_sync([
+            FrontendMessage::Parse {
+                statement_name: String::new(),
+                query: "SELECT 1".to_string(),
+                parameter_types: vec![],
+            },
+            FrontendMessage::Bind {
+                portal_name: String::new(),
+                statement_name: String::new(),
+                param_formats: vec![],
+                params: vec![],
+                result_formats: vec![],
+            },
+            FrontendMessage::DescribePortal {
+                portal_name: String::new(),
+            },
+            FrontendMessage::Execute {
+                portal_name: String::new(),
+                max_rows: 0,
+            },
+            FrontendMessage::Sync,
+        ])
+    });
+
+    let row_desc_count = out
+        .iter()
+        .filter(|msg| matches!(msg, BackendMessage::RowDescription { .. }))
+        .count();
+    assert_eq!(
+        row_desc_count, 1,
+        "exactly one RowDescription expected (from Describe, not Execute)"
+    );
+    let row_desc_idx = out
+        .iter()
+        .position(|msg| matches!(msg, BackendMessage::RowDescription { .. }))
+        .unwrap();
+    let data_row_idx = out
+        .iter()
+        .position(|msg| matches!(msg, BackendMessage::DataRow { .. }))
+        .unwrap();
+    assert!(
+        row_desc_idx < data_row_idx,
+        "RowDescription must precede DataRow"
     );
 }
 
@@ -219,6 +278,9 @@ fn describe_statement_uses_planned_type_metadata() {
 
 #[test]
 fn bind_supports_binary_result_format_codes() {
+    // Spec-correct flow: Describe(portal) comes between Bind and Execute so
+    // the RowDescription is emitted by Describe (not Execute) and carries the
+    // format codes from the Bind message.
     let out = with_isolated_state(|| {
         let mut session = PostgresSession::new();
         session.run_sync([
@@ -234,6 +296,9 @@ fn bind_supports_binary_result_format_codes() {
                 param_formats: vec![],
                 params: vec![],
                 result_formats: vec![1],
+            },
+            FrontendMessage::DescribePortal {
+                portal_name: "p1".to_string(),
             },
             FrontendMessage::Execute {
                 portal_name: "p1".to_string(),

--- a/src/tcop/pquery.rs
+++ b/src/tcop/pquery.rs
@@ -2539,3 +2539,511 @@ fn table_function_output_type_oids(function: &TableFunctionRef, count: usize) ->
     }
     oids
 }
+
+// ─── Parameter-type inference ────────────────────────────────────────────────
+//
+// At Parse time the extended-query protocol lets the server declare each `$N`'s
+// type in the subsequent ParameterDescription message. Real Postgres infers
+// those types from the query's AST: `WHERE col = $1` makes `$1` match col's
+// type; `SELECT $1::int4` makes `$1` int4; `INSERT INTO t(c) VALUES ($1)` uses
+// t.c's declared type.
+//
+// Without inference the server reports OID 0 ("unknown") for every bare `$N`.
+// tokio-postgres and sqlx react by trying to resolve OID 0 through pg_type,
+// which returns zero rows, so they retry — recursing until the client stack
+// overflows. So inference is *structurally required* for any driver that uses
+// the extended protocol with bare parameters.
+//
+// This pass covers the common patterns real drivers and ORMs actually rely on:
+//   - `$N :: type` -> cast type
+//   - `col = $N` / `$N = col` (and other comparisons) -> col's catalog type
+//   - `INSERT INTO t(c1,c2) VALUES ($1, $2)` -> each column's catalog type
+//   - `UPDATE t SET c1 = $1 WHERE ...` -> c1's catalog type
+//
+// It is intentionally conservative: when a slot can't be confidently inferred
+// the existing (likely 0) value stays. A wrong type is worse than no type.
+
+/// Walk `stmt` looking for bare `$N` parameter references and return
+/// `existing` with any previously-unknown slots filled in from context.
+/// Never errors — if inference trips over anything it doesn't understand,
+/// the unchanged input is returned.
+pub(crate) fn infer_statement_parameter_types(stmt: &Statement, existing: Vec<u32>) -> Vec<u32> {
+    let mut inferred = existing;
+    let mut ctx = ParamInferCtx::default();
+    match stmt {
+        Statement::Query(query) => walk_query(query, &mut ctx, &mut inferred),
+        Statement::Insert(ins) => walk_insert(ins, &mut ctx, &mut inferred),
+        Statement::Update(upd) => walk_update(upd, &mut ctx, &mut inferred),
+        Statement::Delete(del) => walk_delete(del, &mut ctx, &mut inferred),
+        _ => {}
+    }
+    inferred
+}
+
+#[derive(Default)]
+struct ParamInferCtx {
+    cte_types: HashMap<String, Vec<PlannedOutputColumn>>,
+}
+
+fn assign_param(params: &mut [u32], index: i32, type_oid: u32) {
+    if type_oid == 0 || index <= 0 {
+        return;
+    }
+    let idx = (index - 1) as usize;
+    if let Some(slot) = params.get_mut(idx)
+        && *slot == 0
+    {
+        *slot = type_oid;
+    }
+}
+
+fn walk_query(query: &crate::parser::ast::Query, ctx: &mut ParamInferCtx, params: &mut Vec<u32>) {
+    // CTEs: process each before the main body so they contribute to scope.
+    if let Some(with) = &query.with {
+        let snapshot = ctx.cte_types.clone();
+        for cte in &with.ctes {
+            walk_query(&cte.query, ctx, params);
+            if let Ok(cols) = derive_query_output_columns_with_ctes(&cte.query, &mut ctx.cte_types)
+            {
+                ctx.cte_types.insert(cte.name.clone(), cols);
+            }
+        }
+        walk_query_expr(&query.body, ctx, params);
+        ctx.cte_types = snapshot;
+    } else {
+        walk_query_expr(&query.body, ctx, params);
+    }
+    for ob in &query.order_by {
+        walk_expr(&ob.expr, None, &TypeScope::default(), ctx, params);
+    }
+    if let Some(limit) = &query.limit {
+        walk_expr(limit, Some(PG_INT8_OID), &TypeScope::default(), ctx, params);
+    }
+    if let Some(offset) = &query.offset {
+        walk_expr(
+            offset,
+            Some(PG_INT8_OID),
+            &TypeScope::default(),
+            ctx,
+            params,
+        );
+    }
+}
+
+fn walk_query_expr(body: &QueryExpr, ctx: &mut ParamInferCtx, params: &mut Vec<u32>) {
+    match body {
+        QueryExpr::Select(select) => walk_select(select, ctx, params),
+        QueryExpr::SetOperation { left, right, .. } => {
+            walk_query_expr(left, ctx, params);
+            walk_query_expr(right, ctx, params);
+        }
+        QueryExpr::Nested(inner) => walk_query(inner, ctx, params),
+        QueryExpr::Values(rows) => {
+            // Without a target column list we can't infer. Recurse so nested
+            // subquery params still get inferred, but without expected types.
+            let scope = TypeScope::default();
+            for row in rows {
+                for expr in row {
+                    walk_expr(expr, None, &scope, ctx, params);
+                }
+            }
+        }
+        QueryExpr::Insert(ins) => walk_insert(ins, ctx, params),
+        QueryExpr::Update(upd) => walk_update(upd, ctx, params),
+        QueryExpr::Delete(del) => walk_delete(del, ctx, params),
+    }
+}
+
+fn walk_select(select: &SelectStatement, ctx: &mut ParamInferCtx, params: &mut Vec<u32>) {
+    // Build the TypeScope from FROM. Failure = empty scope; still walk for
+    // cast-based inference and nested subqueries.
+    let scope = expand_from_columns_typed(&select.from, &ctx.cte_types)
+        .map(build_scope_from_columns)
+        .unwrap_or_default();
+
+    for item in &select.targets {
+        walk_expr(&item.expr, None, &scope, ctx, params);
+    }
+    walk_from_for_join_conditions(&select.from, &scope, ctx, params);
+    if let Some(where_clause) = &select.where_clause {
+        walk_expr(where_clause, Some(PG_BOOL_OID), &scope, ctx, params);
+    }
+    for gb in &select.group_by {
+        if let GroupByExpr::Expr(expr) = gb {
+            walk_expr(expr, None, &scope, ctx, params);
+        }
+    }
+    if let Some(having) = &select.having {
+        walk_expr(having, Some(PG_BOOL_OID), &scope, ctx, params);
+    }
+}
+
+fn walk_from_for_join_conditions(
+    from: &[TableExpression],
+    scope: &TypeScope,
+    ctx: &mut ParamInferCtx,
+    params: &mut Vec<u32>,
+) {
+    for table in from {
+        walk_table_expression_for_joins(table, scope, ctx, params);
+    }
+}
+
+fn walk_table_expression_for_joins(
+    table: &TableExpression,
+    scope: &TypeScope,
+    ctx: &mut ParamInferCtx,
+    params: &mut Vec<u32>,
+) {
+    match table {
+        TableExpression::Relation(_) => {}
+        TableExpression::Subquery(sub) => walk_query(&sub.query, ctx, params),
+        TableExpression::Function(tf) => {
+            for arg in &tf.args {
+                walk_expr(arg, None, scope, ctx, params);
+            }
+        }
+        TableExpression::Join(join) => {
+            walk_table_expression_for_joins(&join.left, scope, ctx, params);
+            walk_table_expression_for_joins(&join.right, scope, ctx, params);
+            if let Some(JoinCondition::On(expr)) = &join.condition {
+                walk_expr(expr, Some(PG_BOOL_OID), scope, ctx, params);
+            }
+        }
+    }
+}
+
+fn walk_insert(
+    ins: &crate::parser::ast::InsertStatement,
+    ctx: &mut ParamInferCtx,
+    params: &mut Vec<u32>,
+) {
+    // Resolve the target table's column types so we can match VALUES to columns.
+    let column_types = lookup_insert_target_column_types(&ins.table_name, &ins.columns);
+    match &ins.source {
+        crate::parser::ast::InsertSource::Values(rows) => {
+            let scope = TypeScope::default();
+            for row in rows {
+                for (i, expr) in row.iter().enumerate() {
+                    let expected = column_types.get(i).copied();
+                    walk_expr(expr, expected, &scope, ctx, params);
+                }
+            }
+        }
+        crate::parser::ast::InsertSource::Query(query) => walk_query(query, ctx, params),
+    }
+    if let Some(crate::parser::ast::OnConflictClause::DoUpdate {
+        assignments,
+        where_clause,
+        ..
+    }) = &ins.on_conflict
+    {
+        let scope = TypeScope::default();
+        for assn in assignments {
+            let expected = column_types
+                .iter()
+                .zip(ins.columns.iter())
+                .find_map(|(ty, name)| (name == &assn.column).then_some(*ty));
+            walk_expr(&assn.value, expected, &scope, ctx, params);
+        }
+        if let Some(where_expr) = where_clause {
+            walk_expr(where_expr, Some(PG_BOOL_OID), &scope, ctx, params);
+        }
+    }
+}
+
+fn walk_update(
+    upd: &crate::parser::ast::UpdateStatement,
+    ctx: &mut ParamInferCtx,
+    params: &mut Vec<u32>,
+) {
+    let scope = update_or_delete_scope(&upd.table_name, upd.alias.as_deref(), &upd.from, ctx);
+    let table_columns = lookup_table_column_type_map(&upd.table_name);
+    for assn in &upd.assignments {
+        let expected = table_columns
+            .get(&assn.column.to_ascii_lowercase())
+            .copied();
+        walk_expr(&assn.value, expected, &scope, ctx, params);
+    }
+    if let Some(where_expr) = &upd.where_clause {
+        walk_expr(where_expr, Some(PG_BOOL_OID), &scope, ctx, params);
+    }
+}
+
+fn walk_delete(
+    del: &crate::parser::ast::DeleteStatement,
+    ctx: &mut ParamInferCtx,
+    params: &mut Vec<u32>,
+) {
+    let scope = update_or_delete_scope(&del.table_name, None, &del.using, ctx);
+    if let Some(where_expr) = &del.where_clause {
+        walk_expr(where_expr, Some(PG_BOOL_OID), &scope, ctx, params);
+    }
+}
+
+fn update_or_delete_scope(
+    table_name: &[String],
+    alias: Option<&str>,
+    from: &[TableExpression],
+    ctx: &ParamInferCtx,
+) -> TypeScope {
+    let mut scope = TypeScope::default();
+    let _ = extend_scope_with_table(&mut scope, table_name, alias);
+    if let Ok(cols) = expand_from_columns_typed(from, &ctx.cte_types) {
+        let extra = build_scope_from_columns(cols);
+        // Merge `extra` into `scope`; on conflict prefer the target table.
+        for (k, v) in extra.unqualified {
+            scope.unqualified.entry(k).or_insert(v);
+        }
+        for (k, v) in extra.qualified {
+            scope.qualified.entry(k).or_insert(v);
+        }
+    }
+    scope
+}
+
+fn lookup_insert_target_column_types(table_name: &[String], columns: &[String]) -> Vec<u32> {
+    let table = with_catalog_read(|catalog| {
+        catalog
+            .resolve_table(table_name, &SearchPath::default())
+            .cloned()
+    });
+    let table = match table {
+        Ok(t) => t,
+        Err(_) => return Vec::new(),
+    };
+    if columns.is_empty() {
+        return table
+            .columns()
+            .iter()
+            .map(|col| type_signature_to_oid(col.type_signature()))
+            .collect();
+    }
+    columns
+        .iter()
+        .map(|name| {
+            table
+                .columns()
+                .iter()
+                .find(|col| col.name().eq_ignore_ascii_case(name))
+                .map_or(0, |col| type_signature_to_oid(col.type_signature()))
+        })
+        .collect()
+}
+
+fn lookup_table_column_type_map(table_name: &[String]) -> HashMap<String, u32> {
+    let Ok(table) = with_catalog_read(|catalog| {
+        catalog
+            .resolve_table(table_name, &SearchPath::default())
+            .cloned()
+    }) else {
+        return HashMap::new();
+    };
+    table
+        .columns()
+        .iter()
+        .map(|col| {
+            (
+                col.name().to_ascii_lowercase(),
+                type_signature_to_oid(col.type_signature()),
+            )
+        })
+        .collect()
+}
+
+fn walk_expr(
+    expr: &Expr,
+    expected: Option<u32>,
+    scope: &TypeScope,
+    ctx: &mut ParamInferCtx,
+    params: &mut Vec<u32>,
+) {
+    match expr {
+        Expr::Parameter(n) => {
+            if let Some(ty) = expected {
+                assign_param(params, *n, ty);
+            }
+        }
+        Expr::Cast {
+            expr: inner,
+            type_name,
+        } => {
+            let ty = cast_type_name_to_oid(type_name);
+            walk_expr(inner, Some(ty), scope, ctx, params);
+        }
+        Expr::TypedLiteral { .. } => {}
+        Expr::Binary { left, op, right } => {
+            if matches!(
+                op,
+                BinaryOp::Eq
+                    | BinaryOp::NotEq
+                    | BinaryOp::Lt
+                    | BinaryOp::Lte
+                    | BinaryOp::Gt
+                    | BinaryOp::Gte
+            ) {
+                // Comparison: each side takes on the other side's inferred type.
+                let left_ty = if matches!(left.as_ref(), Expr::Parameter(_)) {
+                    None
+                } else {
+                    Some(infer_expr_type(left, scope, &ctx.cte_types).type_oid)
+                };
+                let right_ty = if matches!(right.as_ref(), Expr::Parameter(_)) {
+                    None
+                } else {
+                    Some(infer_expr_type(right, scope, &ctx.cte_types).type_oid)
+                };
+                walk_expr(left, right_ty, scope, ctx, params);
+                walk_expr(right, left_ty, scope, ctx, params);
+            } else {
+                walk_expr(left, None, scope, ctx, params);
+                walk_expr(right, None, scope, ctx, params);
+            }
+        }
+        Expr::AnyAll { left, right, .. } => {
+            walk_expr(left, None, scope, ctx, params);
+            walk_expr(right, None, scope, ctx, params);
+        }
+        Expr::Unary { expr: inner, .. } => {
+            walk_expr(inner, expected, scope, ctx, params);
+        }
+        Expr::FunctionCall { args, filter, .. } => {
+            for arg in args {
+                walk_expr(arg, None, scope, ctx, params);
+            }
+            if let Some(f) = filter {
+                walk_expr(f, Some(PG_BOOL_OID), scope, ctx, params);
+            }
+        }
+        Expr::InList {
+            expr: probe, list, ..
+        } => {
+            // In `x IN (a, b, ...)` every list element's type should match x.
+            let probe_ty = if matches!(probe.as_ref(), Expr::Parameter(_)) {
+                None
+            } else {
+                Some(infer_expr_type(probe, scope, &ctx.cte_types).type_oid)
+            };
+            walk_expr(probe, None, scope, ctx, params);
+            for item in list {
+                walk_expr(item, probe_ty, scope, ctx, params);
+            }
+        }
+        Expr::InSubquery {
+            expr: probe,
+            subquery,
+            ..
+        } => {
+            walk_expr(probe, None, scope, ctx, params);
+            walk_query(subquery, ctx, params);
+        }
+        Expr::Between {
+            expr: probe,
+            low,
+            high,
+            ..
+        } => {
+            let probe_ty = if matches!(probe.as_ref(), Expr::Parameter(_)) {
+                None
+            } else {
+                Some(infer_expr_type(probe, scope, &ctx.cte_types).type_oid)
+            };
+            walk_expr(probe, None, scope, ctx, params);
+            walk_expr(low, probe_ty, scope, ctx, params);
+            walk_expr(high, probe_ty, scope, ctx, params);
+        }
+        Expr::Like {
+            expr: probe,
+            pattern,
+            escape,
+            ..
+        } => {
+            walk_expr(probe, Some(PG_TEXT_OID), scope, ctx, params);
+            walk_expr(pattern, Some(PG_TEXT_OID), scope, ctx, params);
+            if let Some(e) = escape {
+                walk_expr(e, Some(PG_TEXT_OID), scope, ctx, params);
+            }
+        }
+        Expr::IsNull { expr: inner, .. } | Expr::BooleanTest { expr: inner, .. } => {
+            walk_expr(inner, None, scope, ctx, params);
+        }
+        Expr::IsDistinctFrom { left, right, .. } => {
+            let left_ty = if matches!(left.as_ref(), Expr::Parameter(_)) {
+                None
+            } else {
+                Some(infer_expr_type(left, scope, &ctx.cte_types).type_oid)
+            };
+            let right_ty = if matches!(right.as_ref(), Expr::Parameter(_)) {
+                None
+            } else {
+                Some(infer_expr_type(right, scope, &ctx.cte_types).type_oid)
+            };
+            walk_expr(left, right_ty, scope, ctx, params);
+            walk_expr(right, left_ty, scope, ctx, params);
+        }
+        Expr::CaseSimple {
+            operand,
+            when_then,
+            else_expr,
+        } => {
+            walk_expr(operand, None, scope, ctx, params);
+            for (w, t) in when_then {
+                walk_expr(w, None, scope, ctx, params);
+                walk_expr(t, expected, scope, ctx, params);
+            }
+            if let Some(e) = else_expr {
+                walk_expr(e, expected, scope, ctx, params);
+            }
+        }
+        Expr::CaseSearched {
+            when_then,
+            else_expr,
+        } => {
+            for (w, t) in when_then {
+                walk_expr(w, Some(PG_BOOL_OID), scope, ctx, params);
+                walk_expr(t, expected, scope, ctx, params);
+            }
+            if let Some(e) = else_expr {
+                walk_expr(e, expected, scope, ctx, params);
+            }
+        }
+        Expr::ArrayConstructor(items) | Expr::RowConstructor(items) => {
+            for item in items {
+                walk_expr(item, None, scope, ctx, params);
+            }
+        }
+        Expr::Exists(q) | Expr::ScalarSubquery(q) | Expr::ArraySubquery(q) => {
+            walk_query(q, ctx, params);
+        }
+        Expr::ArraySubscript {
+            expr: inner, index, ..
+        } => {
+            walk_expr(inner, None, scope, ctx, params);
+            walk_expr(index, Some(PG_INT8_OID), scope, ctx, params);
+        }
+        Expr::ArraySlice {
+            expr: inner,
+            start,
+            end,
+            ..
+        } => {
+            walk_expr(inner, None, scope, ctx, params);
+            if let Some(s) = start {
+                walk_expr(s, Some(PG_INT8_OID), scope, ctx, params);
+            }
+            if let Some(e) = end {
+                walk_expr(e, Some(PG_INT8_OID), scope, ctx, params);
+            }
+        }
+        Expr::MultiColumnSubqueryRef { subquery, .. } => walk_query(subquery, ctx, params),
+        Expr::Identifier(_)
+        | Expr::String(_)
+        | Expr::Integer(_)
+        | Expr::Float(_)
+        | Expr::Boolean(_)
+        | Expr::Null
+        | Expr::Default
+        | Expr::Wildcard
+        | Expr::QualifiedWildcard(_) => {}
+    }
+}

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -1,0 +1,413 @@
+//! Phase 1 regression harness: drives real tokio-postgres against the
+//! in-process pgwire server to lock in the gaps closed in this phase.
+//!
+//! What this guards against:
+//! - Execute emitting RowDescription (spec violation; breaks every Rust ORM's
+//!   extended-query path).
+//! - pg_catalog.pg_range missing (tokio-postgres' type resolver errors on it).
+//! - pg_catalog.pg_type → pg_namespace JOIN returning zero rows (type cache
+//!   stays unresolved, client recurses to stack-overflow).
+//! - pg_catalog.pg_type missing rows for common types (int4, uuid, timestamptz,
+//!   varchar, bytea, jsonb, …).
+//!
+//! The server is spawned in a background thread on an ephemeral port. Each
+//! test gets its own listener so they can run in parallel even though the
+//! underlying engine is process-global.
+
+use std::io::{self, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+use openassay::protocol::messages::{
+    StartupAction, decode_frontend_message, decode_startup_action, encode_backend_message,
+};
+use openassay::tcop::postgres::{BackendMessage, FrontendMessage, PostgresSession};
+
+// ─── test-local pg_server (plain TCP, no TLS) ───────────────────────────────
+
+fn spawn_server() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            thread::spawn(move || {
+                let _ = handle_connection(stream);
+            });
+        }
+    });
+
+    port
+}
+
+fn handle_connection(mut stream: TcpStream) -> io::Result<()> {
+    let _ = stream.set_nodelay(true);
+    let mut session = PostgresSession::new_startup_required();
+
+    if !run_startup_handshake(&mut stream, &mut session)? {
+        return Ok(());
+    }
+
+    loop {
+        let Some((tag, payload)) = read_tagged_message(&mut stream)? else {
+            return Ok(());
+        };
+
+        let frontend = match decode_frontend_message(tag, &payload) {
+            Ok(message) => message,
+            Err(err) => {
+                send_error(&mut stream, &err.message)?;
+                return Ok(());
+            }
+        };
+        if matches!(frontend, FrontendMessage::Terminate) {
+            return Ok(());
+        }
+
+        let out = session.run_sync([frontend]);
+        let out = trim_leading_ready(out);
+        send_backend_messages(&mut stream, &out)?;
+
+        if out.iter().any(|m| matches!(m, BackendMessage::Terminate)) {
+            return Ok(());
+        }
+    }
+}
+
+fn run_startup_handshake(
+    stream: &mut TcpStream,
+    session: &mut PostgresSession,
+) -> io::Result<bool> {
+    loop {
+        let Some(packet) = read_startup_packet(stream)? else {
+            return Ok(false);
+        };
+        match decode_startup_action(&packet) {
+            Ok(StartupAction::SslRequest) => {
+                stream.write_all(b"N")?;
+                stream.flush()?;
+            }
+            Ok(StartupAction::CancelRequest { .. }) => return Ok(false),
+            Ok(StartupAction::Startup(startup)) => {
+                let startup_msg = FrontendMessage::Startup {
+                    user: startup.user,
+                    database: startup.database,
+                    parameters: startup.parameters,
+                };
+                let out = session.run_sync([startup_msg]);
+                send_backend_messages(stream, &out)?;
+                if out
+                    .iter()
+                    .any(|m| matches!(m, BackendMessage::ReadyForQuery { .. }))
+                {
+                    return Ok(true);
+                }
+
+                loop {
+                    let Some((tag, payload)) = read_tagged_message(stream)? else {
+                        return Ok(false);
+                    };
+                    let frontend = match decode_frontend_message(tag, &payload) {
+                        Ok(msg) => msg,
+                        Err(err) => {
+                            send_error(stream, &err.message)?;
+                            return Ok(false);
+                        }
+                    };
+                    if matches!(frontend, FrontendMessage::Terminate) {
+                        return Ok(false);
+                    }
+                    let out = session.run_sync([frontend]);
+                    let out = trim_leading_ready(out);
+                    send_backend_messages(stream, &out)?;
+                    if out
+                        .iter()
+                        .any(|m| matches!(m, BackendMessage::ReadyForQuery { .. }))
+                    {
+                        return Ok(true);
+                    }
+                    if out
+                        .iter()
+                        .any(|m| matches!(m, BackendMessage::ErrorResponse { .. }))
+                    {
+                        return Ok(false);
+                    }
+                }
+            }
+            Err(err) => {
+                send_error(stream, &err.message)?;
+                return Ok(false);
+            }
+        }
+    }
+}
+
+fn trim_leading_ready(mut out: Vec<BackendMessage>) -> Vec<BackendMessage> {
+    if out.len() > 1 && matches!(out.first(), Some(BackendMessage::ReadyForQuery { .. })) {
+        out.remove(0);
+    }
+    out
+}
+
+fn send_backend_messages(stream: &mut TcpStream, messages: &[BackendMessage]) -> io::Result<()> {
+    for message in messages {
+        if let Some(frame) = encode_backend_message(message) {
+            stream.write_all(&frame)?;
+        }
+    }
+    stream.flush()
+}
+
+fn send_error(stream: &mut TcpStream, message: &str) -> io::Result<()> {
+    let error = BackendMessage::ErrorResponse {
+        message: message.to_string(),
+        code: "XX000".to_string(),
+        detail: None,
+        hint: None,
+        position: None,
+    };
+    if let Some(frame) = encode_backend_message(&error) {
+        stream.write_all(&frame)?;
+        stream.flush()?;
+    }
+    Ok(())
+}
+
+fn read_startup_packet(stream: &mut TcpStream) -> io::Result<Option<Vec<u8>>> {
+    let mut len_buf = [0u8; 4];
+    match stream.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err),
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len < 8 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "startup packet too short",
+        ));
+    }
+    let mut body = vec![0u8; len - 4];
+    stream.read_exact(&mut body)?;
+    let mut out = Vec::with_capacity(len);
+    out.extend_from_slice(&len_buf);
+    out.extend_from_slice(&body);
+    Ok(Some(out))
+}
+
+fn read_tagged_message(stream: &mut TcpStream) -> io::Result<Option<(u8, Vec<u8>)>> {
+    let mut tag_buf = [0u8; 1];
+    match stream.read_exact(&mut tag_buf) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err),
+    }
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len < 4 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "frontend message length invalid",
+        ));
+    }
+    let mut payload = vec![0u8; len - 4];
+    stream.read_exact(&mut payload)?;
+    Ok(Some((tag_buf[0], payload)))
+}
+
+// ─── tokio-postgres driven tests ────────────────────────────────────────────
+
+fn conn_str(port: u16) -> String {
+    format!("host=127.0.0.1 port={port} user=postgres password=any dbname=openassay")
+}
+
+async fn connect(port: u16) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(&conn_str(port), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+/// The single exchange that used to crash every Rust ORM: Parse + Bind +
+/// Execute with a parameter, requiring tokio-postgres' type resolver to
+/// succeed before it can decode the result. If any of Phase 1 regresses,
+/// this stack-overflows in the client.
+///
+/// Note: OpenAssay still widens `int4` columns to int8 on the wire (Phase 2
+/// will preserve declared SQL types through RowDescription). Phase 1's
+/// guarantee is only that the *type-resolver loop* no longer diverges and
+/// parameterised queries round-trip for currently-supported wire types.
+#[tokio::test(flavor = "multi_thread")]
+async fn parameterised_query_does_not_stack_overflow() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    // int8 (currently the only integer width emitted on the wire). This
+    // exercises the full Parse+Bind+Describe+Execute path and forces the
+    // client's type resolver to run.
+    let row = client
+        .query_one("SELECT $1::int8 AS a", &[&42i64])
+        .await
+        .expect("query_one int8");
+    let v: i64 = row.try_get(0).expect("try_get");
+    assert_eq!(v, 42);
+}
+
+/// Parameter-type inference: `WHERE col = $1` against a known-typed column
+/// must tell the client that `$1` matches the column's type (not OID 0).
+/// Without this, tokio-postgres' type resolver recurses to stack overflow.
+#[tokio::test(flavor = "multi_thread")]
+async fn parameter_type_inferred_from_column_comparison() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    // pg_type.oid is declared int8 in our catalog. The driver should be able
+    // to prepare + bind this with an int8 value.
+    let rows = client
+        .query(
+            "SELECT typname FROM pg_catalog.pg_type WHERE oid = $1",
+            &[&23i64],
+        )
+        .await
+        .expect("query with inferred param type");
+    assert!(!rows.is_empty(), "int4 (OID 23) should exist in pg_type");
+    let typname: String = rows[0].try_get(0).expect("typname");
+    assert_eq!(typname, "int4");
+}
+
+/// pg_type must list rows for every common type, and every row's typnamespace
+/// must JOIN cleanly to pg_namespace. This is exactly the query tokio-postgres
+/// runs to resolve an unknown type OID.
+#[tokio::test(flavor = "multi_thread")]
+async fn pg_type_join_pg_namespace_returns_rows_for_core_types() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    // Run tokio-postgres' own type-resolver shape, one OID at a time.
+    // (We skip the LEFT OUTER JOIN on pg_range — that's proven to exist
+    // separately in the pg_range_exists test below.)
+    for (oid, expected_typname) in [
+        (16u32, "bool"),
+        (17u32, "bytea"),
+        (20u32, "int8"),
+        (21u32, "int2"),
+        (23u32, "int4"),
+        (25u32, "text"),
+        (700u32, "float4"),
+        (701u32, "float8"),
+        (1043u32, "varchar"),
+        (1082u32, "date"),
+        (1114u32, "timestamp"),
+        (1184u32, "timestamptz"),
+        (1700u32, "numeric"),
+        (2950u32, "uuid"),
+        (3802u32, "jsonb"),
+    ] {
+        let rows = client
+            .query(
+                "SELECT t.typname, t.typtype, n.nspname \
+                 FROM pg_catalog.pg_type t \
+                 INNER JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid \
+                 WHERE t.oid = $1",
+                &[&(oid as i64)],
+            )
+            .await
+            .unwrap_or_else(|e| panic!("query for oid={oid} ({expected_typname}): {e}"));
+        assert!(
+            !rows.is_empty(),
+            "pg_type INNER JOIN pg_namespace returned 0 rows for oid={oid} ({expected_typname}); \
+             typnamespace must link to a real pg_namespace entry"
+        );
+        let typname: String = rows[0].try_get(0).unwrap();
+        assert_eq!(
+            typname, expected_typname,
+            "wrong typname for oid={oid}: {typname} vs expected {expected_typname}"
+        );
+        let nspname: String = rows[0].try_get(2).unwrap();
+        assert_eq!(
+            nspname, "pg_catalog",
+            "builtin types must live in pg_catalog; oid={oid} found in {nspname}"
+        );
+    }
+}
+
+/// pg_range must exist and answer SELECTs without error. tokio-postgres'
+/// type resolver does an outer join on pg_range when inspecting range types;
+/// if the relation is missing, it errors (42P01) and then retries, setting
+/// up the stack-overflow loop. Presence + basic shape is the guarantee.
+#[tokio::test(flavor = "multi_thread")]
+async fn pg_range_exists_with_canonical_rows() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let rows = client
+        .query(
+            "SELECT rngtypid, rngsubtype FROM pg_catalog.pg_range ORDER BY rngtypid",
+            &[],
+        )
+        .await
+        .expect("SELECT from pg_range");
+    assert!(
+        rows.len() >= 5,
+        "pg_range should contain at least the 5 canonical PG range types, found {}",
+        rows.len()
+    );
+    let pairs: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|r| (r.get::<_, i64>(0), r.get::<_, i64>(1)))
+        .collect();
+    // int4range=3904 over int4=23 must be present.
+    assert!(
+        pairs.iter().any(|&(t, s)| t == 3904 && s == 23),
+        "int4range (3904, 23) not in pg_range: {pairs:?}"
+    );
+}
+
+/// pg_language must respond (drivers SELECT from it when introspecting
+/// procedures). We expect the canonical `plpgsql` and `sql` rows even if
+/// plpgsql itself isn't implemented — the row's existence matters to tools.
+#[tokio::test(flavor = "multi_thread")]
+async fn pg_language_has_canonical_rows() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let rows = client
+        .query(
+            "SELECT lanname FROM pg_catalog.pg_language ORDER BY lanname",
+            &[],
+        )
+        .await
+        .expect("SELECT from pg_language");
+    let names: Vec<String> = rows.iter().map(|r| r.get::<_, String>(0)).collect();
+    for expected in ["c", "internal", "plpgsql", "sql"] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "pg_language missing '{expected}': found {names:?}"
+        );
+    }
+}
+
+/// Phase 1.4 direct regression: tokio-postgres' `client.query` on an already-
+/// prepared statement path must succeed. When OpenAssay emitted RowDescription
+/// during Execute, this failed with "unexpected message from server".
+#[tokio::test(flavor = "multi_thread")]
+async fn prepared_then_execute_does_not_emit_extra_row_description() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    // Prepare (Parse + Describe(statement) + Sync) gives us the stmt handle.
+    let stmt = client
+        .prepare("SELECT 1::int8 AS a")
+        .await
+        .expect("prepare");
+    // Now Bind + Execute + Sync on the prepared handle. Pre-Phase-1.4 this
+    // path crashed; we assert it runs and returns the row.
+    let rows = client.query(&stmt, &[]).await.expect("query on prepared");
+    assert_eq!(rows.len(), 1);
+    let v: i64 = rows[0].try_get(0).expect("try_get i64");
+    assert_eq!(v, 1);
+}


### PR DESCRIPTION
## Summary

Unblocks real Rust ORMs (tokio-postgres, sqlx, diesel-async) against OpenAssay's pgwire server. Before this patch any parameterised query — `client.query(&stmt, &[&42i64])` — stack-overflowed inside the driver's type resolver because `pg_catalog` JOINs returned zero rows and `ParameterDescription` reported OID 0 for every bare `$N`.

Phase 1 of the plan in [`TESTKIT_FULL_FIX_PLAN.md`](./TESTKIT_FULL_FIX_PLAN.md).

## What's in here

Five entangled gaps closed as one PR because they unblock the same milestone:

- **Canonical namespace OIDs.** `pg_catalog` is 11, `public` is 2200 — matching real Postgres. User schemas still come from the generator at `FIRST_NORMAL_OID`. Catalog JOINs `pg_type.typnamespace = pg_namespace.oid` finally hit rows.
- **Full `pg_type`.** New `src/catalog/builtin_types.rs` ships ~90 rows covering every OID the engine produces plus every pseudo-type drivers look up: int2/int4/int8, float4/float8, text/varchar/bpchar, bytea/uuid, date/time/timetz/timestamp/timestamptz/interval, json/jsonb, numeric/oid/name/regproc/void/record, plus the `_*` array variants and range types. Column surface expanded from 9 → 29 columns to match what drivers SELECT (typcategory, typrelid, typinput/typsend/typreceive, typbasetype, typcollation, etc.).
- **`pg_range`, `pg_enum`, `pg_description`, `pg_operator`, `pg_collation`, `pg_language`, `pg_authid`, `pg_auth_members`, `pg_trigger`, `pg_rewrite`** exist as virtual relations. `pg_range` ships the six canonical range rows (int4range/int8range/numrange/tsrange/tstzrange/daterange); `pg_language` ships internal/c/sql/plpgsql; `pg_collation` ships default/C/POSIX.
- **Execute no longer emits `RowDescription`.** Per PG 18 wire spec (Message Flow / Extended Query): *"Execute doesn't cause ReadyForQuery or RowDescription to be issued."* The pre-existing `extended_query_flow_requires_sync_for_ready` test that encoded the wrong behaviour is rewritten alongside a new test covering the psql/tokio-postgres path (Parse → Bind → Describe-portal → Execute → Sync).
- **Parse-time parameter-type inference** (`src/tcop/pquery.rs::infer_statement_parameter_types`). Walks the AST after parse and fills any `$N` slot still marked OID 0 from context: `$N::type` casts, `col = $N` comparisons, `INSERT VALUES` column matching, `UPDATE SET` assignments, plus descent through BETWEEN / IN / CASE / array subscripts / subqueries. Without this, drivers recurse on `get_type(0)`.

## Test plan

- [x] `cargo test --lib` — 848/848 pass
- [x] `cargo test --test tokio_postgres_compat` — 6/6 pass (new harness; spawns in-process pgwire listener on an ephemeral port, drives real tokio-postgres against it)
- [x] `cargo test --test regression` — 12,329 PG statements at 100%
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] `scripts/build_wasm.sh` — succeeds

## Not included (deferred)

- `SqlType` refactor so `int4` / `int2` / `varchar` / `timestamptz` surface their real OIDs in `RowDescription` instead of collapsing to int8/text. That's Phase 2; catalog correctness here unblocks the loop, type-OID fidelity finishes the story.
- `CREATE DATABASE`, extension additions (citext/hstore/ltree/cube), error-code fidelity, parser holes (`CURRENT_TIMESTAMP`, `AT TIME ZONE`, composite `CREATE TYPE`). Phases 3–7.

## Incidental cleanups along the way

- Hardcoded `ScalarValue::Int(10)` / `Int(11)` replaced with named `BOOTSTRAP_SUPERUSER_OID` / `PG_CATALOG_NAMESPACE_OID` / `PUBLIC_NAMESPACE_OID` constants.
- `pg_proc.pronamespace` now reports `PUBLIC_NAMESPACE_OID` for user-declared functions (was `Int(0)` — user functions live in `public`, not `pg_catalog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)