### PR TITLE
fix: ArrayConstructor surfaces element-typed array OID

### DIFF
--- a/src/tcop/pquery.rs
+++ b/src/tcop/pquery.rs
@@ -484,10 +484,23 @@ fn infer_expr_type(
                 ResolvedExprType::scalar(PG_TEXT_OID)
             }
         }
-        Expr::ArrayConstructor(exprs) => ResolvedExprType::new(
-            PG_TEXT_OID,
-            &array_type(common_array_element_subscript_type(exprs, scope, ctes)),
-        ),
+        Expr::ArrayConstructor(exprs) => {
+            // Derive the array's wire OID from the element OID so `ARRAY[x::uuid]`
+            // surfaces as uuid[] (2951) rather than text[] (1009). When the
+            // element type can't be resolved (empty array, mixed types), fall
+            // back to text[] — matches pre-Phase-2 behaviour.
+            let element_oid = infer_common_type_oid(exprs, scope, ctes);
+            let array_oid = crate::types::array_oid_from_element_oid(element_oid);
+            let array_oid = if array_oid == 0 {
+                PG_TEXT_OID
+            } else {
+                array_oid
+            };
+            ResolvedExprType::new(
+                array_oid,
+                &array_type(common_array_element_subscript_type(exprs, scope, ctes)),
+            )
+        }
         Expr::ArraySubquery(_) => {
             ResolvedExprType::new(PG_TEXT_OID, &array_type(SubscriptValueType::Other))
         }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -35,4 +35,6 @@
 
 pub mod sql_type;
 
-pub use sql_type::{SqlType, element_oid_from_array_oid, parse_sql_type_name};
+pub use sql_type::{
+    SqlType, array_oid_from_element_oid, element_oid_from_array_oid, parse_sql_type_name,
+};

--- a/src/types/sql_type.rs
+++ b/src/types/sql_type.rs
@@ -358,6 +358,42 @@ fn array_oid_for_element(element: &SqlType) -> Oid {
     }
 }
 
+/// Forward mapping from an element OID to its canonical array OID.
+///
+/// Returns 0 for element OIDs that have no standard array form. Useful in
+/// type inference when the element OID is known but the element's `SqlType`
+/// is not (e.g. a scalar expression whose result OID was computed through
+/// `infer_common_type_oid`).
+pub fn array_oid_from_element_oid(element_oid: Oid) -> Oid {
+    match element_oid {
+        16 => 1000,   // bool
+        17 => 1001,   // bytea
+        18 => 1002,   // "char"
+        19 => 1003,   // name
+        20 => 1016,   // int8
+        21 => 1005,   // int2
+        23 => 1007,   // int4
+        24 => 1008,   // regproc
+        25 => 1009,   // text
+        26 => 1028,   // oid
+        114 => 199,   // json
+        700 => 1021,  // float4
+        701 => 1022,  // float8
+        1042 => 1014, // bpchar
+        1043 => 1015, // varchar
+        1082 => 1182, // date
+        1083 => 1183, // time
+        1114 => 1115, // timestamp
+        1184 => 1185, // timestamptz
+        1186 => 1187, // interval
+        1266 => 1270, // timetz
+        1700 => 1231, // numeric
+        2950 => 2951, // uuid
+        3802 => 3807, // jsonb
+        _ => 0,
+    }
+}
+
 /// Reverse of `array_oid_for_element`: array OID → element OID.
 ///
 /// Used by the pgwire binary encoder/decoder to dispatch element-wise. Covers

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -711,6 +711,35 @@ async fn text_array_decodes_as_vec_string() {
     assert_eq!(decoded, vec!["alpha".to_string(), "beta".to_string()]);
 }
 
+/// Phase 2 follow-up: `ARRAY[x::uuid]` must surface as uuid[] (OID 2951),
+/// not text[] (1009). Before the typer fix, the element CAST collapsed at
+/// the array constructor and the encoder was unreachable for uuid[].
+#[tokio::test(flavor = "multi_thread")]
+async fn uuid_array_surfaces_as_oid_2951_and_decodes() {
+    use uuid::Uuid;
+
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let row = client
+        .query_one(
+            "SELECT ARRAY['11111111-1111-1111-1111-111111111111'::uuid, \
+             '22222222-2222-2222-2222-222222222222'::uuid] AS xs",
+            &[],
+        )
+        .await
+        .expect("query");
+    assert_eq!(row.columns()[0].type_().oid(), 2951);
+    let decoded: Vec<Uuid> = row.get(0);
+    assert_eq!(
+        decoded,
+        vec![
+            Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap(),
+            Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap(),
+        ]
+    );
+}
+
 /// NULLs within an int4[] decode as `Option<i32>::None` at the element level.
 #[tokio::test(flavor = "multi_thread")]
 async fn int4_array_with_null_decodes() {


### PR DESCRIPTION
## Summary

Unblocks end-to-end `uuid[]` (and other element-typed arrays) through tokio-postgres and sqlx. Before this, `SELECT ARRAY['...'::uuid]` advertised RowDescription OID 25 (text) because `ArrayConstructor` hardcoded `PG_TEXT_OID`. The Phase 2 array binary encoder couldn't be reached on that path.

Now: derive the element OID via `infer_common_type_oid`, map to the array OID via the new `array_oid_from_element_oid` helper. Unknown element OIDs fall back to text[] (preserves pre-Phase-2 behaviour for exotic/mixed element types).

## Test plan

- [x] `cargo test --lib` — 873 pass
- [x] `cargo test --test tokio_postgres_compat` — 22 pass, including new `uuid_array_surfaces_as_oid_2951_and_decodes`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)