### PR TITLE
feat: Phase 4 — SQLSTATE fidelity + aborted-tx regression

### DIFF
--- a/src/tcop/postgres/mod.rs
+++ b/src/tcop/postgres/mod.rs
@@ -1646,11 +1646,39 @@ fn classify_sqlstate_error_fields(
     if lower.contains("privilege") || lower.contains("permission denied") {
         return ("42501".to_string(), None, None, None);
     }
-    if lower.contains("duplicate value for key") {
+    if lower.contains("duplicate value for key") || lower.contains("violates unique") {
         return ("23505".to_string(), None, None, None);
     }
-    if lower.contains("does not allow null values") {
+    if lower.contains("does not allow null values") || lower.contains("violates not-null") {
         return ("23502".to_string(), None, None, None);
+    }
+    if lower.contains("violates foreign key") {
+        return ("23503".to_string(), None, None, None);
+    }
+    if lower.contains("violates check") {
+        return ("23514".to_string(), None, None, None);
+    }
+    // Type-parse failures — tokio-postgres inspects SQLSTATE to decide whether
+    // to surface "invalid text representation" (22P02) vs "numeric out of
+    // range" (22003) distinctly from generic XX000.
+    if lower.contains("invalid input syntax") || lower.contains("is invalid") {
+        return ("22P02".to_string(), None, None, None);
+    }
+    if lower.contains("out of range") {
+        return ("22003".to_string(), None, None, None);
+    }
+    if lower.contains("cannot cast") || lower.contains("incompatible type") {
+        return ("42804".to_string(), None, None, None);
+    }
+    if lower.contains("database") && lower.contains("in use") {
+        return ("55006".to_string(), None, None, None);
+    }
+    if lower.contains("database")
+        && (lower.contains("does not exist") || lower.contains("not found"))
+    {
+        // Checked before the generic "does not exist" branches below so we
+        // emit the catalog-scoped code.
+        return ("3D000".to_string(), None, None, None);
     }
     if lower.contains("already exists") {
         if lower.contains("relation")

--- a/src/tcop/postgres/tests.rs
+++ b/src/tcop/postgres/tests.rs
@@ -1475,3 +1475,70 @@ fn interval_binary_encode_rejects_unknown_text_shape() {
     );
     assert!(err.is_err());
 }
+
+// Phase 4.1: SQLSTATE classifier covers the codes library tests match on
+// via `tokio_postgres::error::SqlState`. Lib-level tests (deterministic —
+// the integration path shares process-global catalog state with other
+// tests and races.)
+#[test]
+fn sqlstate_classifies_unique_violation() {
+    let msg = "duplicate value violates unique index \"x_pkey\"";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "23505");
+}
+
+#[test]
+fn sqlstate_classifies_foreign_key_violation() {
+    let msg = "insert or update on relation \"child\" violates foreign key constraint";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "23503");
+}
+
+#[test]
+fn sqlstate_classifies_check_violation() {
+    let msg = "row for relation \"t\" violates CHECK constraint on column \"price\"";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "23514");
+}
+
+#[test]
+fn sqlstate_classifies_not_null_violation() {
+    let msg = "null value in column \"x\" of relation \"t\" violates not-null constraint";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "23502");
+}
+
+#[test]
+fn sqlstate_classifies_invalid_text_representation() {
+    let msg = "invalid input syntax for type int4: \"abc\"";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "22P02");
+}
+
+#[test]
+fn sqlstate_classifies_out_of_range() {
+    let msg = "int2 value 40000 out of range";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "22003");
+}
+
+#[test]
+fn sqlstate_classifies_datatype_mismatch() {
+    let msg = "cannot cast text to uuid";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "42804");
+}
+
+#[test]
+fn sqlstate_classifies_invalid_catalog_name() {
+    let msg = "database \"nonexistent\" does not exist";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "3D000");
+}
+
+#[test]
+fn sqlstate_falls_back_to_xx000_when_unmatched() {
+    let msg = "an unrecognised error message shape";
+    let (code, _, _, _) = classify_sqlstate_error_fields(msg);
+    assert_eq!(code, "XX000");
+}

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -584,18 +584,17 @@ async fn ddl_declared_int4_column_surfaces_as_oid_23() {
             .unwrap()
             .as_nanos()
     );
+    // Bundle CREATE + INSERT into a single batch_execute so they share
+    // session state — the engine's global catalog commit can race with
+    // concurrent tokio_postgres_compat tests otherwise, surfacing as
+    // "relation does not exist" on the INSERT.
     client
         .batch_execute(&format!(
-            "CREATE TABLE {table} (id int4, label varchar(10), stamp timestamptz)"
+            "CREATE TABLE {table} (id int4, label varchar(10), stamp timestamptz); \
+             INSERT INTO {table} VALUES (7, 'hello', '2024-01-15 12:00:00+00');"
         ))
         .await
-        .expect("CREATE TABLE");
-    client
-        .batch_execute(&format!(
-            "INSERT INTO {table} VALUES (7, 'hello', '2024-01-15 12:00:00+00')"
-        ))
-        .await
-        .expect("INSERT");
+        .expect("setup");
 
     let stmt = client
         .prepare(&format!("SELECT id, label, stamp FROM {table}"))
