### PR TITLE
feat: PG 1-D array binary encode/decode (Phase 2 follow-up)

### DIFF
--- a/src/tcop/postgres/encoding.rs
+++ b/src/tcop/postgres/encoding.rs
@@ -174,12 +174,63 @@ pub(super) fn encode_binary_scalar(
             out.extend_from_slice(v.as_bytes());
             Ok(out)
         }
+        // ── 1-D array: header then length-prefixed element payloads.
+        // Multi-dim arrays are intentionally rejected on decode; encoding is
+        // driven by `ScalarValue::Array(Vec<…>)` which is flat by construction.
+        (array_oid, ScalarValue::Array(values))
+            if crate::types::element_oid_from_array_oid(array_oid).is_some() =>
+        {
+            encode_pg_array_binary(array_oid, values, context)
+        }
         // ── NULL: callers use length=-1 framing; payload is empty.
         (_, ScalarValue::Null) => Ok(Vec::new()),
         _ => Err(SessionError {
             message: format!("{context} binary type oid {type_oid} is not supported"),
         }),
     }
+}
+
+/// Build the PG binary array wire payload for a flat (1-D) `ScalarValue::Array`.
+///
+/// Layout (see Postgres `array_send` in src/backend/utils/adt/arrayfuncs.c):
+/// ```text
+///   i32 ndim            number of dimensions (1 here)
+///   i32 dataoffset      0 — NULLs are inline as length=-1, no null bitmap
+///   i32 element_oid     OID of the element type
+///   per-dim:
+///     i32 size            len(values)
+///     i32 lower_bound     1 (PG default)
+///   per-element:
+///     i32 length          -1 for NULL, otherwise byte count
+///     bytes[]             encoded element (recursive encode_binary_scalar)
+/// ```
+fn encode_pg_array_binary(
+    array_oid: PgType,
+    values: &[ScalarValue],
+    context: &str,
+) -> Result<Vec<u8>, SessionError> {
+    let element_oid =
+        crate::types::element_oid_from_array_oid(array_oid).ok_or_else(|| SessionError {
+            message: format!("{context} binary array oid {array_oid} is not supported"),
+        })?;
+    let mut out = Vec::with_capacity(20 + values.len() * 8);
+    out.extend_from_slice(&1i32.to_be_bytes()); // ndim
+    out.extend_from_slice(&0i32.to_be_bytes()); // dataoffset
+    out.extend_from_slice(&element_oid.to_be_bytes());
+    // For empty arrays PG sometimes emits ndim=0 with no dim headers. We
+    // always emit ndim=1 + a zero-length dim; tokio-postgres accepts both.
+    out.extend_from_slice(&(values.len() as i32).to_be_bytes()); // dim size
+    out.extend_from_slice(&1i32.to_be_bytes()); // lower bound
+    for value in values {
+        if matches!(value, ScalarValue::Null) {
+            out.extend_from_slice(&(-1i32).to_be_bytes());
+            continue;
+        }
+        let bytes = encode_binary_scalar(value, element_oid, context)?;
+        out.extend_from_slice(&(bytes.len() as i32).to_be_bytes());
+        out.extend_from_slice(&bytes);
+    }
+    Ok(out)
 }
 
 /// Decode the Postgres bytea text format into raw bytes.
@@ -403,10 +454,99 @@ pub(super) fn decode_binary_scalar(
                 })?,
             ))
         }
+        other if crate::types::element_oid_from_array_oid(other).is_some() => {
+            decode_pg_array_binary(raw, other, context)
+        }
         other => Err(SessionError {
             message: format!("{context} binary type oid {other} is not supported"),
         }),
     }
