### PR TITLE
fix: Phase 7.1 — COPY FROM STDIN over extended-query protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,6 +2261,7 @@ dependencies = [
  "criterion",
  "crossterm",
  "futures",
+ "futures-util",
  "hmac",
  "js-sys",
  "md-5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,8 @@ tokio-postgres = { workspace = true, features = ["with-uuid-1", "with-chrono-0_4
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid = "1"
 chrono = "0.4"
+futures-util = "0.3"
+bytes = "1"
 
 [[bench]]
 name = "engine_bench"

--- a/src/tcop/postgres/copy_protocol.rs
+++ b/src/tcop/postgres/copy_protocol.rs
@@ -456,7 +456,8 @@ fn parse_copy_text_field(
                 message: "COPY boolean field is invalid".to_string(),
             }),
         },
-        20 => field
+        // int2/int4/int8/oid/regproc all share the same text form
+        20 | 21 | 23 | 24 | 26 => field
             .value
             .trim()
             .parse::<i64>()
@@ -464,7 +465,7 @@ fn parse_copy_text_field(
             .map_err(|_| SessionError {
                 message: "COPY integer field is invalid".to_string(),
             }),
-        701 => field
+        700 | 701 => field
             .value
             .trim()
             .parse::<f64>()
@@ -472,7 +473,20 @@ fn parse_copy_text_field(
             .map_err(|_| SessionError {
                 message: "COPY float field is invalid".to_string(),
             }),
-        25 => Ok(ScalarValue::Text(field.value.clone())),
+        1700 => field
+            .value
+            .trim()
+            .parse::<rust_decimal::Decimal>()
+            .map(ScalarValue::Numeric)
+            .map_err(|_| SessionError {
+                message: "COPY numeric field is invalid".to_string(),
+            }),
+        // text / varchar / bpchar / name / json / bytea / uuid / jsonb —
+        // all surface as Text here; their PG text form is already the
+        // value we want to store.
+        25 | 1042 | 1043 | 19 | 114 | 17 | 2950 | 3802 => {
+            Ok(ScalarValue::Text(field.value.clone()))
+        }
         1082 => {
             let days = parse_pg_date_days(field.value.trim())?;
             Ok(ScalarValue::Text(format_pg_date_from_days(days)))

--- a/src/tcop/postgres/mod.rs
+++ b/src/tcop/postgres/mod.rs
@@ -364,6 +364,11 @@ pub(super) struct CopyInState {
     header: bool,
     column_type_oids: Vec<PgType>,
     payload: Vec<u8>,
+    /// Whether the COPY was initiated via simple-query protocol. Simple
+    /// queries bundle `CommandComplete + ReadyForQuery` in the
+    /// per-statement response; extended-query callers expect RFQ only on
+    /// the subsequent `Sync` — not on CopyDone itself.
+    started_via_simple_query: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -608,13 +613,17 @@ impl PostgresSession {
                     | FrontendMessage::CopyDone
                     | FrontendMessage::CopyFail { .. }
                     | FrontendMessage::Flush
+                    | FrontendMessage::Sync
                     | FrontendMessage::Terminate
             )
         {
             // Auto-cancel the in-progress COPY so that the new message can proceed.
             // This mirrors PostgreSQL behaviour when a client abandons COPY without
             // sending CopyDone/CopyFail (e.g. when using the simple query protocol
-            // without a real COPY data stream).
+            // without a real COPY data stream). Sync is deliberately NOT a trigger:
+            // tokio-postgres (and other pipeline clients) emits Sync between the
+            // Execute that started COPY IN and the first CopyData as a harmless
+            // pipeline marker. Per PG protocol, Sync during COPY IN is ignored.
             self.copy_in_state = None;
         }
 
@@ -733,13 +742,28 @@ impl PostgresSession {
                 Ok(ControlFlow::Continue)
             }
             FrontendMessage::CopyDone => {
+                // Capture this before exec_copy_done consumes the state.
+                let simple = self
+                    .copy_in_state
+                    .as_ref()
+                    .is_some_and(|s| s.started_via_simple_query);
                 self.exec_copy_done(out).await?;
-                self.send_ready_for_query = true;
+                // Simple-query COPY expects RFQ bundled with the per-statement
+                // response. Extended-query COPY waits for the client's Sync.
+                if simple {
+                    self.send_ready_for_query = true;
+                }
                 Ok(ControlFlow::Continue)
             }
             FrontendMessage::CopyFail { message } => {
+                let simple = self
+                    .copy_in_state
+                    .as_ref()
+                    .is_some_and(|s| s.started_via_simple_query);
                 self.exec_copy_fail(message)?;
-                self.send_ready_for_query = true;
+                if simple {
+                    self.send_ready_for_query = true;
+                }
                 Ok(ControlFlow::Continue)
             }
             FrontendMessage::Flush => {
@@ -749,7 +773,13 @@ impl PostgresSession {
             FrontendMessage::Sync => {
                 self.ignore_till_sync = false;
                 self.finish_xact_command();
-                self.send_ready_for_query = true;
+                // Per PG protocol: Sync during COPY IN mode does NOT emit
+                // ReadyForQuery — the backend stays in copy-in state until
+                // CopyDone / CopyFail arrives. Only arm the RFQ when we're
+                // out of COPY IN mode.
+                if self.copy_in_state.is_none() {
+                    self.send_ready_for_query = true;
+                }
                 Ok(ControlFlow::Continue)
             }
             FrontendMessage::Terminate => Ok(ControlFlow::Break),
@@ -1121,6 +1151,10 @@ impl PostgresSession {
                             header: command.header,
                             column_type_oids,
                             payload: Vec::new(),
+                            // `doing_extended_query_message` is true while
+                            // dispatching Parse/Bind/Execute/etc. and false
+                            // for simple Query.
+                            started_via_simple_query: !self.doing_extended_query_message,
                         });
                         Ok(ExecutionOutcome::CopyInStart {
                             overall_format,

--- a/src/tcop/postgres/tests.rs
+++ b/src/tcop/postgres/tests.rs
@@ -1542,3 +1542,98 @@ fn sqlstate_falls_back_to_xx000_when_unmatched() {
     let (code, _, _, _) = classify_sqlstate_error_fields(msg);
     assert_eq!(code, "XX000");
 }
+
+/// Phase 7.1 regression: extended-protocol COPY FROM STDIN must not be
+/// disrupted by a `Sync` between the `Execute` that started COPY IN and
+/// the first `CopyData`. tokio-postgres emits that Sync as a pipeline
+/// flush marker. Before the fix, the server cleared `copy_in_state` on
+/// Sync and also emitted a spurious `ReadyForQuery`, which caused the
+/// client to reject the next `CopyData` with UnexpectedMessage.
+#[test]
+fn copy_from_stdin_via_extended_protocol_does_not_lose_copy_state() {
+    let out = with_isolated_state(|| {
+        let mut session = PostgresSession::new();
+        session.run_sync([
+            FrontendMessage::Query {
+                sql: "CREATE TABLE copy_ep (id int4, label text)".to_string(),
+            },
+            FrontendMessage::Parse {
+                statement_name: "s".to_string(),
+                query: "COPY copy_ep FROM STDIN".to_string(),
+                parameter_types: Vec::new(),
+            },
+            FrontendMessage::Bind {
+                portal_name: String::new(),
+                statement_name: "s".to_string(),
+                param_formats: Vec::new(),
+                params: Vec::new(),
+                result_formats: Vec::new(),
+            },
+            FrontendMessage::Execute {
+                portal_name: String::new(),
+                max_rows: 0,
+            },
+            // The Sync-during-COPY IN that exposed the bug.
+            FrontendMessage::Sync,
+            FrontendMessage::CopyData {
+                data: b"1\talpha\n2\tbeta\n".to_vec(),
+            },
+            FrontendMessage::CopyDone,
+            FrontendMessage::Sync,
+        ])
+    });
+
+    // CopyInResponse must be delivered, CommandComplete after CopyDone
+    // must report 2 rows, and no ErrorResponse should appear.
+    let has_copy_in = out
+        .iter()
+        .any(|m| matches!(m, BackendMessage::CopyInResponse { .. }));
+    assert!(
+        has_copy_in,
+        "CopyInResponse missing — Execute path regression"
+    );
+
+    let copy_complete = out.iter().any(|m| {
+        matches!(
+            m,
+            BackendMessage::CommandComplete { tag, rows, .. } if tag == "COPY" && *rows == 2
+        )
+    });
+    assert!(
+        copy_complete,
+        "CommandComplete 'COPY 2' missing — exec_copy_done path regression"
+    );
+
+    let errors: Vec<_> = out
+        .iter()
+        .filter_map(|m| match m {
+            BackendMessage::ErrorResponse { message, .. } => Some(message.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "unexpected ErrorResponse during COPY flow: {errors:?}"
+    );
+
+    // Exactly one RFQ must follow the client's final Sync (not two —
+    // that was the spurious-RFQ regression). Count them by looking at
+    // where they appear: one must come AFTER the CommandComplete for COPY.
+    let copy_cc_idx = out
+        .iter()
+        .position(|m| {
+            matches!(
+                m,
+                BackendMessage::CommandComplete { tag, .. } if tag == "COPY"
+            )
+        })
+        .expect("COPY CommandComplete must exist");
+    let rfq_after_copy = out[copy_cc_idx..]
+        .iter()
+        .filter(|m| matches!(m, BackendMessage::ReadyForQuery { .. }))
+        .count();
+    assert_eq!(
+        rfq_after_copy, 1,
+        "exactly one ReadyForQuery after CopyDone expected (from client's Sync); got {rfq_after_copy}"
+    );
+}

--- a/tests/tokio_postgres_compat.rs
+++ b/tests/tokio_postgres_compat.rs
@@ -917,6 +917,83 @@ async fn listen_notify_delivers_notification_on_same_session() {
     let _ = conn_task.await;
 }
 
+/// Phase 7.1 probe: tokio-postgres `COPY FROM STDIN` flow. Reported by
+/// the original testkit audit as "unexpected message from server".
+/// Gated with `#[ignore]` because concurrent tokio_postgres_compat tests
+/// share the engine's process-global catalog and race on CREATE-table
+/// visibility (Phase 3.1 in the plan is the long-term fix — per-database
+/// catalog isolation). The protocol-level fix this test exercises is
+/// pinned deterministically by the lib-level test
+/// `copy_from_stdin_via_extended_protocol_does_not_lose_copy_state` in
+/// `src/tcop/postgres/tests.rs`. Run manually with
+/// `cargo test --test tokio_postgres_compat copy_from_stdin -- --ignored`.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "catalog-global race under concurrent integration tests; see lib-level regression test"]
+async fn copy_from_stdin_text_delivers_rows() {
+    use bytes::Bytes;
+    use futures_util::SinkExt;
+
+    let port = spawn_server();
+    let client = connect(port).await;
+
+    let table = format!(
+        "c_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    client
+        .batch_execute(&format!("CREATE TABLE {table} (id int4, label text);"))
+        .await
+        .expect("setup");
+
+    // The engine's catalog is process-global; concurrent
+    // tokio_postgres_compat sessions occasionally race on the freshly-
+    // created table being visible to another session's planner. Retry the
+    // copy_in a few times on `relation does not exist` — orthogonal to
+    // the protocol-level behaviour this test pins. See
+    // TESTKIT_FULL_FIX_PLAN.md Phase 3.1 for the per-database catalog
+    // isolation that would make this retry unnecessary.
+    let sink = {
+        let mut last_err: Option<tokio_postgres::Error> = None;
+        let mut attempt = None;
+        for _ in 0..10 {
+            match client.copy_in(&format!("COPY {table} FROM STDIN")).await {
+                Ok(sink) => {
+                    attempt = Some(sink);
+                    break;
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            }
+        }
+        attempt.unwrap_or_else(|| panic!("copy_in: {:?}", last_err.unwrap()))
+    };
+    let mut pinned = std::pin::pin!(sink);
+    pinned
+        .send(Bytes::from_static(b"1\talpha\n2\tbeta\n3\tgamma\n"))
+        .await
+        .expect("send");
+    let rows = pinned.finish().await.expect("finish");
+    // Before this PR the test panicked here with `UnexpectedMessage`
+    // because Sync during COPY IN wrongly cleared the server's
+    // copy_in_state and emitted a spurious ReadyForQuery. Now the
+    // protocol-level handshake completes and we see the correct
+    // `rows` count.
+    assert_eq!(rows, 3, "COPY should report 3 rows inserted");
+    // Row-verification via a follow-up SELECT is deliberately omitted:
+    // concurrent tokio_postgres_compat tests share the engine's
+    // process-global catalog, and a SELECT count(*) can race with other
+    // tests' CREATE/INSERT activity producing transient mismatches. The
+    // correctness signal this test exists to guard — that tokio-postgres
+    // COPY FROM STDIN no longer panics with UnexpectedMessage — is the
+    // `finish()` result above. Full end-to-end row delivery is exercised
+    // by lib-level tests using `with_isolated_state`.
+}
+
 /// Phase 2.2: a NULL bind parameter surfaces as NULL in the result row.
 /// The typed-params refactor changed how NULL flows (Option<String> None →
 /// Option<ScalarValue> None); this pins that NULL passthrough works.


### PR DESCRIPTION
## Summary

tokio-postgres \`client.copy_in(...)\` pipelines Parse + Bind + Execute + Sync in a single burst. Execute triggered \`CopyInResponse\` (correct) but the immediately-following \`Sync\` broke COPY in two ways:

1. The auto-cancel guard in \`dispatch\` treated anything other than \`CopyData\`/\`CopyDone\`/\`CopyFail\`/\`Flush\`/\`Terminate\` as a signal to clear \`copy_in_state\`. \`Sync\` was NOT on that safe list, so the first Sync after entering COPY IN silently cancelled the copy.
2. The Sync handler unconditionally set \`send_ready_for_query = true\`, producing a spurious RFQ mid-COPY. Per PG protocol, Sync during COPY IN does NOT emit RFQ.

Together: the very next \`CopyData\` failed with \"COPY data was sent without COPY IN state\" and the client saw \`UnexpectedMessage\` on \`finish()\`.

## Changes

- \`src/tcop/postgres/mod.rs\`: add \`Sync\` to the copy-state auto-cancel safe list.
- \`src/tcop/postgres/mod.rs\`: Sync handler only arms RFQ when \`copy_in_state.is_none()\`.
- \`src/tcop/postgres/mod.rs\` + \`src/tcop/postgres/copy_protocol.rs\`: track \`started_via_simple_query: bool\` on \`CopyInState\`. Simple-query COPY still gets \`CommandComplete + RFQ\` bundled in the per-statement response. Extended-query COPY waits for the client's Sync.
- \`src/tcop/postgres/copy_protocol.rs\`: extend text-row parser to int2/int4/oid/regproc/numeric/uuid/bytea/json/jsonb. Previously only int8/float8/text/date/timestamp were accepted, so even an \`int4\` column errored with \"unsupported COPY type oid 23\".
- \`Cargo.toml\`: add \`futures-util\` and \`bytes\` as dev-deps for tokio-postgres' \`CopyInSink\` API.

## Test plan

- [x] \`cargo test --lib\` — 892 pass (1 new deterministic regression test: \`copy_from_stdin_via_extended_protocol_does_not_lose_copy_state\`)
- [x] \`cargo test --test tokio_postgres_compat\` — 28 pass, 1 ignored (see below)
- [x] \`cargo test --test tokio_postgres_compat -- --ignored\` — passes
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

## Ignored integration test

\`copy_from_stdin_text_delivers_rows\` in tokio_postgres_compat.rs is marked \`#[ignore]\` because concurrent tokio_postgres_compat tests race on the engine's process-global catalog (CREATE-table visible to other session), producing transient \`42P01\` errors unrelated to the fix. The **lib-level regression test above** covers the fix deterministically. \`TESTKIT_FULL_FIX_PLAN.md\` Phase 3.1 (per-database catalog isolation) is the long-term fix for this class of test-parallelism issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)