@@ -608,10 +607,10 @@ async fn ddl_declared_int4_column_surfaces_as_oid_23() {
         "DDL-declared int4/varchar/timestamptz must report OIDs 23/1043/1184"
     );
 
-    client
-        .batch_execute(&format!("DROP TABLE {table}"))
-        .await
-        .ok();
+    // NB: no DROP TABLE. Concurrent tokio_postgres_compat tests share the
+    // engine's process-global catalog; a DROP here races with other tests'
+    // catalog lookups. Table names embed a nanosecond timestamp to keep
+    // parallel runs non-overlapping.
 }
 
 /// A row with a NULL used to force the whole row into binary encoding
@@ -684,6 +683,62 @@ async fn uuid_bind_parameter_round_trips_via_binary() {
     assert_eq!(row.columns()[0].type_().oid(), 2950);
     let got: Uuid = row.get(0);
     assert_eq!(got, u);
+}
+
+/// Phase 4.2: after an error mid-transaction, subsequent statements must
+/// fail with SQLSTATE 25P02 (in_failed_sql_transaction) until ROLLBACK.
+/// ROLLBACK TO SAVEPOINT returns the block to non-aborted state.
+#[tokio::test(flavor = "multi_thread")]
+async fn aborted_transaction_rejects_until_rollback() {
+    use tokio_postgres::error::SqlState;
+
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let table = format!(
+        "ab_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    client
+        .batch_execute(&format!("CREATE TABLE {table} (id int4 PRIMARY KEY);"))
+        .await
+        .expect("setup");
+
+    client.batch_execute("BEGIN;").await.expect("begin");
+    // Deliberately trigger an error mid-TX.
+    client
+        .batch_execute(&format!(
+            "INSERT INTO {table} VALUES (1); \
+             INSERT INTO {table} VALUES (1);"
+        ))
+        .await
+        .expect_err("second insert must violate unique");
+
+    // Subsequent statements are rejected with 25P02 until ROLLBACK.
+    let in_failed = client
+        .batch_execute(&format!("SELECT * FROM {table};"))
+        .await
+        .expect_err("aborted tx must reject");
+    assert_eq!(
+        in_failed.code(),
+        Some(&SqlState::IN_FAILED_SQL_TRANSACTION),
+        "aborted-tx rejection must be 25P02, got {:?}",
+        in_failed.code()
+    );
+
+    client.batch_execute("ROLLBACK;").await.expect("rollback");
+
+    // After ROLLBACK the connection is usable again.
+    client
+        .batch_execute(&format!("SELECT * FROM {table};"))
+        .await
+        .expect("select after rollback");
+
+    // See note in `constraint_violations_carry_spec_sqlstate_codes` about
+    // why we intentionally don't DROP here.
 }
 
 /// Phase 2.2: a NULL bind parameter surfaces as NULL in the result row.


### PR DESCRIPTION
## Summary

**Phase 4.1** — extend the SQLSTATE classifier so constraint-violation error messages surface with the spec codes that \`tokio-postgres\`/\`sqlx\`/\`diesel-async\` match on via \`SqlState::*\`. Previously these fell through to the generic \`XX000\`.

### Classifier additions

| Message fragment | SQLSTATE | Was |
|---|---|---|
| \`violates unique\` | 23505 | XX000 |
| \`violates not-null\` | 23502 | XX000 |
| \`violates foreign key\` | 23503 | XX000 |
| \`violates check\` | 23514 | XX000 |
| \`invalid input syntax\` / \`is invalid\` | 22P02 | XX000 |
| \`out of range\` | 22003 | XX000 |
| \`cannot cast\` / \`incompatible type\` | 42804 | XX000 |
| \`database ... in use\` | 55006 | XX000 |
| \`database ... does not exist\` | 3D000 | 42704 |

Ordering: \`database does not exist\` is checked before the generic \`does not exist\` branch so we emit the catalog-scoped code.

**Phase 4.2** — integration test that locks in aborted-transaction semantics. Behaviour was already correct: after a mid-TX error, subsequent statements return \`25P02 (in_failed_sql_transaction)\` until \`ROLLBACK\`, and \`ROLLBACK\` returns the block to usable state.

## Test plan

- [x] \`cargo test --lib\` — 891 pass, 9 new SQLSTATE classifier tests (deterministic, not subject to integration-test parallelism race)
- [x] \`cargo test --test tokio_postgres_compat\` — 27 pass, 1 new \`aborted_transaction_rejects_until_rollback\`; verified 8× in a row with no flake
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

## Side-effect

Removed the lingering \`DROP TABLE\` tail from \`ddl_declared_int4_column_surfaces_as_oid_23\` and bundled its \`CREATE TABLE\` + \`INSERT\` into a single \`batch_execute\`. Concurrent tokio_postgres_compat tests share the engine's process-global catalog; independent autocommit roundtrips can race, manifesting as transient \`42P01\` unrelated to the behaviour under test.

## Out of scope

A full typed-SQLSTATE plumbing (\`sqlstate: Option<&'static str>\` on \`EngineError\`) was in the original plan. The string-matching classifier already handles every library-visible error path after this PR and requires no signature churn across the executor — deferring the typed field until a case emerges that the matcher can't distinguish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)