### PR TITLE
feat: Phase 5.1 — date/time keyword literals

### DIFF
--- a/src/parser/sql_parser/expr.rs
+++ b/src/parser/sql_parser/expr.rs
@@ -635,6 +635,34 @@ impl Parser {
     pub(super) fn parse_identifier_expr(&mut self) -> Result<Expr, ParseError> {
         let mut name = vec![self.parse_expr_identifier()?];
 
+        // PG date/time keyword literals: CURRENT_TIMESTAMP, CURRENT_DATE,
+        // CURRENT_TIME, LOCALTIMESTAMP, LOCALTIME. These are parsed as
+        // zero-arg function calls when not followed by `(` so the executor
+        // can dispatch to `now()` / `current_date()` / `current_time()`.
+        // SQL lets the user write `CURRENT_TIMESTAMP(6)` too — that stays
+        // as a normal function call on the path below.
+        if name.len() == 1 && !matches!(self.peek_nth_kind(0), Some(TokenKind::LParen)) {
+            let keyword_fn = match name[0].as_str() {
+                "current_timestamp" => Some("current_timestamp"),
+                "current_date" => Some("current_date"),
+                "current_time" => Some("current_time"),
+                "localtimestamp" => Some("localtimestamp"),
+                "localtime" => Some("localtime"),
+                _ => None,
+            };
+            if let Some(fn_name) = keyword_fn {
+                return Ok(Expr::FunctionCall {
+                    name: vec![fn_name.to_string()],
+                    args: Vec::new(),
+                    distinct: false,
+                    order_by: Vec::new(),
+                    within_group: Vec::new(),
+                    filter: None,
+                    over: None,
+                });
+            }
+        }
+
         // Handle type-name 'literal' syntax for types like bool, int, etc.
         if name.len() == 1 {
             let type_lower = name[0].clone();

--- a/src/utils/fmgr.rs
+++ b/src/utils/fmgr.rs
@@ -721,10 +721,23 @@ pub(crate) async fn eval_scalar_function(
         }
         "date" if args.len() == 1 => eval_date_function(&args[0]),
         "timestamp" if args.len() == 1 => eval_timestamp_function(&args[0]),
-        "now" | "current_timestamp" if args.is_empty() => {
+        "now" | "current_timestamp" | "statement_timestamp" | "transaction_timestamp"
+            if args.is_empty() =>
+        {
             Ok(ScalarValue::Text(current_timestamp_string()?))
         }
         "clock_timestamp" if args.is_empty() => Ok(ScalarValue::Text(current_timestamp_string()?)),
+        // `localtimestamp` and `localtime` return timestamps without a
+        // timezone. We don't track TZ distinctly, so they alias to the
+        // current timestamp / time in text form.
+        "localtimestamp" if args.is_empty() => Ok(ScalarValue::Text(current_timestamp_string()?)),
+        "current_time" | "localtime" if args.is_empty() => {
+            // HH:MM:SS[.ffffff] slice of the current timestamp. Strip the
+            // leading `YYYY-MM-DD ` prefix that current_timestamp emits.
+            let ts = current_timestamp_string()?;
+            let time_part = ts.split_once(' ').map(|(_, t)| t).unwrap_or(&ts);
+            Ok(ScalarValue::Text(time_part.to_string()))
+        }
         "pg_sleep" if args.len() == 1 => {
             if matches!(args[0], ScalarValue::Null) {
                 return Ok(ScalarValue::Null);

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -741,6 +741,41 @@ async fn aborted_transaction_rejects_until_rollback() {
     // why we intentionally don't DROP here.
 }
 
+/// Phase 5.1: PG date/time keyword literals — CURRENT_TIMESTAMP,
+/// CURRENT_DATE, CURRENT_TIME, LOCALTIMESTAMP, LOCALTIME parse as
+/// special keyword calls (not regular functions) and evaluate. Before
+/// this the parser treated them as plain identifiers and raised
+/// `unknown column`.
+#[tokio::test(flavor = "multi_thread")]
+async fn date_time_keyword_literals_parse_and_evaluate() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    // CAST each to text so we can assert a non-empty shape without
+    // depending on whatever OID the engine currently advertises for each
+    // (timestamptz/date/time/etc.) — the point of this test is that the
+    // KEYWORDS parse and evaluate, not the wire types of the results.
+    let row = client
+        .query_one(
+            "SELECT \
+             CAST(CURRENT_TIMESTAMP AS text), \
+             CAST(CURRENT_DATE AS text), \
+             CAST(CURRENT_TIME AS text), \
+             CAST(LOCALTIMESTAMP AS text), \
+             CAST(LOCALTIME AS text)",
+            &[],
+        )
+        .await
+        .expect("query");
+    for i in 0..5 {
+        let value: String = row.get(i);
+        assert!(
+            !value.is_empty(),
+            "column {i} must surface a non-empty text value, got {value:?}"
+        );
+    }
+}
+
 /// Phase 2.2: a NULL bind parameter surfaces as NULL in the result row.
 /// The typed-params refactor changed how NULL flows (Option<String> None →
 /// Option<ScalarValue> None); this pins that NULL passthrough works.


### PR DESCRIPTION
## Summary

PG parses \`CURRENT_TIMESTAMP\`, \`CURRENT_DATE\`, \`CURRENT_TIME\`, \`LOCALTIMESTAMP\`, \`LOCALTIME\` as special keyword calls, not as identifiers. Without this, migrations, default-value clauses, and ad-hoc queries using the keywords bare (very common in sqlx/Diesel-based code under test) fail with \`unknown column "current_timestamp"\`.

## Changes

**Parser** — in \`parse_identifier_expr\`: if the bare identifier matches one of the five keywords and is NOT followed by \`(\`, rewrite it as a zero-arg \`Expr::FunctionCall\`. The \`CURRENT_TIMESTAMP(6)\` form still works (falls through to normal function-call parsing).

**Executor** (fmgr.rs):
- \`localtimestamp\`, \`statement_timestamp\`, \`transaction_timestamp\` alias to the current timestamp.
- \`localtime\` / \`current_time\` slice \`HH:MM:SS\` out of the current timestamp.

## Test plan

- [x] \`cargo test --lib\` — 882 pass
- [x] \`cargo test --test tokio_postgres_compat\` — 27 pass, 1 new: \`date_time_keyword_literals_parse_and_evaluate\`
- [x] \`cargo clippy -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)