+}
+
+/// Decode the PG binary array wire format into `ScalarValue::Array`. Only
+/// 1-D arrays are supported — `ndim > 1` is rejected rather than flattened
+/// so callers don't silently lose structure.
+fn decode_pg_array_binary(
+    raw: &[u8],
+    array_oid: PgType,
+    context: &str,
+) -> Result<ScalarValue, SessionError> {
+    if raw.len() < 12 {
+        return Err(SessionError {
+            message: format!("{context} array header truncated"),
+        });
+    }
+    let ndim = i32::from_be_bytes(raw[0..4].try_into().unwrap());
+    // PG sometimes emits ndim=0 for empty arrays; accept that as an empty 1-D.
+    if !(0..=1).contains(&ndim) {
+        return Err(SessionError {
+            message: format!("{context} multi-dim arrays (ndim={ndim}) are not supported yet"),
+        });
+    }
+    // dataoffset at [4..8] — we don't implement null bitmaps; PG normally
+    // writes 0 here. Non-zero means a null bitmap is present, which we skip
+    // because NULLs are always encoded inline as length=-1 on the send side.
+    // Reading a null bitmap here would be incorrect for flat 1-D decoding;
+    // surface an error so we don't silently mis-read.
+    let dataoffset = i32::from_be_bytes(raw[4..8].try_into().unwrap());
+    if dataoffset != 0 {
+        return Err(SessionError {
+            message: format!("{context} array null bitmap is not supported"),
+        });
+    }
+    let element_oid = u32::from_be_bytes(raw[8..12].try_into().unwrap());
+    let expected_element =
+        crate::types::element_oid_from_array_oid(array_oid).ok_or_else(|| SessionError {
+            message: format!("{context} array oid {array_oid} is not supported"),
+        })?;
+    if element_oid != expected_element {
+        return Err(SessionError {
+            message: format!(
+                "{context} array element oid mismatch: header={element_oid}, expected={expected_element}"
+            ),
+        });
+    }
+    if ndim == 0 {
+        return Ok(ScalarValue::Array(Vec::new()));
+    }
+    if raw.len() < 20 {
+        return Err(SessionError {
+            message: format!("{context} array dim header truncated"),
+        });
+    }
+    let dim_size = i32::from_be_bytes(raw[12..16].try_into().unwrap());
+    // lower_bound at [16..20] — we don't propagate it because ScalarValue::Array
+    // is always 1-based in the engine. Ignore.
+    let mut cursor = 20;
+    let mut values = Vec::with_capacity(dim_size.max(0) as usize);
+    for _ in 0..dim_size {
+        if cursor + 4 > raw.len() {
+            return Err(SessionError {
+                message: format!("{context} array element length truncated"),
+            });
+        }
+        let len = i32::from_be_bytes(raw[cursor..cursor + 4].try_into().unwrap());
+        cursor += 4;
+        if len == -1 {
+            values.push(ScalarValue::Null);
+            continue;
+        }
+        if len < 0 {
+            return Err(SessionError {
+                message: format!("{context} array element has negative length {len}"),
+            });
+        }
+        let end = cursor + len as usize;
+        if end > raw.len() {
+            return Err(SessionError {
+                message: format!("{context} array element payload truncated"),
+            });
+        }
+        let elem = decode_binary_scalar(&raw[cursor..end], element_oid, context)?;
+        values.push(elem);
+        cursor = end;
+    }
+    Ok(ScalarValue::Array(values))
 }
 
 pub(super) fn parse_pg_date_days(text: &str) -> Result<i32, SessionError> {

--- a/src/tcop/postgres/tests.rs
+++ b/src/tcop/postgres/tests.rs
@@ -1281,6 +1281,97 @@ fn interval_binary_encode_accepts_hours_over_24() {
 }
 
 #[test]
+fn int4_array_binary_encode_layout() {
+    // Int4[] = [7, 8, 9] — header + 3 length-prefixed int4 payloads.
+    let values = vec![
+        ScalarValue::Int(7),
+        ScalarValue::Int(8),
+        ScalarValue::Int(9),
+    ];
+    let encoded =
+        encode_binary_scalar(&ScalarValue::Array(values), 1007, "a").expect("int4[] encodes");
+    assert_eq!(i32::from_be_bytes(encoded[0..4].try_into().unwrap()), 1); // ndim
+    assert_eq!(i32::from_be_bytes(encoded[4..8].try_into().unwrap()), 0); // dataoffset
+    assert_eq!(u32::from_be_bytes(encoded[8..12].try_into().unwrap()), 23); // int4 oid
+    assert_eq!(i32::from_be_bytes(encoded[12..16].try_into().unwrap()), 3); // dim size
+    assert_eq!(i32::from_be_bytes(encoded[16..20].try_into().unwrap()), 1); // lower_bound
+    // first element: len=4, value=7
+    assert_eq!(i32::from_be_bytes(encoded[20..24].try_into().unwrap()), 4);
+    assert_eq!(i32::from_be_bytes(encoded[24..28].try_into().unwrap()), 7);
+}
+
+#[test]
+fn int4_array_binary_roundtrips_with_nulls() {
+    let values = vec![ScalarValue::Int(1), ScalarValue::Null, ScalarValue::Int(3)];
+    let encoded = encode_binary_scalar(&ScalarValue::Array(values.clone()), 1007, "a").unwrap();
+    let decoded = decode_binary_scalar(&encoded, 1007, "a").unwrap();
+    match decoded {
+        ScalarValue::Array(got) => {
+            assert_eq!(got.len(), 3);
+            assert!(matches!(got[0], ScalarValue::Int(1)));
+            assert!(matches!(got[1], ScalarValue::Null));
+            assert!(matches!(got[2], ScalarValue::Int(3)));
+        }
+        other => panic!("expected Array, got {other:?}"),
+    }
+}
+
+#[test]
+fn text_array_binary_roundtrips() {
+    let values = vec![
+        ScalarValue::Text("hello".to_string()),
+        ScalarValue::Text("world".to_string()),
+    ];
+    let encoded = encode_binary_scalar(&ScalarValue::Array(values.clone()), 1009, "a").unwrap();
+    let decoded = decode_binary_scalar(&encoded, 1009, "a").unwrap();
+    assert_eq!(decoded, ScalarValue::Array(values));
+}
+
+#[test]
+fn empty_int4_array_binary_decodes() {
+    let encoded = encode_binary_scalar(&ScalarValue::Array(Vec::new()), 1007, "a").unwrap();
+    // Header alone = 20 bytes (ndim + dataoffset + oid + dim_size + lower_bound).
+    assert_eq!(encoded.len(), 20);
+    let decoded = decode_binary_scalar(&encoded, 1007, "a").unwrap();
+    assert_eq!(decoded, ScalarValue::Array(Vec::new()));
+}
+
+#[test]
+fn empty_array_with_ndim_zero_is_accepted_on_decode() {
+    // Some PG versions emit ndim=0 for empty arrays. Construct that shape
+    // by hand and make sure the decoder accepts it.
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&0i32.to_be_bytes()); // ndim=0
+    raw.extend_from_slice(&0i32.to_be_bytes()); // dataoffset
+    raw.extend_from_slice(&23u32.to_be_bytes()); // int4 element oid
+    let decoded = decode_binary_scalar(&raw, 1007, "a").unwrap();
+    assert_eq!(decoded, ScalarValue::Array(Vec::new()));
+}
+
+#[test]
+fn multidim_array_binary_decode_is_rejected() {
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&2i32.to_be_bytes()); // ndim=2 — not supported
+    raw.extend_from_slice(&0i32.to_be_bytes());
+    raw.extend_from_slice(&23u32.to_be_bytes());
+    let err = decode_binary_scalar(&raw, 1007, "a");
+    assert!(err.is_err());
+}
+
+#[test]
+fn array_element_oid_mismatch_is_rejected() {
+    // Header says int4 element; decoder was asked for int8[] → reject.
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&1i32.to_be_bytes());
+    raw.extend_from_slice(&0i32.to_be_bytes());
+    raw.extend_from_slice(&23u32.to_be_bytes()); // int4 — but we'll decode as int8[]
+    raw.extend_from_slice(&0i32.to_be_bytes());
+    raw.extend_from_slice(&1i32.to_be_bytes());
+    let err = decode_binary_scalar(&raw, 1016, "a");
+    assert!(err.is_err());
+}
+
+#[test]
 fn interval_binary_encode_rejects_unknown_text_shape() {
     let err = encode_binary_scalar(
         &ScalarValue::Text("3 months, 14 days, 02:30:00".to_string()),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -35,4 +35,4 @@
 
 pub mod sql_type;
 
-pub use sql_type::{SqlType, parse_sql_type_name};
+pub use sql_type::{SqlType, element_oid_from_array_oid, parse_sql_type_name};

--- a/src/types/sql_type.rs
+++ b/src/types/sql_type.rs
@@ -358,6 +358,42 @@ fn array_oid_for_element(element: &SqlType) -> Oid {
     }
 }
 
+/// Reverse of `array_oid_for_element`: array OID → element OID.
+///
+/// Used by the pgwire binary encoder/decoder to dispatch element-wise. Covers
+/// every entry in `array_oid_for_element`; unknown inputs return `None` so
+/// callers can surface a clear error.
+pub fn element_oid_from_array_oid(array_oid: Oid) -> Option<Oid> {
+    let elem = match array_oid {
+        1000 => 16,   // bool[]
+        1001 => 17,   // bytea[]
+        1002 => 18,   // "char"[]
+        1003 => 19,   // name[]
+        1005 => 21,   // int2[]
+        1007 => 23,   // int4[]
+        1008 => 24,   // regproc[]
+        1009 => 25,   // text[]
+        1014 => 1042, // bpchar[]
+        1015 => 1043, // varchar[]
+        1016 => 20,   // int8[]
+        1021 => 700,  // float4[]
+        1022 => 701,  // float8[]
+        1028 => 26,   // oid[]
+        199 => 114,   // json[]
+        1115 => 1114, // timestamp[]
+        1182 => 1082, // date[]
+        1183 => 1083, // time[]
+        1185 => 1184, // timestamptz[]
+        1187 => 1186, // interval[]
+        1231 => 1700, // numeric[]
+        1270 => 1266, // timetz[]
+        2951 => 2950, // uuid[]
+        3807 => 3802, // jsonb[]
+        _ => return None,
+    };
+    Some(elem)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -662,3 +662,65 @@ async fn time_cast_surfaces_as_oid_1083_and_decodes_binary() {
     let decoded: NaiveTime = row.get(0);
     assert_eq!(decoded, NaiveTime::from_hms_opt(12, 34, 56).unwrap());
 }
+
+/// Phase 2 follow-up: int4[] must surface with OID 1007 and decode as
+/// `Vec<i32>` via tokio-postgres' binary path. tokio-postgres requests
+/// format 1 for Vec<i32> — if our PG array binary layout is wrong the
+/// decode errors instead of silently succeeding.
+#[tokio::test(flavor = "multi_thread")]
+async fn int4_array_decodes_as_vec_i32() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let row = client
+        .query_one("SELECT ARRAY[10, 20, 30]::int4[] AS xs", &[])
+        .await
+        .expect("query");
+    assert_eq!(row.columns()[0].type_().oid(), 1007);
+    let decoded: Vec<i32> = row.get(0);
+    assert_eq!(decoded, vec![10, 20, 30]);
+}
+
+/// Empty-array round-trip via the binary path.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_int4_array_decodes_as_empty_vec() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let row = client
+        .query_one("SELECT ARRAY[]::int4[] AS xs", &[])
+        .await
+        .expect("query");
+    assert_eq!(row.columns()[0].type_().oid(), 1007);
+    let decoded: Vec<i32> = row.get(0);
+    assert!(decoded.is_empty());
+}
+
+/// text[] round-trips as `Vec<String>`.
+#[tokio::test(flavor = "multi_thread")]
+async fn text_array_decodes_as_vec_string() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let row = client
+        .query_one("SELECT ARRAY['alpha', 'beta']::text[] AS xs", &[])
+        .await
+        .expect("query");
+    assert_eq!(row.columns()[0].type_().oid(), 1009);
+    let decoded: Vec<String> = row.get(0);
+    assert_eq!(decoded, vec!["alpha".to_string(), "beta".to_string()]);
+}
+
+/// NULLs within an int4[] decode as `Option<i32>::None` at the element level.
+#[tokio::test(flavor = "multi_thread")]
+async fn int4_array_with_null_decodes() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let row = client
+        .query_one("SELECT ARRAY[1, NULL, 3]::int4[] AS xs", &[])
+        .await
+        .expect("query");
+    let decoded: Vec<Option<i32>> = row.get(0);
+    assert_eq!(decoded, vec![Some(1), None, Some(3)]);
+}


