### PR TITLE
Fix #169: reflect user enums + composites in pg_type/pg_class/pg_attribute/pg_enum

### DIFF
--- a/src/commands/typecmd.rs
+++ b/src/commands/typecmd.rs
@@ -1,3 +1,4 @@
+use crate::catalog::with_catalog_write;
 use crate::parser::ast::{
     CreateCastStatement, CreateDomainStatement, CreateTypeStatement, DropDomainStatement,
     DropTypeStatement,
@@ -16,15 +17,32 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
     let normalized_name: Vec<String> = create.name.clone();
 
     if !create.as_composite.is_empty() {
-        let attributes: Vec<(String, String)> = create
+        // Reject duplicates before allocating OIDs so failed CREATEs don't
+        // burn OID space.
+        with_ext_write(|ext| {
+            if name_exists(ext, &normalized_name) {
+                Err(EngineError {
+                    message: format!("type \"{}\" already exists", create.name.join(".")),
+                })
+            } else {
+                Ok(())
+            }
+        })?;
+
+        let (type_oid, class_oid) = with_catalog_write(|catalog| {
+            let type_oid = catalog
+                .next_oid()
+                .map_err(|e| EngineError { message: e.message })?;
+            let class_oid = catalog
+                .next_oid()
+                .map_err(|e| EngineError { message: e.message })?;
+            Ok::<_, EngineError>((type_oid, class_oid))
+        })?;
+
+        let attributes = create
             .as_composite
             .iter()
-            .map(|attr| {
-                (
-                    attr.name.clone(),
-                    format!("{:?}", attr.data_type).to_ascii_lowercase(),
-                )
-            })
+            .map(|attr| (attr.name.clone(), attr.data_type.clone()))
             .collect();
 
         with_ext_write(|ext| {
@@ -34,6 +52,8 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
                 });
             }
             ext.user_composite_types.push(UserCompositeType {
+                oid: type_oid,
+                class_oid,
                 name: normalized_name,
                 attributes,
             });
@@ -60,11 +80,28 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
 
     with_ext_write(|ext| {
         if name_exists(ext, &normalized_name) {
+            Err(EngineError {
+                message: format!("type \"{}\" already exists", create.name.join(".")),
+            })
+        } else {
+            Ok(())
+        }
+    })?;
+
+    let type_oid = with_catalog_write(|catalog| {
+        catalog
+            .next_oid()
+            .map_err(|e| EngineError { message: e.message })
+    })?;
+
+    with_ext_write(|ext| {
+        if name_exists(ext, &normalized_name) {
             return Err(EngineError {
                 message: format!("type \"{}\" already exists", create.name.join(".")),
             });
         }
         ext.user_types.push(UserEnumType {
+            oid: type_oid,
             name: normalized_name,
             labels: create.as_enum.clone(),
         });

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -1475,6 +1475,23 @@ pub(super) fn virtual_relation_rows(
                 }
                 out
             });
+            // Append a pg_class row (relkind='c') for each user-defined
+            // composite type. attrelid / typrelid references these.
+            let composite_classes = with_ext_read(|ext| {
+                ext.user_composite_types
+                    .iter()
+                    .map(|t| {
+                        (
+                            t.class_oid,
+                            t.name.last().cloned().unwrap_or_default(),
+                            PUBLIC_NAMESPACE_OID,
+                            "c".to_string(),
+                            false,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            });
+            entries.extend(composite_classes);
             entries.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
             Ok(entries
                 .into_iter()
@@ -1513,6 +1530,28 @@ pub(super) fn virtual_relation_rows(
                 }
                 out
             });
+            // Append pg_attribute rows for each composite type's attributes,
+            // keyed by the composite's class_oid. atttypid comes from
+            // sql_type_from_ast(&type_name).oid().
+            let composite_attrs = with_ext_read(|ext| {
+                let mut out = Vec::new();
+                for composite in &ext.user_composite_types {
+                    for (ordinal, (name, type_name)) in composite.attributes.iter().enumerate() {
+                        let atttypid =
+                            crate::commands::create_table::sql_type_from_ast(type_name).oid();
+                        out.push((
+                            composite.class_oid,
+                            ordinal as u16,
+                            name.clone(),
+                            atttypid,
+                            true, // attnotnull: composite attrs are NOT NULL by default in PG
+                            false,
+                        ));
+                    }
+                }
+                out
+            });
+            entries.extend(composite_attrs);
             entries.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
             Ok(entries
                 .into_iter()
@@ -1534,7 +1573,7 @@ pub(super) fn virtual_relation_rows(
         ("pg_catalog", "pg_type") => {
             // Source of truth: src/catalog/builtin_types.rs. Column set and
             // order must match system_catalogs.rs pg_type column defs.
-            Ok(BUILTIN_TYPES
+            let mut rows: Vec<Vec<ScalarValue>> = BUILTIN_TYPES
                 .iter()
                 .map(|t| {
                     vec![
@@ -1569,7 +1608,85 @@ pub(super) fn virtual_relation_rows(
                         ScalarValue::Null,        // typdefault
                     ]
                 })
-                .collect())
+                .collect();
+
+            // Append user-defined enum types (typtype='e', typcategory='E').
+            // Append user-defined composite types (typtype='c', typcategory='C').
+            // typarray=0 is a partial — no auto-created `_foo` array companion.
+            let user_type_rows = with_ext_read(|ext| {
+                let mut out: Vec<Vec<ScalarValue>> = Vec::new();
+                for enum_ty in &ext.user_types {
+                    let name = enum_ty.name.last().cloned().unwrap_or_default();
+                    out.push(vec![
+                        ScalarValue::Int(enum_ty.oid as i64),
+                        ScalarValue::Text(name),
+                        ScalarValue::Int(PUBLIC_NAMESPACE_OID as i64),
+                        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
+                        ScalarValue::Int(4),     // typlen: enum = 4
+                        ScalarValue::Bool(true), // typbyval
+                        ScalarValue::Text("e".to_string()),
+                        ScalarValue::Text("E".to_string()),
+                        ScalarValue::Bool(false),
+                        ScalarValue::Bool(true),
+                        ScalarValue::Text(",".to_string()),
+                        ScalarValue::Int(0), // typrelid: enums aren't class-backed
+                        ScalarValue::Int(0), // typelem
+                        ScalarValue::Int(0), // typarray: partial — no array companion
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Text("i".to_string()),
+                        ScalarValue::Text("p".to_string()),
+                        ScalarValue::Bool(false),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(-1),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Null,
+                    ]);
+                }
+                for comp in &ext.user_composite_types {
+                    let name = comp.name.last().cloned().unwrap_or_default();
+                    out.push(vec![
+                        ScalarValue::Int(comp.oid as i64),
+                        ScalarValue::Text(name),
+                        ScalarValue::Int(PUBLIC_NAMESPACE_OID as i64),
+                        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
+                        ScalarValue::Int(-1),     // typlen: composite is varlen
+                        ScalarValue::Bool(false), // typbyval
+                        ScalarValue::Text("c".to_string()),
+                        ScalarValue::Text("C".to_string()),
+                        ScalarValue::Bool(false),
+                        ScalarValue::Bool(true),
+                        ScalarValue::Text(",".to_string()),
+                        ScalarValue::Int(comp.class_oid as i64), // typrelid
+                        ScalarValue::Int(0),                     // typelem
+                        ScalarValue::Int(0),                     // typarray: partial
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Text("d".to_string()),
+                        ScalarValue::Text("x".to_string()),
+                        ScalarValue::Bool(false),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(-1),
+                        ScalarValue::Int(0),
+                        ScalarValue::Int(0),
+                        ScalarValue::Null,
+                    ]);
+                }
+                out
+            });
+            rows.extend(user_type_rows);
+            Ok(rows)
         }
         ("pg_catalog", "pg_range") => Ok(BUILTIN_RANGES
             .iter()
@@ -1586,9 +1703,25 @@ pub(super) fn virtual_relation_rows(
             })
             .collect()),
         ("pg_catalog", "pg_enum") => {
-            // No user-defined enums surfaced yet. When CREATE TYPE ... AS ENUM
-            // lands (Phase 5), populate from catalog.
-            Ok(Vec::new())
+            // Each user-defined enum label gets one pg_enum row. enumsortorder
+            // is 1-based, matching PG's convention. Row-level oid column is a
+            // stable synthetic ordering key (enumtypid * 1000 + label_index);
+            // drivers don't rely on it being real-catalog OIDs.
+            Ok(with_ext_read(|ext| {
+                let mut rows = Vec::new();
+                for enum_ty in &ext.user_types {
+                    for (idx, label) in enum_ty.labels.iter().enumerate() {
+                        let synthetic_oid = (enum_ty.oid as i64) * 1000 + (idx as i64 + 1);
+                        rows.push(vec![
+                            ScalarValue::Int(synthetic_oid),
+                            ScalarValue::Int(enum_ty.oid as i64),
+                            ScalarValue::Int(idx as i64 + 1),
+                            ScalarValue::Text(label.clone()),
+                        ]);
+                    }
+                }
+                rows
+            }))
         }
         ("pg_catalog", "pg_description") => Ok(Vec::new()),
         ("pg_catalog", "pg_operator") => Ok(Vec::new()),

--- a/src/tcop/engine.rs
+++ b/src/tcop/engine.rs
@@ -17,7 +17,7 @@ use crate::parser::ast::{
     ConflictTarget, CreateFunctionStatement, DeleteStatement, Expr, ForeignKeyAction,
     FunctionParam, FunctionParamMode, FunctionReturnType, InsertSource, InsertStatement,
     MergeStatement, MergeWhenClause, OnConflictClause, Statement, TableConstraint, TriggerEvent,
-    TriggerTiming, UpdateStatement,
+    TriggerTiming, TypeName, UpdateStatement,
 };
 use crate::planner::{self, PlanNode};
 use crate::security::{self, RlsCommand, TablePrivilege};
@@ -851,13 +851,12 @@ pub(crate) fn sync_wasm_ws_state(conn_id: i64) {
     }
 }
 
-// TODO(#79): UserEnumType metadata is stored but never read back for type dispatch.
-// The proxy does not yet use this information to handle user-defined enum types in
-// query results. Implement a read path or remove the scaffolding when enum support
-// is prioritized.
+// User-defined enum type. `oid` is the pg_type.oid reflected in pg_catalog.pg_type
+// (typtype='e') and pg_catalog.pg_enum (enumtypid).
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub(crate) struct UserEnumType {
+    pub(crate) oid: Oid,
     pub(crate) name: Vec<String>,
     pub(crate) labels: Vec<String>,
 }
@@ -873,16 +872,16 @@ pub(crate) struct UserDomain {
     pub(crate) base_type: String,
 }
 
-// TODO(#169): UserCompositeType metadata is stored but never reflected in the
-// catalog. CREATE TYPE ... AS (col1 type, ...) is parsed and recorded here, but
-// pg_type / pg_class / pg_attribute reflection is the follow-up that makes the
-// type visible to introspection. The read path is also not yet wired into type
-// dispatch.
+// User-defined composite type. `oid` is the pg_type.oid; `class_oid` is the
+// pg_class.oid that backs the composite (typrelid in pg_type, attrelid in
+// pg_attribute). PG allocates them as separate OIDs.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub(crate) struct UserCompositeType {
+    pub(crate) oid: Oid,
+    pub(crate) class_oid: Oid,
     pub(crate) name: Vec<String>,
-    pub(crate) attributes: Vec<(String, String)>,
+    pub(crate) attributes: Vec<(String, TypeName)>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/tcop/engine_tests.rs
+++ b/src/tcop/engine_tests.rs
@@ -5793,12 +5793,19 @@ fn creates_composite_type_stores_metadata() {
                 .map(|(n, _)| n.as_str())
                 .collect();
             assert_eq!(attr_names, vec!["street", "city", "zip"]);
-            let attr_types: Vec<&str> = composite
+            let attr_types: Vec<crate::parser::ast::TypeName> = composite
                 .attributes
                 .iter()
-                .map(|(_, t)| t.as_str())
+                .map(|(_, t)| t.clone())
                 .collect();
-            assert_eq!(attr_types, vec!["text", "text", "int4"]);
+            assert_eq!(
+                attr_types,
+                vec![
+                    crate::parser::ast::TypeName::Text,
+                    crate::parser::ast::TypeName::Text,
+                    crate::parser::ast::TypeName::Int4,
+                ]
+            );
         });
 
         let drop_result = run_statement("DROP TYPE address", &[]);
@@ -5869,6 +5876,77 @@ fn empty_composite_type_rejected_at_parse() {
     let err = parse_statement("CREATE TYPE empty AS ()")
         .expect_err("empty composite should fail to parse");
     let _ = err;
+}
+
+#[test]
+fn composite_type_reflects_in_pg_type_and_pg_attribute() {
+    with_isolated_state(|| {
+        run_statement("CREATE TYPE addr AS (street TEXT, zip INT)", &[]);
+
+        let result = run_statement(
+            "SELECT typname, typtype FROM pg_catalog.pg_type WHERE typname = 'addr'",
+            &[],
+        );
+        assert_eq!(result.rows.len(), 1, "expected 1 pg_type row for addr");
+        assert_eq!(result.rows[0][0], ScalarValue::Text("addr".to_string()));
+        assert_eq!(result.rows[0][1], ScalarValue::Text("c".to_string()));
+
+        let typrelid_row = run_statement(
+            "SELECT typrelid FROM pg_catalog.pg_type WHERE typname = 'addr'",
+            &[],
+        );
+        let ScalarValue::Int(typrelid) = typrelid_row.rows[0][0] else {
+            panic!("typrelid should be int");
+        };
+        assert!(typrelid > 0, "composite typrelid should be non-zero");
+
+        let attrs = run_statement(
+            &format!(
+                "SELECT attname, atttypid FROM pg_catalog.pg_attribute WHERE attrelid = {} ORDER BY attnum",
+                typrelid
+            ),
+            &[],
+        );
+        assert_eq!(attrs.rows.len(), 2);
+        assert_eq!(attrs.rows[0][0], ScalarValue::Text("street".to_string()));
+        assert_eq!(attrs.rows[0][1], ScalarValue::Int(25)); // text
+        assert_eq!(attrs.rows[1][0], ScalarValue::Text("zip".to_string()));
+        assert_eq!(attrs.rows[1][1], ScalarValue::Int(23)); // int4
+    });
+}
+
+#[test]
+fn enum_type_reflects_in_pg_type_and_pg_enum() {
+    with_isolated_state(|| {
+        run_statement("CREATE TYPE mood AS ENUM ('happy', 'sad')", &[]);
+
+        let result = run_statement(
+            "SELECT typname, typtype FROM pg_catalog.pg_type WHERE typname = 'mood'",
+            &[],
+        );
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0][0], ScalarValue::Text("mood".to_string()));
+        assert_eq!(result.rows[0][1], ScalarValue::Text("e".to_string()));
+
+        let oid_row = run_statement(
+            "SELECT oid FROM pg_catalog.pg_type WHERE typname = 'mood'",
+            &[],
+        );
+        let ScalarValue::Int(oid) = oid_row.rows[0][0] else {
+            panic!("oid should be int");
+        };
+
+        let labels = run_statement(
+            &format!(
+                "SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid = {} ORDER BY enumsortorder",
+                oid
+            ),
+            &[],
+        );
+        assert_eq!(labels.rows.len(), 2);
+        assert_eq!(labels.rows[0][0], ScalarValue::Text("happy".to_string()));
+        assert_eq!(labels.rows[1][0], ScalarValue::Text("sad".to_string()));
+    });
 }
 
 #[test]


### PR DESCRIPTION
Closes #169.

## Summary

Phase 5.3 (partial) in #171 landed parser + in-memory storage for CREATE TYPE. Metadata was recorded but not reflected in pg_catalog, so tokio-postgres / sqlx type resolvers and library-under-test introspection queries saw nothing. This PR wires the read path.

## Discriminating test (from issue body)

\`\`\`sql
CREATE TYPE mood AS ENUM ('happy', 'sad');
CREATE TYPE addr AS (street TEXT, zip INT);

SELECT typname, typtype FROM pg_catalog.pg_type WHERE typname IN ('mood', 'addr');
-- addr, c   /   mood, e

SELECT attname, atttypid FROM pg_catalog.pg_attribute
  WHERE attrelid = (SELECT typrelid FROM pg_type WHERE typname='addr')
  ORDER BY attnum;
-- street, 25   /   zip, 23

SELECT enumlabel FROM pg_catalog.pg_enum
  WHERE enumtypid = (SELECT oid FROM pg_type WHERE typname='mood')
  ORDER BY enumsortorder;
-- happy   /   sad
\`\`\`

All three round-trip. Captured as \`composite_type_reflects_in_pg_type_and_pg_attribute\` and \`enum_type_reflects_in_pg_type_and_pg_enum\`.

## Changes

### Storage
- \`UserEnumType\` gains \`oid: Oid\`
- \`UserCompositeType\` gains \`oid: Oid\` + \`class_oid: Oid\` (PG allocates separate OIDs — typrelid / attrelid need the class OID, not the type OID)
- \`UserCompositeType.attributes\`: \`Vec<(String, String)>\` → \`Vec<(String, TypeName)>\`. Earlier lossy \`format!(\"{:?}\", t).to_ascii_lowercase()\` didn't roundtrip for \`Array(T)\`; storing \`TypeName\` hands real values to the OID resolver.

### Allocation (typecmd.rs)
- Duplicate check against \`ExtensionState\` first (so failed CREATEs don't burn OID space)
- OIDs allocated via \`catalog.next_oid()\` under catalog lock
- Push to ExtensionState under its own lock — no nested locks

### Read path (table_functions.rs)
- \`pg_type\` appends user rows after \`BUILTIN_TYPES\`:
  - enums: \`typtype='e'\`, \`typcategory='E'\`, \`typnamespace=PUBLIC_NAMESPACE_OID (2200)\`
  - composites: \`typtype='c'\`, \`typcategory='C'\`, \`typrelid=class_oid\`
- \`pg_class\` appends \`relkind='c'\` rows per composite, keyed by \`class_oid\`
- \`pg_attribute\` appends rows per composite attribute, \`atttypid\` via \`sql_type_from_ast(type_name).oid()\`
- \`pg_enum\` returns rows with 1-based \`enumsortorder\`

## Partial scope (stated in code + here)

| Gap | Impact | Why deferred |
|---|---|---|
| \`typarray = 0\` | Tests with \`user_type[]\` columns won't see an array companion OID | Needs array-companion pg_type row emission; separate PR |
| No VARCHAR(n) fidelity | Composite attributes lose length modifiers | \`TypeName::Varchar\` has no length field — pre-existing |
| No \`pg_description\` comments | \`COMMENT ON TYPE\` not reflected | Separate feature |

## Test plan

- [x] \`cargo test --lib reflects_in\` → 2/2 (discriminating tests)
- [x] \`cargo test --lib composite\` → 10/10 (no regression on 5.3 partial)
- [x] \`cargo test --lib pg_\` → 28/28 (no regression on pg_catalog virtual relations)
- [x] \`cargo test --lib\` → 899/899
- [x] \`cargo clippy --lib\` → clean

## Related

- Closes #169
- Phase 5.4 range types (#170) is next — separate PR, not stacked (avoid OID-infrastructure churn in one review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)