### PR TITLE
feat: typed bind parameters (Phase 2.2)

### DIFF
--- a/src/catalog/iceberg.rs
+++ b/src/catalog/iceberg.rs
@@ -627,7 +627,7 @@ pub async fn scan_iceberg_table_with_predicate(
     path: &str,
     predicate: Option<&Expr>,
     qualifiers: &[String],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<IcebergScanPlan, EngineError> {
     let resolved = resolve_iceberg_table(path).await.map_err(to_engine_error)?;
     let partition_fields = resolved
@@ -672,7 +672,7 @@ pub fn extract_partition_predicates(
     predicate: &Expr,
     qualifiers: &[String],
     partition_fields: &[IcebergSchemaField],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<IcebergPartitionPredicate>, EngineError> {
     let partition_lookup = partition_fields
         .iter()
@@ -1366,7 +1366,7 @@ fn extract_single_partition_predicate(
     expr: &Expr,
     qualifiers: &[String],
     partition_lookup: &HashMap<String, IcebergSchemaField>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Option<IcebergPartitionPredicate>, EngineError> {
     match expr {
         Expr::Binary { left, op, right } => {
@@ -1441,7 +1441,7 @@ fn extract_partition_column_and_value(
     right: &Expr,
     qualifiers: &[String],
     partition_lookup: &HashMap<String, IcebergSchemaField>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Option<(String, IcebergSchemaField, ScalarValue, bool)>, EngineError> {
     if let Some((column, field)) = extract_partition_column(left, qualifiers, partition_lookup) {
         let value = eval_constant_scalar(right, params)?;
@@ -1485,7 +1485,7 @@ fn extract_partition_column(
 
 fn eval_constant_scalar(
     expr: &Expr,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ScalarValue, EngineError> {
     match expr {
         Expr::Null => Ok(ScalarValue::Null),
@@ -1515,7 +1515,7 @@ fn eval_constant_scalar(
         Expr::Parameter(index) => params
             .get(index.saturating_sub(1) as usize)
             .and_then(Option::as_ref)
-            .map(|value| ScalarValue::Text(value.clone()))
+            .cloned()
             .ok_or_else(|| EngineError {
                 message: format!("missing value for parameter ${index}"),
             }),

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -6,7 +6,7 @@ use crate::tcop::engine::{
 
 pub async fn execute_explain(
     explain: &ExplainStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     let mut plan_lines = Vec::new();
     let planned = planner::plan(&explain.statement);

--- a/src/commands/matview.rs
+++ b/src/commands/matview.rs
@@ -69,7 +69,7 @@ fn acquire_refresh_execution_guard(
 
 pub async fn execute_create_materialized_view(
     create: &CreateViewStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     crate::commands::view::execute_create_view_internal(create, params).await
 }
@@ -88,7 +88,7 @@ pub async fn execute_drop_materialized_view(
 
 pub async fn execute_refresh_materialized_view(
     refresh: &RefreshMaterializedViewStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     let relation = with_catalog_read(|catalog| {
         catalog
@@ -161,7 +161,7 @@ pub async fn execute_refresh_materialized_view(
 async fn evaluate_materialized_view_rows_live(
     relation: &crate::catalog::Table,
     with_data: bool,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<Vec<ScalarValue>>, EngineError> {
     if !with_data {
         return Ok(Vec::new());
@@ -180,7 +180,7 @@ async fn evaluate_materialized_view_rows_live(
 async fn evaluate_materialized_view_rows_concurrently(
     relation: &crate::catalog::Table,
     with_data: bool,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<Vec<ScalarValue>>, EngineError> {
     let baseline = crate::tcop::engine::snapshot_state();
     let evaluated = evaluate_materialized_view_rows_live(relation, with_data, params).await;

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -3,11 +3,12 @@ use crate::commands::create_table::relation_name_for_create;
 use crate::parser::ast::{
     AlterViewAction, AlterViewStatement, CreateViewStatement, DropBehavior, DropViewStatement,
 };
+use crate::storage::tuple::ScalarValue;
 use crate::tcop::engine::{EngineError, QueryResult, with_storage_write};
 
 pub async fn execute_create_view(
     create: &CreateViewStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     execute_create_view_internal(create, params).await
 }
@@ -22,7 +23,7 @@ pub async fn execute_drop_view(drop_view: &DropViewStatement) -> Result<QueryRes
 
 pub(crate) async fn execute_create_view_internal(
     create: &CreateViewStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     let (schema_name, view_name) = relation_name_for_create(&create.name)?;
 

--- a/src/executor/bytecode_expr.rs
+++ b/src/executor/bytecode_expr.rs
@@ -82,7 +82,7 @@ impl CompiledExpr {
     pub(crate) fn evaluate(
         &self,
         scope: &EvalScope,
-        params: &[Option<String>],
+        params: &[Option<ScalarValue>],
     ) -> Result<ScalarValue, EngineError> {
         let mut ip = 0usize;
         let mut stack = Vec::with_capacity(self.instructions.len().max(1));

--- a/src/executor/exec_expr.rs
+++ b/src/executor/exec_expr.rs
@@ -201,7 +201,7 @@ impl EvalScope {
 pub(crate) fn eval_expr<'a>(
     expr: &'a Expr,
     scope: &'a EvalScope,
-    params: &'a [Option<String>],
+    params: &'a [Option<ScalarValue>],
 ) -> EngineFuture<'a, Result<ScalarValue, EngineError>> {
     Box::pin(async move {
         match expr {
@@ -532,7 +532,7 @@ pub(crate) fn eval_expr_with_window<'a>(
     row_idx: usize,
     all_rows: &'a [EvalScope],
     window_definitions: &'a [WindowDefinition],
-    params: &'a [Option<String>],
+    params: &'a [Option<ScalarValue>],
 ) -> EngineFuture<'a, Result<ScalarValue, EngineError>> {
     Box::pin(async move {
         match expr {
@@ -1230,7 +1230,7 @@ async fn eval_window_function(
     window_definitions: &[WindowDefinition],
     row_idx: usize,
     all_rows: &[EvalScope],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ScalarValue, EngineError> {
     // Resolve any named window reference
     let resolved_window = resolve_window_spec(window, window_definitions)?;
@@ -1511,7 +1511,7 @@ async fn window_partition_rows(
     window: &WindowSpec,
     row_idx: usize,
     all_rows: &[EvalScope],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<usize>, EngineError> {
     if window.partition_by.is_empty() {
         return Ok((0..all_rows.len()).collect());
@@ -1539,7 +1539,7 @@ async fn window_order_keys(
     window: &WindowSpec,
     partition: &mut [usize],
     all_rows: &[EvalScope],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<Vec<ScalarValue>>, EngineError> {
     if window.order_by.is_empty() {
         return Ok(Vec::new());
@@ -1565,7 +1565,7 @@ async fn window_frame_rows(
     order_keys: &[Vec<ScalarValue>],
     current_pos: usize,
     all_rows: &[EvalScope],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<usize>, EngineError> {
     let Some(frame) = window.frame.as_ref() else {
         // PostgreSQL default frame:
@@ -1844,7 +1844,7 @@ async fn groups_frame_boundary(
     current_group: usize,
     total_groups: usize,
     current_row: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<usize, EngineError> {
     match bound {
         WindowFrameBound::UnboundedPreceding => Ok(0),
@@ -1878,7 +1878,7 @@ async fn frame_row_position(
     current_pos: usize,
     partition_len: usize,
     current_scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<usize, EngineError> {
     let max_pos = partition_len.saturating_sub(1);
     Ok(match bound {
@@ -1899,7 +1899,7 @@ async fn frame_row_position(
 async fn frame_bound_offset_usize(
     expr: &Expr,
     current_scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<usize, EngineError> {
     let value = eval_expr(expr, current_scope, params).await?;
     parse_non_negative_int(&value, "window frame offset")
@@ -1908,7 +1908,7 @@ async fn frame_bound_offset_usize(
 async fn frame_bound_offset_f64(
     expr: &Expr,
     current_scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<f64, EngineError> {
     let value = eval_expr(expr, current_scope, params).await?;
     let parsed = parse_f64_scalar(&value, "window frame offset must be numeric").unwrap_or(0.0);
@@ -1925,7 +1925,7 @@ async fn range_bound_threshold(
     current: f64,
     is_start: bool,
     current_scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Option<f64>, EngineError> {
     match bound {
         WindowFrameBound::UnboundedPreceding if is_start => Ok(None),
@@ -1953,7 +1953,7 @@ async fn window_first_order_numeric_key(
     row_idx: usize,
     all_rows: &[EvalScope],
     window: &WindowSpec,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<f64, EngineError> {
     if let Some(value) = order_keys.get(pos).and_then(|keys| keys.first()) {
         return Ok(
@@ -2393,8 +2393,11 @@ fn like_match_recursive(
 
 pub(crate) fn parse_param(
     index: i32,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ScalarValue, EngineError> {
+    // Phase 2.2: params arrive pre-typed. Text-format binds were already
+    // parsed into a typed ScalarValue at Bind time (see
+    // `decode_bind_parameter`), so this is now a simple lookup/clone.
     if index <= 0 {
         return Err(EngineError {
             message: format!("invalid parameter reference ${index}"),
@@ -2404,25 +2407,7 @@ pub(crate) fn parse_param(
     let value = params.get(idx).ok_or_else(|| EngineError {
         message: format!("missing value for parameter ${index}"),
     })?;
-
-    let Some(raw) = value else {
-        return Ok(ScalarValue::Null);
-    };
-
-    let trimmed = raw.trim();
-    if trimmed.eq_ignore_ascii_case("true") {
-        return Ok(ScalarValue::Bool(true));
-    }
-    if trimmed.eq_ignore_ascii_case("false") {
-        return Ok(ScalarValue::Bool(false));
-    }
-    if let Ok(v) = trimmed.parse::<i64>() {
-        return Ok(ScalarValue::Int(v));
-    }
-    if let Ok(v) = trimmed.parse::<f64>() {
-        return Ok(ScalarValue::Float(v));
-    }
-    Ok(ScalarValue::Text(raw.clone()))
+    Ok(value.clone().unwrap_or(ScalarValue::Null))
 }
 
 pub(crate) fn eval_unary(op: UnaryOp, value: ScalarValue) -> Result<ScalarValue, EngineError> {
@@ -3059,7 +3044,7 @@ async fn eval_function(
     filter: Option<&Expr>,
     over: Option<&crate::parser::ast::WindowSpec>,
     scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ScalarValue, EngineError> {
     let fn_name = name
         .last()

--- a/src/executor/exec_main/aggregation.rs
+++ b/src/executor/exec_main/aggregation.rs
@@ -22,7 +22,7 @@ pub(super) async fn eval_expr_maybe_compiled(
     expr: &Expr,
     compiled: Option<&CompiledExpr>,
     scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ScalarValue, EngineError> {
     if let Some(compiled) = compiled {
         let _span = profiling::span("compiled_expr_eval");
@@ -37,7 +37,7 @@ pub(super) async fn project_select_row_compiled(
     targets: &[crate::parser::ast::SelectItem],
     compiled_targets: &[Option<CompiledExpr>],
     scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     wildcard_columns: Option<&[ExpandedFromColumn]>,
 ) -> Result<Vec<ScalarValue>, EngineError> {
     let mut row = Vec::new();
@@ -107,7 +107,7 @@ pub(super) async fn project_select_row_with_window(
     row_idx: usize,
     all_rows: &[EvalScope],
     window_definitions: &[crate::parser::ast::WindowDefinition],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     wildcard_columns: Option<&[ExpandedFromColumn]>,
 ) -> Result<Vec<ScalarValue>, EngineError> {
     let mut row = Vec::new();
@@ -497,7 +497,7 @@ pub(super) fn eval_group_expr<'a>(
     expr: &'a Expr,
     group_rows: &'a [EvalScope],
     representative: &'a EvalScope,
-    params: &'a [Option<String>],
+    params: &'a [Option<ScalarValue>],
     grouping: &'a GroupingContext,
 ) -> EngineFuture<'a, Result<ScalarValue, EngineError>> {
     Box::pin(async move {
@@ -837,7 +837,7 @@ pub(super) async fn build_aggregate_input_rows(
     order_by: &[OrderByExpr],
     filter: Option<&Expr>,
     group_rows: &[EvalScope],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<AggregateInputRow>, EngineError> {
     let mut out = Vec::with_capacity(group_rows.len());
     for scope in group_rows {
@@ -1099,7 +1099,7 @@ pub async fn eval_aggregate_function(
     within_group: &[OrderByExpr],
     filter: Option<&Expr>,
     group_rows: &[EvalScope],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ScalarValue, EngineError> {
     let is_ordered_set = matches!(fn_name, "percentile_cont" | "percentile_disc" | "mode");
     if !within_group.is_empty() && !is_ordered_set {

--- a/src/executor/exec_main/from_clause.rs
+++ b/src/executor/exec_main/from_clause.rs
@@ -18,7 +18,7 @@ pub struct TableEval {
 
 pub async fn evaluate_from_clause(
     from: &[TableExpression],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<Vec<EvalScope>, EngineError> {
     let mut current = vec![EvalScope::default()];
@@ -191,7 +191,7 @@ pub(super) async fn relation_index_offsets_for_predicates(
     table: &crate::catalog::Table,
     qualifiers: &[String],
     relation_predicates: &[Expr],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<Option<Vec<usize>>, EngineError> {
     let mut index_descriptors =
@@ -266,7 +266,7 @@ pub(super) async fn extract_relation_equality_constraint(
     predicate: &Expr,
     qualifiers: &[String],
     table_columns: &HashSet<String>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<Option<(String, ScalarValue)>, EngineError> {
     let Expr::Binary {
@@ -353,7 +353,7 @@ pub(super) async fn extract_relation_scan_predicate(
     qualifiers: &[String],
     table_columns: &HashSet<String>,
     column_indexes: &HashMap<String, usize>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Option<ScanPredicate>, EngineError> {
     if let Expr::Like {
         expr,
@@ -508,7 +508,7 @@ pub(super) fn remaining_predicate_from_applied(
 /// be pushed down (e.g., those with subqueries).
 pub(super) async fn evaluate_from_clause_with_pushdown(
     from: &[TableExpression],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     conjuncts: &[Expr],
 ) -> Result<(Vec<EvalScope>, Option<Expr>), EngineError> {
@@ -735,7 +735,9 @@ mod tests {
             &["hits".to_string()],
             &table_columns,
             &column_indexes,
-            &[Some("7".to_string())],
+            // Phase 2.2: typed binds. Real bind path parses "7" with declared
+            // int type-OID into Int(7) before reaching predicate extraction.
+            &[Some(ScalarValue::Int(7))],
         ))
         .expect("predicate extraction should succeed");
 
@@ -787,7 +789,7 @@ mod tests {
 
 pub fn evaluate_table_expression<'a>(
     table: &'a TableExpression,
-    params: &'a [Option<String>],
+    params: &'a [Option<ScalarValue>],
     outer_scope: Option<&'a EvalScope>,
 ) -> EngineFuture<'a, Result<TableEval, EngineError>> {
     Box::pin(async move {
@@ -858,7 +860,7 @@ pub(super) fn is_lateral_table_expression(table: &TableExpression) -> bool {
 pub(super) async fn evaluate_lateral_join(
     join: &JoinExpr,
     left: &TableEval,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<TableEval, EngineError> {
     if matches!(join.kind, JoinType::Right | JoinType::Full) {
@@ -979,7 +981,7 @@ pub(super) async fn evaluate_join(
     natural: bool,
     left: &TableEval,
     right: &TableEval,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<TableEval, EngineError> {
     let using_columns = if natural {
         left.columns
@@ -1108,7 +1110,7 @@ pub(super) async fn join_condition_matches(
     using_columns: &[String],
     left_row: &EvalScope,
     right_row: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<bool, EngineError> {
     if let Some(JoinCondition::On(expr)) = condition {
         let scope = combine_scopes(left_row, right_row, &HashSet::new());

--- a/src/executor/exec_main/order_limit.rs
+++ b/src/executor/exec_main/order_limit.rs
@@ -75,7 +75,10 @@ struct TopNKeyPart {
 }
 
 impl QueryRowCollector {
-    pub(super) async fn new(query: &Query, params: &[Option<String>]) -> Result<Self, EngineError> {
+    pub(super) async fn new(
+        query: &Query,
+        params: &[Option<ScalarValue>],
+    ) -> Result<Self, EngineError> {
         let offset = if let Some(expr) = &query.offset {
             parse_non_negative_int(
                 &eval_expr(expr, &EvalScope::default(), params).await?,
@@ -123,7 +126,7 @@ impl QueryRowCollector {
         &mut self,
         columns: &[String],
         row: Vec<ScalarValue>,
-        params: &[Option<String>],
+        params: &[Option<ScalarValue>],
     ) -> Result<bool, EngineError> {
         let _span = profiling::span("query_row_collector_push_row");
         match &mut self.strategy {
@@ -218,7 +221,7 @@ impl SimpleTopNCollector {
     pub(super) async fn new(
         query: &Query,
         columns: &[String],
-        params: &[Option<String>],
+        params: &[Option<ScalarValue>],
     ) -> Result<Option<Self>, EngineError> {
         if query.order_by.is_empty() {
             return Ok(None);
@@ -337,7 +340,7 @@ impl OffsetTopNCollector {
     pub(super) async fn new(
         query: &Query,
         columns: &[String],
-        params: &[Option<String>],
+        params: &[Option<ScalarValue>],
     ) -> Result<Option<Self>, EngineError> {
         let Some(base) = SimpleTopNCollector::new(query, columns, params).await? else {
             return Ok(None);
@@ -576,7 +579,7 @@ async fn resolve_order_keys(
     order_by: &[OrderByExpr],
     columns: &[String],
     row: &[ScalarValue],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<ScalarValue>, EngineError> {
     let _span = profiling::span("resolve_order_keys");
     let scope = EvalScope::from_output_row(columns, row);
@@ -680,7 +683,7 @@ pub(super) fn augment_select_for_order_by(body: &QueryExpr, extras: &[Expr]) -> 
 pub(super) async fn apply_order_by(
     result: &mut QueryResult,
     query: &Query,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<(), EngineError> {
     if query.order_by.is_empty() || result.rows.is_empty() {
         return Ok(());
@@ -740,7 +743,7 @@ pub(super) async fn resolve_order_key(
     scope: &EvalScope,
     columns: &[String],
     row: &[ScalarValue],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ScalarValue, EngineError> {
     if let Expr::Integer(pos) = expr
         && *pos > 0
@@ -785,7 +788,7 @@ pub(super) async fn resolve_order_key(
 pub(super) async fn apply_offset_limit(
     result: &mut QueryResult,
     query: &Query,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<(), EngineError> {
     let offset = if let Some(expr) = &query.offset {
         parse_non_negative_int(

--- a/src/executor/exec_main/query_pipeline.rs
+++ b/src/executor/exec_main/query_pipeline.rs
@@ -21,14 +21,14 @@ use std::collections::BTreeSet;
 
 pub async fn execute_query(
     query: &Query,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     execute_query_with_outer(query, params, None).await
 }
 
 pub fn execute_query_with_outer<'a>(
     query: &'a Query,
-    params: &'a [Option<String>],
+    params: &'a [Option<ScalarValue>],
     outer_scope: Option<&'a EvalScope>,
 ) -> EngineFuture<'a, Result<QueryResult, EngineError>> {
     Box::pin(async move {
@@ -146,7 +146,7 @@ pub(super) const MAX_RECURSIVE_CTE_ITERATIONS: usize = 2_048;
 
 pub(super) async fn evaluate_recursive_cte_binding(
     cte: &crate::parser::ast::CommonTableExpr,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     inherited_ctes: &HashMap<String, CteBinding>,
 ) -> Result<CteBinding, EngineError> {
@@ -268,7 +268,7 @@ pub(super) async fn evaluate_recursive_cte_binding(
 
 pub(super) fn execute_query_expr_with_outer<'a>(
     expr: &'a QueryExpr,
-    params: &'a [Option<String>],
+    params: &'a [Option<ScalarValue>],
     outer_scope: Option<&'a EvalScope>,
 ) -> EngineFuture<'a, Result<QueryResult, EngineError>> {
     Box::pin(async move {
@@ -309,7 +309,7 @@ pub(super) fn execute_query_expr_with_outer<'a>(
 
 pub(super) async fn execute_values(
     rows: &[Vec<Expr>],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<QueryResult, EngineError> {
     // Execute VALUES query - return all rows with column names column1, column2, etc.
@@ -602,7 +602,7 @@ fn schema_batch_for_table(table: &crate::catalog::Table) -> ColumnBatch {
 async fn prepare_columnar_relation_scan(
     rel: &TableRef,
     relation_predicates: &[Expr],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Option<ColumnarRelationScanPlan>, EngineError> {
     let resolved_table = with_catalog_read(|catalog| {
         catalog
@@ -658,7 +658,7 @@ async fn prepare_columnar_relation_scan(
 
 async fn stage_limit_spec(
     query: Option<&Query>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Option<StageLimitSpec>, EngineError> {
     let Some(query) = query else {
         return Ok(None);
@@ -1131,7 +1131,7 @@ fn columnar_group_key_indices(plan: &ColumnarAggPlan, base_column_count: usize) 
 async fn append_derived_group_key_columns(
     plan: &ColumnarAggPlan,
     batch: ColumnBatch,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ColumnBatch, EngineError> {
     let mut batch = batch;
     for (group_idx, source) in plan.group_key_sources.iter().enumerate() {
@@ -1481,7 +1481,7 @@ fn classify_simple_like_scan_predicate(
 async fn try_execute_simple_columnar_select(
     select: &SelectStatement,
     query: Option<&Query>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     rel: &TableRef,
     relation_predicates: &[Expr],
     columns: &[String],
@@ -2004,7 +2004,7 @@ async fn try_execute_simple_columnar_select(
 async fn try_execute_columnar_aggregation(
     select: &SelectStatement,
     query: Option<&Query>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     rel: &TableRef,
     relation_predicates: &[Expr],
     columns: &[String],
@@ -2177,7 +2177,7 @@ async fn try_execute_columnar_aggregation(
 async fn plan_columnar_window_targets(
     select: &SelectStatement,
     batch: &ColumnBatch,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Option<Vec<ColumnarWindowTargetPlan>>, EngineError> {
     let mut targets = Vec::with_capacity(select.targets.len());
     for target in &select.targets {
@@ -2297,7 +2297,7 @@ async fn plan_columnar_window_targets(
 async fn try_execute_columnar_windows(
     select: &SelectStatement,
     query: Option<&Query>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     rel: &TableRef,
     relation_predicates: &[Expr],
     columns: &[String],
@@ -2396,7 +2396,7 @@ async fn try_execute_columnar_windows(
 
 pub(super) async fn execute_select(
     select: &SelectStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<QueryResult, EngineError> {
     execute_select_internal(select, None, params, outer_scope).await
@@ -2405,7 +2405,7 @@ pub(super) async fn execute_select(
 async fn execute_select_with_query(
     select: &SelectStatement,
     query: &Query,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<QueryResult, EngineError> {
     execute_select_internal(select, Some(query), params, outer_scope).await
@@ -2610,7 +2610,7 @@ async fn try_execute_simple_column_aggregates(
 async fn try_execute_simple_grouped_column_aggregates(
     select: &SelectStatement,
     query: Option<&Query>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     columns: &[String],
 ) -> Result<Option<QueryResult>, EngineError> {
@@ -2752,7 +2752,7 @@ async fn try_execute_simple_grouped_column_aggregates(
 async fn try_execute_simple_count_star(
     select: &SelectStatement,
     query: Option<&Query>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     columns: &[String],
 ) -> Result<Option<QueryResult>, EngineError> {
@@ -2893,7 +2893,7 @@ async fn try_execute_simple_count_star(
 async fn execute_select_internal(
     select: &SelectStatement,
     query: Option<&Query>,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<QueryResult, EngineError> {
     let _span = profiling::span("execute_select_internal");

--- a/src/executor/exec_main/set_operations.rs
+++ b/src/executor/exec_main/set_operations.rs
@@ -6,7 +6,7 @@ pub(super) async fn execute_set_operation(
     op: SetOperator,
     quantifier: SetQuantifier,
     right: &QueryExpr,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<QueryResult, EngineError> {
     let left_res = execute_query_expr_with_outer(left, params, outer_scope).await?;

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -10,7 +10,7 @@ use crate::executor::profiling;
 
 pub(super) async fn evaluate_table_function(
     function: &TableFunctionRef,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
 ) -> Result<TableEval, EngineError> {
     let mut scope = EvalScope::default();
@@ -79,7 +79,7 @@ pub(super) async fn evaluate_table_function(
 #[cfg(target_arch = "wasm32")]
 pub(super) async fn evaluate_table_function_with_predicate(
     _function: &TableFunctionRef,
-    _params: &[Option<String>],
+    _params: &[Option<ScalarValue>],
     _outer_scope: Option<&EvalScope>,
     _predicate: Option<&Expr>,
 ) -> Result<Option<TableEval>, EngineError> {
@@ -89,7 +89,7 @@ pub(super) async fn evaluate_table_function_with_predicate(
 #[cfg(not(target_arch = "wasm32"))]
 pub(super) async fn evaluate_table_function_with_predicate(
     function: &TableFunctionRef,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     predicate: Option<&Expr>,
 ) -> Result<Option<TableEval>, EngineError> {
@@ -1065,7 +1065,7 @@ pub(super) fn eval_pg_get_keywords() -> Result<(Vec<String>, Vec<Vec<ScalarValue
 
 pub(super) async fn evaluate_relation(
     rel: &TableRef,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     projected_columns: Option<Vec<usize>>,
 ) -> Result<TableEval, EngineError> {
@@ -1076,7 +1076,7 @@ pub(super) async fn evaluate_relation(
 
 pub(super) async fn evaluate_relation_with_predicates(
     rel: &TableRef,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     relation_predicates: &[Expr],
     projected_columns: Option<Vec<usize>>,
@@ -1094,7 +1094,7 @@ pub(super) async fn evaluate_relation_with_predicates(
 
 pub(super) async fn evaluate_relation_with_predicates_columnar(
     rel: &TableRef,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     relation_predicates: &[Expr],
 ) -> Result<(TableEval, Vec<usize>), EngineError> {
@@ -1111,7 +1111,7 @@ pub(super) async fn evaluate_relation_with_predicates_columnar(
 
 async fn evaluate_relation_with_predicates_impl(
     rel: &TableRef,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
     outer_scope: Option<&EvalScope>,
     relation_predicates: &[Expr],
     projected_columns: Option<Vec<usize>>,

--- a/src/executor/hash_join.rs
+++ b/src/executor/hash_join.rs
@@ -47,7 +47,7 @@ impl HashJoinExecutor {
         right: &ColumnBatch,
         left_rows: &[EvalScope],
         right_rows: &[EvalScope],
-        params: &[Option<String>],
+        params: &[Option<ScalarValue>],
     ) -> Result<HashJoinResult, EngineError> {
         let mut build_map: HashMap<u64, Vec<usize>> = HashMap::new();
         for right_row_idx in 0..right.row_count {
@@ -140,7 +140,7 @@ impl HashJoinExecutor {
         candidates: &[usize],
         left_rows: &[EvalScope],
         right_rows: &[EvalScope],
-        params: &[Option<String>],
+        params: &[Option<ScalarValue>],
     ) -> Result<Vec<usize>, EngineError> {
         let mut matches = Vec::new();
         for right_row_idx in candidates.iter().copied() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,11 @@ async fn main() {
                             std::process::exit(1);
                         }
                     };
-                    let result = match execute_planned_query(&plan, &params).await {
+                    let typed_params: Vec<Option<openassay::storage::tuple::ScalarValue>> = params
+                        .iter()
+                        .map(|p| p.as_deref().map(cli_param_to_scalar))
+                        .collect();
+                    let result = match execute_planned_query(&plan, &typed_params).await {
                         Ok(result) => result,
                         Err(err) => {
                             eprintln!("execution error: {err}");
@@ -102,6 +106,27 @@ async fn main() {
             std::process::exit(2);
         }
     }
+}
+
+/// CLI `--param` values arrive as raw strings with no declared type. Apply
+/// the same bool/int/float/text heuristic that `parse_param` historically
+/// used so typed-bind-params (Phase 2.2) preserves CLI behaviour.
+fn cli_param_to_scalar(raw: &str) -> openassay::storage::tuple::ScalarValue {
+    use openassay::storage::tuple::ScalarValue;
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("true") {
+        return ScalarValue::Bool(true);
+    }
+    if trimmed.eq_ignore_ascii_case("false") {
+        return ScalarValue::Bool(false);
+    }
+    if let Ok(v) = trimmed.parse::<i64>() {
+        return ScalarValue::Int(v);
+    }
+    if let Ok(v) = trimmed.parse::<f64>() {
+        return ScalarValue::Float(v);
+    }
+    ScalarValue::Text(raw.to_string())
 }
 
 fn parse_exec_invocation(raw_args: Vec<String>) -> Result<(Vec<Option<String>>, String), String> {

--- a/src/tcop/engine.rs
+++ b/src/tcop/engine.rs
@@ -287,7 +287,7 @@ pub fn plan_statement(statement: Statement) -> Result<PlannedQuery, EngineError>
 
 pub fn execute_planned_query<'a>(
     plan: &'a PlannedQuery,
-    params: &'a [Option<String>],
+    params: &'a [Option<ScalarValue>],
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<QueryResult, EngineError>> + 'a>> {
     Box::pin(async move {
         let result = match &plan.plan {
@@ -1167,7 +1167,7 @@ pub(crate) async fn relation_row_visible_for_command(
     table: &crate::catalog::Table,
     row: &[ScalarValue],
     command: RlsCommand,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<bool, EngineError> {
     let role = security::current_role();
     let eval = security::rls_evaluation_for_role(&role, table.oid(), command);
@@ -1194,7 +1194,7 @@ async fn relation_row_passes_check_for_command(
     table: &crate::catalog::Table,
     row: &[ScalarValue],
     command: RlsCommand,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<bool, EngineError> {
     let role = security::current_role();
     let eval = security::rls_evaluation_for_role(&role, table.oid(), command);
@@ -1231,7 +1231,7 @@ enum IndexMutationAction {
 
 async fn execute_insert(
     insert: &InsertStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     let table = with_catalog_read(|catalog| {
         catalog
@@ -1578,7 +1578,7 @@ async fn execute_insert(
 
 async fn execute_update(
     update: &UpdateStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     let table = with_catalog_read(|catalog| {
         catalog
@@ -1798,7 +1798,7 @@ async fn execute_update(
 
 async fn execute_delete(
     delete: &DeleteStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     let table = with_catalog_read(|catalog| {
         catalog
@@ -1939,7 +1939,7 @@ async fn execute_delete(
 
 async fn execute_merge(
     merge: &MergeStatement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     let table = with_catalog_read(|catalog| {
         catalog
@@ -2609,7 +2609,7 @@ async fn eval_update_assignment_value(
     expr: &Expr,
     column: &Column,
     scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<ScalarValue, EngineError> {
     let raw = if matches!(expr, Expr::Default) {
         if let Some(default_expr) = column.default() {

--- a/src/tcop/engine_tests.rs
+++ b/src/tcop/engine_tests.rs
@@ -23,7 +23,7 @@ fn with_isolated_state<T>(f: impl FnOnce() -> T) -> T {
     })
 }
 
-fn run_statement(sql: &str, params: &[Option<String>]) -> QueryResult {
+fn run_statement(sql: &str, params: &[Option<ScalarValue>]) -> QueryResult {
     let statement = parse_statement(sql).expect("statement should parse");
     let planned = plan_statement(statement).expect("statement should plan");
     block_on(execute_planned_query(&planned, params)).expect("query should execute")
@@ -184,7 +184,8 @@ fn executes_simple_heap_projection_filter_limit_shape() {
 
 #[test]
 fn executes_parameterized_expression() {
-    let result = with_isolated_state(|| run_statement("SELECT $1 + 5", &[Some("7".to_string())]));
+    let result =
+        with_isolated_state(|| run_statement("SELECT $1 + 5", &[Some(ScalarValue::Int(7))]));
     assert_eq!(result.rows[0], vec![ScalarValue::Int(12)]);
 }
 

--- a/src/tcop/postgres/extended_query.rs
+++ b/src/tcop/postgres/extended_query.rs
@@ -275,15 +275,22 @@ fn decode_bind_parameter(
     param: Option<Vec<u8>>,
     format_code: i16,
     type_oid: PgType,
-) -> Result<Option<String>, SessionError> {
+) -> Result<Option<ScalarValue>, SessionError> {
+    // Phase 2.2: return a typed `ScalarValue` instead of the rendered text.
+    // Binary-format binds decode straight through `decode_binary_scalar`;
+    // text-format binds are parsed once here using the declared type OID so
+    // the executor sees the full typed value — no more render → reparse.
     let Some(raw) = param else {
         return Ok(None);
     };
 
     let decoded = match format_code {
-        0 => String::from_utf8(raw).map_err(|_| SessionError {
-            message: format!("bind parameter ${} contains invalid UTF-8 text", index + 1),
-        })?,
+        0 => {
+            let text = String::from_utf8(raw).map_err(|_| SessionError {
+                message: format!("bind parameter ${} contains invalid UTF-8 text", index + 1),
+            })?;
+            parse_text_bind_parameter(index, text, type_oid)?
+        }
         1 => decode_binary_bind_parameter(index, &raw, type_oid)?,
         other => {
             return Err(SessionError {
@@ -298,14 +305,81 @@ fn decode_binary_bind_parameter(
     index: usize,
     raw: &[u8],
     type_oid: PgType,
-) -> Result<String, SessionError> {
+) -> Result<ScalarValue, SessionError> {
     if type_oid == 0 {
-        return String::from_utf8(raw.to_vec()).map_err(|_| SessionError {
-            message: format!(
-                "bind parameter ${} has binary format but unknown type",
-                index + 1
-            ),
-        });
+        return String::from_utf8(raw.to_vec())
+            .map(ScalarValue::Text)
+            .map_err(|_| SessionError {
+                message: format!(
+                    "bind parameter ${} has binary format but unknown type",
+                    index + 1
+                ),
+            });
     }
-    Ok(decode_binary_scalar(raw, type_oid, "bind parameter")?.render())
+    decode_binary_scalar(raw, type_oid, "bind parameter")
+}
+
+/// Parse a text-format bind parameter into a typed `ScalarValue`. The
+/// declared parameter type OID drives which PG text form to expect; when
+/// the OID is 0 (unknown — client skipped declaring parameter types) the
+/// value falls back to the earlier bool/int/float/text heuristic so that
+/// untyped `$1` placeholders keep working.
+fn parse_text_bind_parameter(
+    index: usize,
+    text: String,
+    type_oid: PgType,
+) -> Result<ScalarValue, SessionError> {
+    let err = |ctx: &str| SessionError {
+        message: format!("bind parameter ${} {ctx}", index + 1),
+    };
+    let trimmed = text.trim();
+    match type_oid {
+        // Integer family. Text form is the decimal string.
+        20 | 21 | 23 | 24 | 26 => trimmed
+            .parse::<i64>()
+            .map(ScalarValue::Int)
+            .map_err(|_| err("integer text is invalid")),
+        // Float family.
+        700 | 701 => trimmed
+            .parse::<f64>()
+            .map(ScalarValue::Float)
+            .map_err(|_| err("float text is invalid")),
+        // Booleans accept t/f, true/false (any case), 1/0.
+        16 => match trimmed.to_ascii_lowercase().as_str() {
+            "t" | "true" | "1" => Ok(ScalarValue::Bool(true)),
+            "f" | "false" | "0" => Ok(ScalarValue::Bool(false)),
+            _ => Err(err("boolean text is invalid")),
+        },
+        // Numeric: keep precision via rust_decimal.
+        1700 => trimmed
+            .parse::<rust_decimal::Decimal>()
+            .map(ScalarValue::Numeric)
+            .map_err(|_| err("numeric text is invalid")),
+        // Text-like types: the wire form is already the text. Keep the raw
+        // string (not the trimmed form) so whitespace semantics survive.
+        25 | 1042 | 1043 | 19 | 114 | 17 | 2950 | 1082 | 1083 | 1114 | 1184 | 1186 | 1266
+        | 3802 => Ok(ScalarValue::Text(text)),
+        // Array types: the text form is `{a,b,c}`. Preserve as Text so the
+        // engine's array-literal path handles parsing — mirrors pre-2.2
+        // behaviour.
+        other if crate::types::element_oid_from_array_oid(other).is_some() => {
+            Ok(ScalarValue::Text(text))
+        }
+        // Unknown or pseudo types: fall back to the heuristic parse.
+        _ => {
+            if trimmed.eq_ignore_ascii_case("true") {
+                return Ok(ScalarValue::Bool(true));
+            }
+            if trimmed.eq_ignore_ascii_case("false") {
+                return Ok(ScalarValue::Bool(false));
+            }
+            if let Ok(v) = trimmed.parse::<i64>() {
+                return Ok(ScalarValue::Int(v));
+            }
+            if let Ok(v) = trimmed.parse::<f64>() {
+                return Ok(ScalarValue::Float(v));
+            }
+            Ok(ScalarValue::Text(text))
+        }
+    }
 }

--- a/src/tcop/postgres/mod.rs
+++ b/src/tcop/postgres/mod.rs
@@ -229,7 +229,7 @@ pub(super) struct PreparedStatement {
 #[derive(Debug, Clone)]
 pub(super) struct Portal {
     operation: PlannedOperation,
-    params: Vec<Option<String>>,
+    params: Vec<Option<ScalarValue>>,
     result_format_codes: Vec<i16>,
     result_cache: Option<QueryResult>,
     cursor: usize,
@@ -1049,7 +1049,7 @@ impl PostgresSession {
     async fn execute_operation(
         &mut self,
         operation: &PlannedOperation,
-        params: &[Option<String>],
+        params: &[Option<ScalarValue>],
     ) -> Result<ExecutionOutcome, SessionError> {
         if !self.cacheable_simple_query_operation(operation) {
             self.simple_query_cache.clear();
@@ -1250,7 +1250,7 @@ impl PostgresSession {
     async fn execute_query_in_transaction_scope(
         &mut self,
         plan: &PlannedQuery,
-        params: &[Option<String>],
+        params: &[Option<ScalarValue>],
     ) -> Result<QueryResult, SessionError> {
         let baseline = snapshot_state();
         let working = self

--- a/src/tcop/pquery.rs
+++ b/src/tcop/pquery.rs
@@ -2063,7 +2063,7 @@ pub(crate) async fn project_returning_row(
     returning: &[crate::parser::ast::SelectItem],
     table: &crate::catalog::Table,
     row: &[ScalarValue],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<ScalarValue>, EngineError> {
     let scope = scope_for_table_row(table, row);
     project_returning_row_from_scope(returning, row, &scope, params).await
@@ -2074,7 +2074,7 @@ pub(crate) async fn project_returning_row_with_qualifiers(
     table: &crate::catalog::Table,
     row: &[ScalarValue],
     qualifiers: &[String],
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<ScalarValue>, EngineError> {
     let scope = scope_for_table_row_with_qualifiers(table, row, qualifiers);
     project_returning_row_from_scope(returning, row, &scope, params).await
@@ -2084,7 +2084,7 @@ async fn project_returning_row_from_scope(
     returning: &[crate::parser::ast::SelectItem],
     row: &[ScalarValue],
     scope: &EvalScope,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<Vec<ScalarValue>, EngineError> {
     let mut out = Vec::new();
     for target in returning {

--- a/src/tcop/utility.rs
+++ b/src/tcop/utility.rs
@@ -5,11 +5,12 @@ use crate::commands::{
     schema, sequence, trigger, typecmd, variable, view,
 };
 use crate::parser::ast::Statement;
+use crate::storage::tuple::ScalarValue;
 use crate::tcop::engine::{EngineError, QueryResult};
 
 pub async fn execute_utility_statement(
     statement: &Statement,
-    params: &[Option<String>],
+    params: &[Option<ScalarValue>],
 ) -> Result<QueryResult, EngineError> {
     match statement {
         Statement::CreateTable(create) => create_table::execute_create_table(create).await,

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -663,6 +663,65 @@ async fn time_cast_surfaces_as_oid_1083_and_decodes_binary() {
     assert_eq!(decoded, NaiveTime::from_hms_opt(12, 34, 56).unwrap());
 }
 
+/// Phase 2.2: UUID bound as a parameter survives a round-trip without
+/// precision loss. Before typed bind params, the binary-decoded UUID was
+/// rendered to text ("11111111-…") and handed to the executor as a string;
+/// any code path that compared it against the original binary value could
+/// have mismatched on canonical formatting. Typed binds make the ScalarValue
+/// flow through unchanged.
+#[tokio::test(flavor = "multi_thread")]
+async fn uuid_bind_parameter_round_trips_via_binary() {
+    use uuid::Uuid;
+
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let u = Uuid::parse_str("deadbeef-dead-beef-dead-beefdeadbeef").unwrap();
+    let row = client
+        .query_one("SELECT $1::uuid AS v", &[&u])
+        .await
+        .expect("query");
+    assert_eq!(row.columns()[0].type_().oid(), 2950);
+    let got: Uuid = row.get(0);
+    assert_eq!(got, u);
+}
+
+/// Phase 2.2: a NULL bind parameter surfaces as NULL in the result row.
+/// The typed-params refactor changed how NULL flows (Option<String> None →
+/// Option<ScalarValue> None); this pins that NULL passthrough works.
+#[tokio::test(flavor = "multi_thread")]
+async fn null_bind_parameter_surfaces_as_null() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let null_i32: Option<i32> = None;
+    let row = client
+        .query_one("SELECT $1::int4 AS v", &[&null_i32])
+        .await
+        .expect("query");
+    let got: Option<i32> = row.get(0);
+    assert_eq!(got, None);
+}
+
+/// Phase 2.2: an int4 bind param stays typed as int on the way through
+/// the executor, exercising the typed-params path. This guards against
+/// regressing back to render → reparse for integers. `SELECT $1::int4`
+/// keeps the result at int4 (OID 23); after typed binds the integer value
+/// never transits through its text form in the engine.
+#[tokio::test(flavor = "multi_thread")]
+async fn int4_bind_parameter_survives_typed_path() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let row = client
+        .query_one("SELECT $1::int4 AS v", &[&42_i32])
+        .await
+        .expect("query");
+    assert_eq!(row.columns()[0].type_().oid(), 23);
+    let got: i32 = row.get(0);
+    assert_eq!(got, 42);
+}
+
 /// Phase 2 follow-up: int4[] must surface with OID 1007 and decode as
 /// `Vec<i32>` via tokio-postgres' binary path. tokio-postgres requests
 /// format 1 for Vec<i32> — if our PG array binary layout is wrong the
@@ -711,7 +770,6 @@ async fn text_array_decodes_as_vec_string() {
     assert_eq!(decoded, vec!["alpha".to_string(), "beta".to_string()]);
 }
 
-/// Phase 2 follow-up: integer binary operators preserve the wider operand
 /// width instead of blindly widening to int8. Before, every `int4 + int4`
 /// surfaced as int8 (OID 20), which caused sqlx to reject a Vec<i32>
 /// result column when running trivial arithmetic.


### PR DESCRIPTION
## Summary

Replace \`Vec<Option<String>>\` with \`Vec<Option<ScalarValue>>\` everywhere the executor threads bind parameters. Bind values now arrive in the executor pre-typed instead of being \`render()\`'d at Bind time and re-parsed at Execute time.

### Before
\`\`\`
client sends binary uuid bytes
  → decode_binary_scalar (typed)
  → render() (back to text)
  → Portal stores String
  → parse_param re-guesses type from text
  → executor sees a Text value
\`\`\`

### After
\`\`\`
client sends binary uuid bytes
  → decode_binary_scalar
  → Portal stores ScalarValue
  → parse_param clones
  → executor sees the original typed value
\`\`\`

Text-format binds use the declared parameter type OID to parse once at Bind time — integers become \`Int\`, numerics become \`Numeric\` (preserving \`Decimal\` precision), booleans become \`Bool\`. The legacy bool/int/float/text heuristic only runs as a fallback when no type OID was declared.

## BREAKING

\`execute_planned_query\`, \`execute_query\`, \`execute_insert\`, \`execute_update\`, \`execute_delete\`, \`execute_merge\`, and the executor helper chain now take \`&[Option<ScalarValue>]\` instead of \`&[Option<String>]\`.

Downstream callers passing raw strings must wrap each as a typed \`ScalarValue\` — see \`src/main.rs::cli_param_to_scalar\` for the heuristic parser that preserves the old CLI behaviour.

## Files changed

Mechanical signature rewrites across 21 files. Actual logic changes concentrated in:
- \`src/executor/exec_expr.rs\` — \`parse_param\` simplified to a clone
- \`src/tcop/postgres/extended_query.rs\` — new \`parse_text_bind_parameter\` with type-OID dispatch
- \`src/tcop/postgres/mod.rs\` — \`Portal::params\` storage type
- \`src/catalog/iceberg.rs\` — constant-expression param lookup

## Test plan

- [x] \`cargo test --lib\` — 882 pass (one test updated to pass typed \`ScalarValue::Int(7)\` instead of raw \`"7"\`, which reflects what real binds actually deliver)
- [x] \`cargo test --test tokio_postgres_compat\` — 26 pass (3 new)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo build --lib --target wasm32-unknown-unknown\` clean
- [x] \`cargo fmt --check\` clean

New integration tests:
- \`uuid_bind_parameter_round_trips_via_binary\`
- \`int4_bind_parameter_survives_typed_path\`
- \`null_bind_parameter_surfaces_as_null\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)