### PR TITLE
feat: int binary operators preserve max-width OID (Phase 2)

### DIFF
--- a/src/tcop/pquery.rs
+++ b/src/tcop/pquery.rs
@@ -16,7 +16,10 @@ use crate::tcop::engine::EngineError;
 
 const PG_BOOL_OID: u32 = 16;
 const PG_INT8_OID: u32 = 20;
+const PG_INT2_OID: u32 = 21;
+const PG_INT4_OID: u32 = 23;
 const PG_TEXT_OID: u32 = 25;
+const PG_FLOAT4_OID: u32 = 700;
 const PG_FLOAT8_OID: u32 = 701;
 const PG_DATE_OID: u32 = 1082;
 const PG_TIMESTAMP_OID: u32 = 1114;
@@ -174,8 +177,31 @@ fn cast_type_name_to_oid(type_name: &str) -> u32 {
 }
 
 fn infer_numeric_result_oid(left: u32, right: u32) -> u32 {
+    // Max-width promotion within each family, matching PG's per-operator
+    // result types in `pg_operator.dat`:
+    //   int2+int2 → int2, int4+int4 → int4, int8+int8 → int8
+    //   mixed ints → the wider of the two
+    //   any float4 combined with int or float4 → float4
+    //   any float8 involvement → float8
+    // Unknown/text OIDs fall through to int8 (the prior behaviour), which
+    // keeps callers inferring a sensible numeric type when operand types
+    // aren't fully resolved.
     if left == PG_FLOAT8_OID || right == PG_FLOAT8_OID {
-        PG_FLOAT8_OID
+        return PG_FLOAT8_OID;
+    }
+    if left == PG_FLOAT4_OID || right == PG_FLOAT4_OID {
+        // float4 op int promotes to float4 in PG (no silent widen to float8).
+        return PG_FLOAT4_OID;
+    }
+    let is_int = |oid: u32| matches!(oid, PG_INT2_OID | PG_INT4_OID | PG_INT8_OID);
+    if is_int(left) && is_int(right) {
+        if left == PG_INT8_OID || right == PG_INT8_OID {
+            PG_INT8_OID
+        } else if left == PG_INT4_OID || right == PG_INT4_OID {
+            PG_INT4_OID
+        } else {
+            PG_INT2_OID
+        }
     } else {
         PG_INT8_OID
     }

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -711,6 +711,29 @@ async fn text_array_decodes_as_vec_string() {
     assert_eq!(decoded, vec!["alpha".to_string(), "beta".to_string()]);
 }
 
+/// Phase 2 follow-up: integer binary operators preserve the wider operand
+/// width instead of blindly widening to int8. Before, every `int4 + int4`
+/// surfaced as int8 (OID 20), which caused sqlx to reject a Vec<i32>
+/// result column when running trivial arithmetic.
+#[tokio::test(flavor = "multi_thread")]
+async fn int_binary_op_result_preserves_max_width() {
+    let port = spawn_server();
+    let client = connect(port).await;
+    for (sql, expected) in [
+        ("SELECT 1::int4 + 2::int4", 23), // int4 + int4 → int4
+        ("SELECT 1::int2 + 2::int2", 21), // int2 + int2 → int2
+        ("SELECT 1::int2 + 2::int4", 23), // max-width mix
+        ("SELECT 1::int4 * 2::int8", 20), // int8 wins
+    ] {
+        let stmt = client.prepare(sql).await.expect("prepare");
+        assert_eq!(
+            stmt.columns()[0].type_().oid(),
+            expected,
+            "{sql} should surface with OID {expected}"
+        );
+    }
+}
+
 /// Phase 2 follow-up: `ARRAY[x::uuid]` must surface as uuid[] (OID 2951),
 /// not text[] (1009). Before the typer fix, the element CAST collapsed at
 /// the array constructor and the encoder was unreachable for uuid[].


### PR DESCRIPTION
## Summary

Before: every int2/int4 binary op widened the result OID to int8 (20), so sqlx/tokio-postgres clients saw \`OID 20\` for \`SELECT 1::int4 + 2::int4\`. That broke trivial \`Vec<i32>\` decode paths and forced users to cast the whole expression back to int4 as a workaround.

Now \`infer_numeric_result_oid\` applies PG's max-width promotion rule:

- int2 + int2 → int2
- int4 + int4 → int4
- int2 + int4 → int4
- int8 + {int2 | int4 | int8} → int8
- {int, float4} → float4
- {anything, float8} → float8

## Deliberately out of scope

- **Literal inference** (bare \`SELECT 42\` reporting OID 20 instead of 23). That has a wider blast radius — \`Expr::Integer(_) → PG_INT8_OID\` fan-out into parameter-type inference and numerous tests using bare integer literals. Its own PR.
- **Cross-family coercion** (int + float8, int + numeric, etc.) — left at prior behavior.

## Test plan

- [x] \`cargo test --lib\` — 882 pass (no regressions)
- [x] \`cargo test --test tokio_postgres_compat\` — 23 pass, including new \`int_binary_op_result_preserves_max_width\`
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)