### PR TITLE
feat: time/interval binary encoders (Phase 2 follow-up)

### DIFF
--- a/src/tcop/postgres/encoding.rs
+++ b/src/tcop/postgres/encoding.rs
@@ -150,6 +150,23 @@ pub(super) fn encode_binary_scalar(
             let micros = parse_pg_timestamp_micros(v)?;
             Ok(micros.to_be_bytes().to_vec())
         }
+        // ── time: i64 microseconds since 00:00:00
+        (1083, ScalarValue::Text(v)) => {
+            let micros = parse_pg_time_micros(v)?;
+            Ok(micros.to_be_bytes().to_vec())
+        }
+        // ── interval: i64 microseconds, i32 days, i32 months (16 bytes).
+        // The engine's `IntervalValue::seconds` is second-precision only, so
+        // sub-second fractions of the text form are already truncated before
+        // we reach this encoder — we multiply seconds × 1_000_000 on the wire.
+        (1186, ScalarValue::Text(v)) => {
+            let (months, days, micros) = parse_pg_interval_parts(v)?;
+            let mut out = Vec::with_capacity(16);
+            out.extend_from_slice(&micros.to_be_bytes());
+            out.extend_from_slice(&days.to_be_bytes());
+            out.extend_from_slice(&months.to_be_bytes());
+            Ok(out)
+        }
         // ── jsonb: 1-byte version prefix (always 1 per PG 9.4+) then JSON text
         (3802, ScalarValue::Text(v)) => {
             let mut out = Vec::with_capacity(v.len() + 1);
@@ -342,6 +359,32 @@ pub(super) fn decode_binary_scalar(
             ]);
             Ok(ScalarValue::Text(format_pg_timestamp_from_micros(micros)))
         }
+        1083 => {
+            if raw.len() != 8 {
+                return Err(SessionError {
+                    message: format!("{context} time field length must be 8"),
+                });
+            }
+            let micros = i64::from_be_bytes([
+                raw[0], raw[1], raw[2], raw[3], raw[4], raw[5], raw[6], raw[7],
+            ]);
+            Ok(ScalarValue::Text(format_pg_time_from_micros(micros)))
+        }
+        1186 => {
+            if raw.len() != 16 {
+                return Err(SessionError {
+                    message: format!("{context} interval field length must be 16"),
+                });
+            }
+            let micros = i64::from_be_bytes([
+                raw[0], raw[1], raw[2], raw[3], raw[4], raw[5], raw[6], raw[7],
+            ]);
+            let days = i32::from_be_bytes([raw[8], raw[9], raw[10], raw[11]]);
+            let months = i32::from_be_bytes([raw[12], raw[13], raw[14], raw[15]]);
+            Ok(ScalarValue::Text(format_pg_interval_from_parts(
+                months, days, micros,
+            )))
+        }
         // jsonb binary format: 1-byte version prefix (1), then UTF-8 JSON text
         3802 => {
             if raw.is_empty() {
@@ -399,6 +442,95 @@ pub(super) fn format_pg_date_from_days(days: i32) -> String {
     let absolute_days = pg_epoch + days as i64;
     let (year, month, day) = civil_from_days(absolute_days);
     format!("{year:04}-{month:02}-{day:02}")
+}
+
+pub(super) fn parse_pg_time_micros(text: &str) -> Result<i64, SessionError> {
+    let (hour, minute, second, micros) = parse_time_hms_micros(text.trim())?;
+    Ok((hour as i64) * 3_600_000_000
+        + (minute as i64) * 60_000_000
+        + (second as i64) * 1_000_000
+        + (micros as i64))
+}
+
+pub(super) fn format_pg_time_from_micros(micros: i64) -> String {
+    let day_micros = 86_400_000_000i64;
+    let clamped = micros.rem_euclid(day_micros);
+    let hour = clamped / 3_600_000_000;
+    let minute = (clamped % 3_600_000_000) / 60_000_000;
+    let second = (clamped % 60_000_000) / 1_000_000;
+    let fractional = clamped % 1_000_000;
+    if fractional == 0 {
+        format!("{hour:02}:{minute:02}:{second:02}")
+    } else {
+        format!("{hour:02}:{minute:02}:{second:02}.{fractional:06}")
+    }
+}
+
+/// Parse the engine's interval text format `"M mons D days [-]HH:MM:SS"` into
+/// `(months, days, microseconds)` for the wire encoder. The engine stores
+/// seconds with no sub-second precision, so we multiply by 1_000_000 here.
+pub(super) fn parse_pg_interval_parts(text: &str) -> Result<(i32, i32, i64), SessionError> {
+    let trimmed = text.trim();
+    let invalid = || SessionError {
+        message: format!("interval text `{trimmed}` is invalid"),
+    };
+    let parts: Vec<&str> = trimmed.split_whitespace().collect();
+    if parts.len() != 5 || parts[1] != "mons" || parts[3] != "days" {
+        return Err(invalid());
+    }
+    let months: i32 = parts[0].parse().map_err(|_| invalid())?;
+    let days: i32 = parts[2].parse().map_err(|_| invalid())?;
+    let time_part = parts[4];
+    let (sign, hms) = match time_part.strip_prefix('-') {
+        Some(rest) => (-1i64, rest),
+        None => (1i64, time_part),
+    };
+    // Interval HMS is unbounded — `INTERVAL '36 hours'` renders as
+    // `"36:00:00"`, which `parse_time_hms_micros` would reject. Split
+    // inline without the 24-hour cap.
+    let hms_parts: Vec<&str> = hms.split(':').collect();
+    if hms_parts.len() != 3 {
+        return Err(invalid());
+    }
+    let hour: u64 = hms_parts[0].parse().map_err(|_| invalid())?;
+    let minute: u64 = hms_parts[1].parse().map_err(|_| invalid())?;
+    if minute >= 60 {
+        return Err(invalid());
+    }
+    let (second, micros_frac) = if let Some((sec, frac)) = hms_parts[2].split_once('.') {
+        let second: u64 = sec.parse().map_err(|_| invalid())?;
+        let digits: String = frac.chars().take(6).collect();
+        let mut padded = digits;
+        while padded.len() < 6 {
+            padded.push('0');
+        }
+        let micros: u64 = padded.parse().map_err(|_| invalid())?;
+        (second, micros)
+    } else {
+        let second: u64 = hms_parts[2].parse().map_err(|_| invalid())?;
+        (second, 0)
+    };
+    if second >= 60 {
+        return Err(invalid());
+    }
+    let magnitude = (hour as i64) * 3_600_000_000
+        + (minute as i64) * 60_000_000
+        + (second as i64) * 1_000_000
+        + (micros_frac as i64);
+    Ok((months, days, sign * magnitude))
+}
+
+/// Format `(months, days, microseconds)` back into the engine's interval text
+/// format so callers see a consistent `ScalarValue::Text` representation.
+pub(super) fn format_pg_interval_from_parts(months: i32, days: i32, micros: i64) -> String {
+    let sign = if micros < 0 { "-" } else { "" };
+    let abs = micros.unsigned_abs();
+    let hours = abs / 3_600_000_000;
+    let minutes = (abs % 3_600_000_000) / 60_000_000;
+    let seconds = (abs % 60_000_000) / 1_000_000;
+    // The engine's text format does not carry sub-second digits; the decoder
+    // preserves that shape so round-tripping stays stable.
+    format!("{months} mons {days} days {sign}{hours:02}:{minutes:02}:{seconds:02}")
 }
 
 pub(super) fn format_pg_timestamp_from_micros(micros: i64) -> String {

--- a/src/tcop/postgres/mod.rs
+++ b/src/tcop/postgres/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;

--- a/src/tcop/postgres/tests.rs
+++ b/src/tcop/postgres/tests.rs
@@ -1209,3 +1209,83 @@ fn implicit_transaction_auto_rollback_prevents_cascade_failures() {
         )
     }));
 }
