### PR TITLE
[codex] speed up CI with nextest and parallel lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,33 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy, rustfmt
           targets: wasm32-unknown-unknown
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Cargo build
         run: cargo build
       - name: Cargo build (WASM lib)
         run: cargo build --lib --target wasm32-unknown-unknown
-      - name: Cargo test
-        run: cargo test
+      - name: Cargo nextest
+        run: cargo nextest run --workspace
+      - name: Cargo doctest
+        run: cargo test --doc
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
       - name: Cargo fmt
         run: cargo fmt --check
       - name: Cargo clippy


### PR DESCRIPTION
## Summary

Implements #163 by shortening the CI critical path in `.github/workflows/ci.yml`.

## What Changed

- replaces `cargo test` in the main Rust job with `cargo nextest run --workspace`
- keeps doctest coverage explicit with `cargo test --doc`
- splits `cargo fmt --check` and `cargo clippy -- -D warnings` into a parallel `lint` job
- keeps the existing build, WASM build, integration, and WASM bundle jobs intact

## Why

The existing `rust` job serialized build, test, fmt, and clippy work. That made it the PR bottleneck even when the integration and WASM jobs finished earlier. Moving lint into its own job and using `nextest` should cut the Rust-side tail without dropping doctest coverage.

## Validation

- `cargo nextest run --workspace --no-run`
- `cargo test --doc`
- local YAML parse of `.github/workflows/ci.yml`

## Notes

- this stays intentionally narrow to the workflow change proposed in #163
- the PR is draft while CI timing is observed on the first run