### PR TITLE
feat: Phase 5.2 — AT TIME ZONE clause

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -162,6 +162,8 @@ pub enum Keyword {
     Time,
     Timestamp,
     Interval,
+    At,
+    Zone,
     Window,
 }
 
@@ -326,6 +328,8 @@ impl Keyword {
             "time" => Some(Self::Time),
             "timestamp" => Some(Self::Timestamp),
             "interval" => Some(Self::Interval),
+            "at" => Some(Self::At),
+            "zone" => Some(Self::Zone),
             "window" => Some(Self::Window),
             _ => None,
         }

--- a/src/parser/sql_parser/expr.rs
+++ b/src/parser/sql_parser/expr.rs
@@ -10,6 +10,33 @@ impl Parser {
         let mut lhs = self.parse_prefix_expr()?;
 
         loop {
+            // PG `expr AT TIME ZONE zone_expr`. Per PG grammar this has the
+            // same precedence as the `::` cast. Lower it to a function call
+            // `timezone(zone, expr)` so the executor handles it through the
+            // existing timezone() path — no new AST variant needed.
+            if self.peek_nth_kind(0) == Some(&TokenKind::Keyword(Keyword::At))
+                && self.peek_nth_kind(1) == Some(&TokenKind::Keyword(Keyword::Time))
+                && self.peek_nth_kind(2) == Some(&TokenKind::Keyword(Keyword::Zone))
+            {
+                let l_bp = 12;
+                if l_bp < min_bp {
+                    break;
+                }
+                self.advance(); // AT
+                self.advance(); // TIME
+                self.advance(); // ZONE
+                let zone = self.parse_expr_bp(l_bp)?;
+                lhs = Expr::FunctionCall {
+                    name: vec!["timezone".to_string()],
+                    args: vec![zone, lhs],
+                    distinct: false,
+                    order_by: Vec::new(),
+                    within_group: Vec::new(),
+                    filter: None,
+                    over: None,
+                };
+                continue;
+            }
             if self
                 .peek_nth_kind(0)
                 .is_some_and(|k| matches!(k, TokenKind::Typecast))

--- a/src/parser/sql_parser/helpers.rs
+++ b/src/parser/sql_parser/helpers.rs
@@ -417,6 +417,8 @@ impl Parser {
                 | Keyword::Refresh
                 | Keyword::Window
                 | Keyword::Array
+                | Keyword::At
+                | Keyword::Zone
         )
     }
 

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -741,6 +741,28 @@ async fn aborted_transaction_rejects_until_rollback() {
     // why we intentionally don't DROP here.
 }
 
+/// Phase 5.2: `AT TIME ZONE` parses and evaluates. Lowered to
+/// `timezone(zone, expr)` in the expression parser. The engine's
+/// timezone conversion is currently a pass-through (timestamptz and
+/// timestamp share a text representation), so this test only asserts
+/// that the syntax parses and returns a non-empty string — not a
+/// specific TZ shift. When real TZ handling lands the test can tighten.
+#[tokio::test(flavor = "multi_thread")]
+async fn at_time_zone_parses_and_evaluates() {
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let row = client
+        .query_one(
+            "SELECT CAST(TIMESTAMP '2024-01-15 12:00:00' AT TIME ZONE 'UTC' AS text)",
+            &[],
+        )
+        .await
+        .expect("query");
+    let value: String = row.get(0);
+    assert!(!value.is_empty(), "AT TIME ZONE result must not be empty");
+}
+
 /// Phase 5.1: PG date/time keyword literals — CURRENT_TIMESTAMP,
 /// CURRENT_DATE, CURRENT_TIME, LOCALTIMESTAMP, LOCALTIME parse as
 /// special keyword calls (not regular functions) and evaluate. Before


### PR DESCRIPTION
## Summary

Parse \`expr AT TIME ZONE zone_expr\` at the same precedence as \`::\` cast. PG's grammar specifies this as a postfix operator, not a function call, so the syntax must be recognised in the expression parser.

## Implementation

- **Lexer**: add \`At\` and \`Zone\` to the \`Keyword\` enum, map \`"at"\` and \`"zone"\` in \`from_str\`, and mark both as unreserved so they still work as identifiers elsewhere.
- **Parser**: in \`parse_expr_bp\`, detect the three-token sequence \`AT TIME ZONE\` before the \`::\` cast branch. Lower to \`timezone(zone, expr)\` \`FunctionCall\` — no new AST variant needed. Executor dispatches through the existing \`timezone()\` path.

## Caveat

The engine's \`timezone()\` is currently a pass-through — we don't track TZ distinctly (timestamptz and timestamp share a text representation). This PR wires the syntax so sqlx/Diesel migrations and queries that use \`AT TIME ZONE\` parse; real TZ-shift arithmetic lands with a future datetime pass. The integration test only asserts the syntax parses and evaluates to a non-empty value; it can tighten when real TZ handling arrives.

## Test plan

- [x] \`cargo test --lib\` — 891 pass (no regressions)
- [x] \`cargo test --test tokio_postgres_compat\` — 29 pass, 1 new: \`at_time_zone_parses_and_evaluates\`
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)