+
+#[test]
+fn time_binary_encode_roundtrips_through_decode() {
+    let encoded =
+        encode_binary_scalar(&ScalarValue::Text("12:34:56.789012".to_string()), 1083, "t")
+            .expect("time encodes");
+    assert_eq!(encoded.len(), 8);
+    let expected_micros: i64 = 12 * 3_600_000_000 + 34 * 60_000_000 + 56 * 1_000_000 + 789_012;
+    assert_eq!(encoded, expected_micros.to_be_bytes().to_vec());
+
+    let decoded = decode_binary_scalar(&encoded, 1083, "t").expect("time decodes");
+    assert_eq!(decoded, ScalarValue::Text("12:34:56.789012".to_string()));
+}
+
+#[test]
+fn time_binary_encode_zero_fraction_formats_without_decimal() {
+    let encoded =
+        encode_binary_scalar(&ScalarValue::Text("00:00:00".to_string()), 1083, "t").unwrap();
+    assert_eq!(encoded, 0i64.to_be_bytes().to_vec());
+    let decoded = decode_binary_scalar(&encoded, 1083, "t").unwrap();
+    assert_eq!(decoded, ScalarValue::Text("00:00:00".to_string()));
+}
+
+#[test]
+fn interval_binary_encode_lays_out_micros_days_months() {
+    // Engine text: "3 mons 14 days 02:30:00"
+    let encoded = encode_binary_scalar(
+        &ScalarValue::Text("3 mons 14 days 02:30:00".to_string()),
+        1186,
+        "i",
+    )
+    .expect("interval encodes");
+    assert_eq!(encoded.len(), 16);
+    let micros = i64::from_be_bytes(encoded[0..8].try_into().unwrap());
+    let days = i32::from_be_bytes(encoded[8..12].try_into().unwrap());
+    let months = i32::from_be_bytes(encoded[12..16].try_into().unwrap());
+    assert_eq!(micros, 2 * 3_600_000_000 + 30 * 60_000_000);
+    assert_eq!(days, 14);
+    assert_eq!(months, 3);
+}
+
+#[test]
+fn interval_binary_encode_roundtrips_negative_time() {
+    let encoded = encode_binary_scalar(
+        &ScalarValue::Text("0 mons 0 days -01:00:00".to_string()),
+        1186,
+        "i",
+    )
+    .unwrap();
+    let decoded = decode_binary_scalar(&encoded, 1186, "i").unwrap();
+    assert_eq!(
+        decoded,
+        ScalarValue::Text("0 mons 0 days -01:00:00".to_string())
+    );
+}
+
+#[test]
+fn interval_binary_encode_accepts_hours_over_24() {
+    // The engine renders intervals without a 24-hour cap, e.g. `36:45:00`,
+    // so the interval HMS parse path must not reject hours >= 24 — unlike
+    // `time` which is bounded to [00:00, 24:00).
+    let encoded = encode_binary_scalar(
+        &ScalarValue::Text("0 mons 0 days 36:45:00".to_string()),
+        1186,
+        "i",
+    )
+    .expect("36-hour interval encodes");
+    let micros = i64::from_be_bytes(encoded[0..8].try_into().unwrap());
+    assert_eq!(micros, 36 * 3_600_000_000 + 45 * 60_000_000);
+}
+
+#[test]
+fn interval_binary_encode_rejects_unknown_text_shape() {
+    let err = encode_binary_scalar(
+        &ScalarValue::Text("3 months, 14 days, 02:30:00".to_string()),
+        1186,
+        "i",
+    );
+    assert!(err.is_err());
+}

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -640,3 +640,25 @@ async fn null_column_does_not_force_binary_encoding_of_whole_row() {
     assert_eq!(row.get(1), None);
     assert_eq!(row.get(2), Some("keep"));
 }
