### PR TITLE
refactor: extract Oid alias to crate-root module

### DIFF
--- a/src/catalog/oid.rs
+++ b/src/catalog/oid.rs
@@ -1,18 +1,12 @@
 use super::CatalogError;
 
-pub type Oid = u32;
-
-pub const FIRST_NORMAL_OID: Oid = 16_384;
-
-// PG-canonical namespace OIDs. These match Postgres's bootstrap constants so
-// that catalog JOINs like `pg_type.typnamespace = pg_namespace.oid` hit the
-// rows real drivers expect.
-pub const PG_CATALOG_NAMESPACE_OID: Oid = 11;
-pub const PUBLIC_NAMESPACE_OID: Oid = 2_200;
-pub const INFORMATION_SCHEMA_NAMESPACE_OID: Oid = 13_000;
-
-// Superuser-role OID used wherever pg_catalog rows need an owner.
-pub const BOOTSTRAP_SUPERUSER_OID: Oid = 10;
+// Re-exports from the crate-root `oid` module. Kept here so existing
+// callers that import `crate::catalog::oid::Oid` continue to work after
+// the leaf module was introduced (Phase 2 layering cleanup).
+pub use crate::oid::{
+    BOOTSTRAP_SUPERUSER_OID, FIRST_NORMAL_OID, INFORMATION_SCHEMA_NAMESPACE_OID, Oid,
+    PG_CATALOG_NAMESPACE_OID, PUBLIC_NAMESPACE_OID,
+};
 
 #[derive(Debug, Clone)]
 pub struct OidGenerator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub mod commands;
 pub mod executor;
 pub mod extensions;
 pub mod foreign;
+pub mod oid;
 pub mod parser;
 pub mod planner;
 pub mod plpgsql;

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,0 +1,28 @@
+//! Postgres object-identifier primitives.
+//!
+//! Crate-root leaf module so both `catalog` and `types` can depend on it
+//! without either reaching into the other. The split was introduced during
+//! Phase 2 when `types::SqlType` grew to carry wire-level OIDs; before that
+//! the `Oid` alias lived in `catalog::oid`, which forced `types` to import
+//! from `catalog` (a higher-level module in terms of semantics).
+//!
+//! Only the primitive alias and canonical PG-bootstrap constants live here.
+//! The `OidGenerator` stays in `catalog::oid` because it models catalog state
+//! (error-on-exhaustion behaviour and `CatalogError`) rather than the pure
+//! identifier concept.
+
+pub type Oid = u32;
+
+/// The lowest OID catalog generators hand out for non-bootstrap objects.
+/// Matches Postgres's `FirstNormalObjectId` from `src/include/access/transam.h`.
+pub const FIRST_NORMAL_OID: Oid = 16_384;
+
+// PG-canonical namespace OIDs. These match Postgres's bootstrap constants so
+// that catalog JOINs like `pg_type.typnamespace = pg_namespace.oid` hit the
+// rows real drivers expect.
+pub const PG_CATALOG_NAMESPACE_OID: Oid = 11;
+pub const PUBLIC_NAMESPACE_OID: Oid = 2_200;
+pub const INFORMATION_SCHEMA_NAMESPACE_OID: Oid = 13_000;
+
+/// Superuser role OID used wherever pg_catalog rows need an owner.
+pub const BOOTSTRAP_SUPERUSER_OID: Oid = 10;

--- a/src/types/sql_type.rs
+++ b/src/types/sql_type.rs
@@ -1,6 +1,6 @@
 //! The `SqlType` enum. Canonical declared type of a column or expression.
 
-use crate::catalog::oid::Oid;
+use crate::oid::Oid;
 
 /// Declared SQL type. Carries enough information to emit a spec-correct
 /// `RowDescription` and to binary-encode values on the wire without guessing.


### PR DESCRIPTION
## Summary

Breaks the \`types → catalog::oid\` reverse dependency by moving the \`Oid\` type alias and canonical PG-bootstrap constants to a new leaf module at \`src/oid.rs\`.

Before, \`src/types/sql_type.rs\` imported \`crate::catalog::oid::Oid\` — a reverse dependency, since catalog is conceptually a lower layer and types carries wire-protocol semantics on top.

Changes:
- **New** \`src/oid.rs\`: holds \`Oid\`, \`FIRST_NORMAL_OID\`, canonical PG namespace/superuser OIDs. These are primitive identifiers, not catalog state, so a leaf module is the right home.
- \`src/catalog/oid.rs\`: re-exports from the new module and keeps \`OidGenerator\` (catalog-specific state with \`CatalogError\`).
- \`src/types/sql_type.rs\`: switches to \`crate::oid::Oid\`.

All 12 other files that import \`catalog::oid::{…}\` keep working unchanged via the re-export.

## Remaining scope (not blocking)

The **other direction** of the original inversion — \`src/catalog/table.rs\` storing \`sql_type: Option<crate::types::SqlType>\` on \`Column\` — is a separate design call. Two candidate resolutions:
1. Move \`SqlType\` into catalog (collapsing types to wire-encoding helpers).
2. Carve Column's wire metadata into a types-owned struct referenced by catalog.

Both are architectural and would benefit from human review of the tradeoffs.

## Test plan

- [x] \`cargo test --lib\` — 882 pass
- [x] \`cargo build --target wasm32-unknown-unknown\` clean
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)