### PR DESCRIPTION
## Summary

Adds binary encode/decode for 1-D arrays so tokio-postgres and sqlx can round-trip `Vec<T>` through the PG wire.

Dispatches per element via recursive `encode_binary_scalar`, so every array-of-supported-type works from the same code path: `int4[]`, `int8[]`, `text[]`, `varchar[]`, `float4[]`, `float8[]`, `bool[]`, `uuid[]`, `timestamptz[]`, etc.

Adds `element_oid_from_array_oid` reverse map alongside the existing `array_oid_for_element` in `src/types/sql_type.rs` — kept co-located so new array types get both directions in one edit.

## Wire layout

Matches PG `array_send`:

```
i32 ndim = 1
i32 dataoffset = 0    (no null bitmap; NULLs are inline as length=-1)
i32 element_oid
i32 dim_size
i32 lower_bound = 1
[ i32 elem_len, elem_bytes... ]  per element, len=-1 for NULL
```

## Known limitations (deliberate, to keep the PR scoped)

- **Multi-dim arrays (ndim > 1)** — decoder rejects with a clear error rather than silently flattening. Encoder always emits `ndim=1` (matches the engine's flat `ScalarValue::Array`).
- **Array payloads with a null bitmap (`dataoffset != 0`)** — rejected on decode. Sends always inline NULL as `length=-1`, which is what every mainstream driver expects and what PG itself emits when there are no inserted NULLs.
- **`uuid[]` surfaces as `text[]` (OID 25)** today — this is a separate expression-typer bug (`ARRAY['...'::uuid]` collapses the element CAST). The encoder is ready for `uuid[]` (OID 2951) once the typer is fixed.

## Test plan

- [x] `cargo test --lib` — 873 tests pass
- [x] `cargo test --test tokio_postgres_compat` — 21 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --lib --target wasm32-unknown-unknown` clean

New unit tests:
- `int4_array_binary_encode_layout` — pins the exact byte layout (ndim, dataoffset, element oid, dim size, lower bound, element len+value)
- `int4_array_binary_roundtrips_with_nulls` — NULL at arbitrary position survives encode → decode
- `text_array_binary_roundtrips` — text element path
- `empty_int4_array_binary_decodes` — header-only empty array
- `empty_array_with_ndim_zero_is_accepted_on_decode` — tolerates PG's alternate empty-array shape
- `multidim_array_binary_decode_is_rejected` — clear error, not silent flatten
- `array_element_oid_mismatch_is_rejected` — catches misdeclared array type

New integration tests via tokio-postgres (binary path, not just byte shape):
- `int4_array_decodes_as_vec_i32`
- `empty_int4_array_decodes_as_empty_vec`
- `text_array_decodes_as_vec_string`
- `int4_array_with_null_decodes` — `Vec<Option<i32>>` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)