+
+/// Phase 2 follow-up: a `time` cast must surface with OID 1083 and decode
+/// binary into chrono::NaiveTime via the tokio-postgres `with-chrono-0_4`
+/// path. Prior to this follow-up the OID was right but the binary format
+/// was unsupported, so the client's binary decode path would error.
+#[tokio::test(flavor = "multi_thread")]
+async fn time_cast_surfaces_as_oid_1083_and_decodes_binary() {
+    use chrono::NaiveTime;
+
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let row = client
+        .query_one("SELECT CAST('12:34:56' AS time) AS t", &[])
+        .await
+        .expect("query");
+    let col = &row.columns()[0];
+    assert_eq!(col.type_().oid(), 1083, "time OID must be 1083");
+
+    let decoded: NaiveTime = row.get(0);
+    assert_eq!(decoded, NaiveTime::from_hms_opt(12, 34, 56).unwrap());
+}


### PR DESCRIPTION
## Summary

- Binary encode/decode for **OID 1083 (time)** — i64 microseconds since 00:00. Works end-to-end with `tokio-postgres` chrono::NaiveTime.
- Binary encode/decode for **OID 1186 (interval)** — i64 micros + i32 days + i32 months (16 bytes, PG wire layout).
- Cfg-gate `use std::cell::RefCell` in `src/tcop/postgres/mod.rs` so wasm builds stop warning (`SYNC_RUNTIME` is already cfg'd out there).

Branch name is a misnomer — this is the first slice of follow-up task #15. PG **numeric** binary (task #18) and **array** binary (task #19) are separate PRs per advisor guidance; bundling all three would have been another 1500+ LOC review.

## Known limitations (called out so they don't surprise reviewers)

- Sub-second precision on intervals is **truncated at the engine layer**: `IntervalValue::seconds` is `i64` with no microseconds field, so the wire encoder just multiplies by 1_000_000. Fixing this requires widening `IntervalValue` and updating `parse_interval_text` / `format_interval` — tracked separately.
- No tokio-postgres integration test for interval: tokio-postgres can't decode interval without the `pg_interval` dep. Unit tests cover the binary layout, sign handling, and round-trip.
- Interval HMS is **unbounded** (`INTERVAL '36 hours'` renders as `"36:00:00"`), so `parse_pg_interval_parts` splits HMS inline rather than reusing `parse_time_hms_micros` — that validator is correct for `time` and must keep its 24-hour cap.

## Test plan

- [x] `cargo test --lib` — 866 tests pass
- [x] `cargo test --test tokio_postgres_compat` — 17 tests pass, including new `time_cast_surfaces_as_oid_1083_and_decodes_binary`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --lib --target wasm32-unknown-unknown` — RefCell warning gone
- [x] New unit tests: `time_binary_encode_roundtrips_through_decode`, `time_binary_encode_zero_fraction_formats_without_decimal`, `interval_binary_encode_lays_out_micros_days_months`, `interval_binary_encode_accepts_hours_over_24` (regression — would fail before the inline HMS split), `interval_binary_encode_roundtrips_negative_time`, `interval_binary_encode_rejects_unknown_text_shape`

🤖 Generated with [Claude Code](https://claude.com/claude-code)