### PR TITLE
feat: auto-create _foo array companion pg_type rows for user types

### DIFF
--- a/src/commands/typecmd.rs
+++ b/src/commands/typecmd.rs
@@ -20,25 +20,9 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
     if !create.as_composite.is_empty() {
         // Reject duplicates before allocating OIDs so failed CREATEs don't
         // burn OID space.
-        with_ext_write(|ext| {
-            if name_exists(ext, &normalized_name) {
-                Err(EngineError {
-                    message: format!("type \"{}\" already exists", create.name.join(".")),
-                })
-            } else {
-                Ok(())
-            }
-        })?;
+        ensure_unique(&normalized_name, &create.name)?;
 
-        let (type_oid, class_oid) = with_catalog_write(|catalog| {
-            let type_oid = catalog
-                .next_oid()
-                .map_err(|e| EngineError { message: e.message })?;
-            let class_oid = catalog
-                .next_oid()
-                .map_err(|e| EngineError { message: e.message })?;
-            Ok::<_, EngineError>((type_oid, class_oid))
-        })?;
+        let [type_oid, class_oid, array_oid] = alloc_oids::<3>()?;
 
         let attributes = create
             .as_composite
@@ -55,6 +39,7 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
             ext.user_composite_types.push(UserCompositeType {
                 oid: type_oid,
                 class_oid,
+                array_oid,
                 name: normalized_name,
                 attributes,
             });
@@ -70,23 +55,11 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
     }
 
     if let Some(subtype) = &create.as_range_subtype {
-        with_ext_write(|ext| {
-            if name_exists(ext, &normalized_name) {
-                Err(EngineError {
-                    message: format!("type \"{}\" already exists", create.name.join(".")),
-                })
-            } else {
-                Ok(())
-            }
-        })?;
+        ensure_unique(&normalized_name, &create.name)?;
 
         let subtype_oid = crate::commands::create_table::sql_type_from_ast(subtype).oid();
 
-        let type_oid = with_catalog_write(|catalog| {
-            catalog
-                .next_oid()
-                .map_err(|e| EngineError { message: e.message })
-        })?;
+        let [type_oid, array_oid] = alloc_oids::<2>()?;
 
         with_ext_write(|ext| {
             if name_exists(ext, &normalized_name) {
@@ -96,6 +69,7 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
             }
             ext.user_range_types.push(UserRangeType {
                 oid: type_oid,
+                array_oid,
                 subtype_oid,
                 name: normalized_name,
             });
@@ -121,21 +95,9 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
         });
     }
 
-    with_ext_write(|ext| {
-        if name_exists(ext, &normalized_name) {
-            Err(EngineError {
-                message: format!("type \"{}\" already exists", create.name.join(".")),
-            })
-        } else {
-            Ok(())
-        }
-    })?;
+    ensure_unique(&normalized_name, &create.name)?;
 
-    let type_oid = with_catalog_write(|catalog| {
-        catalog
-            .next_oid()
-            .map_err(|e| EngineError { message: e.message })
-    })?;
+    let [type_oid, array_oid] = alloc_oids::<2>()?;
 
     with_ext_write(|ext| {
         if name_exists(ext, &normalized_name) {
@@ -145,6 +107,7 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
         }
         ext.user_types.push(UserEnumType {
             oid: type_oid,
+            array_oid,
             name: normalized_name,
             labels: create.as_enum.clone(),
         });
@@ -156,6 +119,30 @@ pub async fn execute_create_type(create: &CreateTypeStatement) -> Result<QueryRe
         rows: Vec::new(),
         command_tag: "CREATE TYPE".to_string(),
         rows_affected: 0,
+    })
+}
+
+fn ensure_unique(normalized: &[String], qualified: &[String]) -> Result<(), EngineError> {
+    with_ext_write(|ext| {
+        if name_exists(ext, normalized) {
+            Err(EngineError {
+                message: format!("type \"{}\" already exists", qualified.join(".")),
+            })
+        } else {
+            Ok(())
+        }
+    })
+}
+
+fn alloc_oids<const N: usize>() -> Result<[crate::catalog::oid::Oid; N], EngineError> {
+    with_catalog_write(|catalog| {
+        let mut out = [0; N];
+        for slot in &mut out {
+            *slot = catalog
+                .next_oid()
+                .map_err(|e| EngineError { message: e.message })?;
+        }
+        Ok(out)
     })
 }
 

--- a/src/executor/exec_main/table_functions.rs
+++ b/src/executor/exec_main/table_functions.rs
@@ -1610,112 +1610,68 @@ pub(super) fn virtual_relation_rows(
                 })
                 .collect();
 
-            // Append user-defined enum types (typtype='e', typcategory='E').
-            // Append user-defined composite types (typtype='c', typcategory='C').
-            // typarray=0 is a partial — no auto-created `_foo` array companion.
+            // Append user-defined enum/composite/range types and their `_foo`
+            // array companions. Each user type now owns two pg_type rows: the
+            // main entry (typtype='e'/'c'/'r') and an array companion
+            // (typtype='b', typcategory='A', typelem=main_oid). Drivers
+            // resolve `my_type[]` through the companion row.
             let user_type_rows = with_ext_read(|ext| {
                 let mut out: Vec<Vec<ScalarValue>> = Vec::new();
                 for enum_ty in &ext.user_types {
                     let name = enum_ty.name.last().cloned().unwrap_or_default();
-                    out.push(vec![
-                        ScalarValue::Int(enum_ty.oid as i64),
-                        ScalarValue::Text(name),
-                        ScalarValue::Int(PUBLIC_NAMESPACE_OID as i64),
-                        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
-                        ScalarValue::Int(4),     // typlen: enum = 4
-                        ScalarValue::Bool(true), // typbyval
-                        ScalarValue::Text("e".to_string()),
-                        ScalarValue::Text("E".to_string()),
-                        ScalarValue::Bool(false),
-                        ScalarValue::Bool(true),
-                        ScalarValue::Text(",".to_string()),
-                        ScalarValue::Int(0), // typrelid: enums aren't class-backed
-                        ScalarValue::Int(0), // typelem
-                        ScalarValue::Int(0), // typarray: partial — no array companion
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Text("i".to_string()),
-                        ScalarValue::Text("p".to_string()),
-                        ScalarValue::Bool(false),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(-1),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Null,
-                    ]);
+                    out.push(user_type_row(
+                        enum_ty.oid,
+                        &name,
+                        'e',
+                        'E',
+                        4,
+                        true,
+                        0,
+                        0,
+                        enum_ty.array_oid,
+                        'i',
+                        'p',
+                    ));
+                    out.push(array_companion_row(
+                        enum_ty.array_oid,
+                        &name,
+                        enum_ty.oid,
+                        'i',
+                    ));
                 }
                 for comp in &ext.user_composite_types {
                     let name = comp.name.last().cloned().unwrap_or_default();
-                    out.push(vec![
-                        ScalarValue::Int(comp.oid as i64),
-                        ScalarValue::Text(name),
-                        ScalarValue::Int(PUBLIC_NAMESPACE_OID as i64),
-                        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
-                        ScalarValue::Int(-1),     // typlen: composite is varlen
-                        ScalarValue::Bool(false), // typbyval
-                        ScalarValue::Text("c".to_string()),
-                        ScalarValue::Text("C".to_string()),
-                        ScalarValue::Bool(false),
-                        ScalarValue::Bool(true),
-                        ScalarValue::Text(",".to_string()),
-                        ScalarValue::Int(comp.class_oid as i64), // typrelid
-                        ScalarValue::Int(0),                     // typelem
-                        ScalarValue::Int(0),                     // typarray: partial
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Text("d".to_string()),
-                        ScalarValue::Text("x".to_string()),
-                        ScalarValue::Bool(false),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(-1),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Null,
-                    ]);
+                    out.push(user_type_row(
+                        comp.oid,
+                        &name,
+                        'c',
+                        'C',
+                        -1,
+                        false,
+                        comp.class_oid,
+                        0,
+                        comp.array_oid,
+                        'd',
+                        'x',
+                    ));
+                    out.push(array_companion_row(comp.array_oid, &name, comp.oid, 'd'));
                 }
                 for range in &ext.user_range_types {
                     let name = range.name.last().cloned().unwrap_or_default();
-                    out.push(vec![
-                        ScalarValue::Int(range.oid as i64),
-                        ScalarValue::Text(name),
-                        ScalarValue::Int(PUBLIC_NAMESPACE_OID as i64),
-                        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
-                        ScalarValue::Int(-1),     // typlen
-                        ScalarValue::Bool(false), // typbyval
-                        ScalarValue::Text("r".to_string()),
-                        ScalarValue::Text("R".to_string()),
-                        ScalarValue::Bool(false),
-                        ScalarValue::Bool(true),
-                        ScalarValue::Text(",".to_string()),
-                        ScalarValue::Int(0), // typrelid
-                        ScalarValue::Int(0), // typelem
-                        ScalarValue::Int(0), // typarray: partial
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Text("i".to_string()),
-                        ScalarValue::Text("x".to_string()),
-                        ScalarValue::Bool(false),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(-1),
-                        ScalarValue::Int(0),
-                        ScalarValue::Int(0),
-                        ScalarValue::Null,
-                    ]);
+                    out.push(user_type_row(
+                        range.oid,
+                        &name,
+                        'r',
+                        'R',
+                        -1,
+                        false,
+                        0,
+                        0,
+                        range.array_oid,
+                        'i',
+                        'x',
+                    ));
+                    out.push(array_companion_row(range.array_oid, &name, range.oid, 'i'));
                 }
                 out
             });
@@ -2475,6 +2431,77 @@ pub(super) fn virtual_relation_rows(
             message: format!("relation \"{schema}.{relation}\" does not exist"),
         }),
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn user_type_row(
+    oid: crate::catalog::oid::Oid,
+    name: &str,
+    typtype: char,
+    typcategory: char,
+    typlen: i16,
+    typbyval: bool,
+    typrelid: crate::catalog::oid::Oid,
+    typelem: crate::catalog::oid::Oid,
+    typarray: crate::catalog::oid::Oid,
+    typalign: char,
+    typstorage: char,
+) -> Vec<ScalarValue> {
+    vec![
+        ScalarValue::Int(oid as i64),
+        ScalarValue::Text(name.to_string()),
+        ScalarValue::Int(PUBLIC_NAMESPACE_OID as i64),
+        ScalarValue::Int(BOOTSTRAP_SUPERUSER_OID as i64),
+        ScalarValue::Int(typlen as i64),
+        ScalarValue::Bool(typbyval),
+        ScalarValue::Text(typtype.to_string()),
+        ScalarValue::Text(typcategory.to_string()),
+        ScalarValue::Bool(false),
+        ScalarValue::Bool(true),
+        ScalarValue::Text(",".to_string()),
+        ScalarValue::Int(typrelid as i64),
+        ScalarValue::Int(typelem as i64),
+        ScalarValue::Int(typarray as i64),
+        ScalarValue::Int(0),
+        ScalarValue::Int(0),
+        ScalarValue::Int(0),
+        ScalarValue::Int(0),
+        ScalarValue::Int(0),
+        ScalarValue::Int(0),
+        ScalarValue::Int(0),
+        ScalarValue::Text(typalign.to_string()),
+        ScalarValue::Text(typstorage.to_string()),
+        ScalarValue::Bool(false),
+        ScalarValue::Int(0),
+        ScalarValue::Int(-1),
+        ScalarValue::Int(0),
+        ScalarValue::Int(0),
+        ScalarValue::Null,
+    ]
+}
+
+fn array_companion_row(
+    array_oid: crate::catalog::oid::Oid,
+    base_name: &str,
+    element_oid: crate::catalog::oid::Oid,
+    typalign: char,
+) -> Vec<ScalarValue> {
+    // PG convention: array companion typname is `_<base>`. typtype='b'
+    // (arrays are base type even when the element is enum/composite/range);
+    // typcategory='A'; typelem points at the user type's oid.
+    user_type_row(
+        array_oid,
+        &format!("_{base_name}"),
+        'b',
+        'A',
+        -1,
+        false,
+        0,
+        element_oid,
+        0,
+        typalign,
+        'x',
+    )
 }
 
 pub(super) fn pg_relkind_for_table(kind: TableKind) -> &'static str {

--- a/src/tcop/engine.rs
+++ b/src/tcop/engine.rs
@@ -852,11 +852,14 @@ pub(crate) fn sync_wasm_ws_state(conn_id: i64) {
 }
 
 // User-defined enum type. `oid` is the pg_type.oid reflected in pg_catalog.pg_type
-// (typtype='e') and pg_catalog.pg_enum (enumtypid).
+// (typtype='e') and pg_catalog.pg_enum (enumtypid). `array_oid` is the companion
+// `_foo` pg_type row emitted alongside the main entry so drivers can resolve
+// `my_enum[]` through introspection.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub(crate) struct UserEnumType {
     pub(crate) oid: Oid,
+    pub(crate) array_oid: Oid,
     pub(crate) name: Vec<String>,
     pub(crate) labels: Vec<String>,
 }
@@ -874,22 +877,26 @@ pub(crate) struct UserDomain {
 
 // User-defined composite type. `oid` is the pg_type.oid; `class_oid` is the
 // pg_class.oid that backs the composite (typrelid in pg_type, attrelid in
-// pg_attribute). PG allocates them as separate OIDs.
+// pg_attribute). `array_oid` is the companion `_foo` pg_type row. PG allocates
+// all three as separate OIDs.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub(crate) struct UserCompositeType {
     pub(crate) oid: Oid,
     pub(crate) class_oid: Oid,
+    pub(crate) array_oid: Oid,
     pub(crate) name: Vec<String>,
     pub(crate) attributes: Vec<(String, TypeName)>,
 }
 
 // User-defined range type. `oid` is pg_type.oid (typtype='r'); `subtype_oid`
 // is the underlying element type OID surfaced as pg_range.rngsubtype.
+// `array_oid` is the companion `_foo` pg_type row.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub(crate) struct UserRangeType {
     pub(crate) oid: Oid,
+    pub(crate) array_oid: Oid,
     pub(crate) subtype_oid: Oid,
     pub(crate) name: Vec<String>,
 }

--- a/src/tcop/engine_tests.rs
+++ b/src/tcop/engine_tests.rs
@@ -5944,6 +5944,92 @@ fn range_contains_element_does_not_break_json_contains() {
 }
 
 #[test]
+fn enum_type_has_array_companion() {
+    with_isolated_state(|| {
+        run_statement("CREATE TYPE mood AS ENUM ('happy', 'sad')", &[]);
+
+        // Main + companion rows both exist.
+        let main = run_statement(
+            "SELECT oid, typtype, typcategory, typarray FROM pg_catalog.pg_type WHERE typname = 'mood'",
+            &[],
+        );
+        assert_eq!(main.rows.len(), 1);
+        let main_oid = main.rows[0][0].clone();
+        assert_eq!(main.rows[0][1], ScalarValue::Text("e".to_string()));
+        assert_eq!(main.rows[0][2], ScalarValue::Text("E".to_string()));
+        let ScalarValue::Int(main_typarray) = main.rows[0][3] else {
+            panic!("typarray should be int");
+        };
+        assert!(main_typarray > 0, "main.typarray should point at companion");
+
+        let companion = run_statement(
+            "SELECT oid, typtype, typcategory, typelem, typarray FROM pg_catalog.pg_type WHERE typname = '_mood'",
+            &[],
+        );
+        assert_eq!(companion.rows.len(), 1);
+        assert_eq!(companion.rows[0][0], ScalarValue::Int(main_typarray));
+        assert_eq!(companion.rows[0][1], ScalarValue::Text("b".to_string()));
+        assert_eq!(companion.rows[0][2], ScalarValue::Text("A".to_string()));
+        assert_eq!(companion.rows[0][3], main_oid);
+        assert_eq!(companion.rows[0][4], ScalarValue::Int(0));
+    });
+}
+
+#[test]
+fn composite_type_has_array_companion() {
+    with_isolated_state(|| {
+        run_statement("CREATE TYPE addr AS (street TEXT, zip INT)", &[]);
+
+        let main = run_statement(
+            "SELECT oid, typtype, typarray FROM pg_catalog.pg_type WHERE typname = 'addr'",
+            &[],
+        );
+        let main_oid = main.rows[0][0].clone();
+        let ScalarValue::Int(main_typarray) = main.rows[0][2] else {
+            panic!("typarray should be int");
+        };
+        assert!(main_typarray > 0);
+
+        let companion = run_statement(
+            "SELECT oid, typtype, typcategory, typelem FROM pg_catalog.pg_type WHERE typname = '_addr'",
+            &[],
+        );
+        assert_eq!(companion.rows.len(), 1);
+        assert_eq!(companion.rows[0][0], ScalarValue::Int(main_typarray));
+        assert_eq!(companion.rows[0][1], ScalarValue::Text("b".to_string()));
+        assert_eq!(companion.rows[0][2], ScalarValue::Text("A".to_string()));
+        assert_eq!(companion.rows[0][3], main_oid);
+    });
+}
+
+#[test]
+fn range_type_has_array_companion() {
+    with_isolated_state(|| {
+        run_statement("CREATE TYPE pct AS RANGE (subtype = int4)", &[]);
+
+        let main = run_statement(
+            "SELECT oid, typarray FROM pg_catalog.pg_type WHERE typname = 'pct'",
+            &[],
+        );
+        let main_oid = main.rows[0][0].clone();
+        let ScalarValue::Int(main_typarray) = main.rows[0][1] else {
+            panic!("typarray should be int");
+        };
+        assert!(main_typarray > 0);
+
+        let companion = run_statement(
+            "SELECT oid, typtype, typcategory, typelem FROM pg_catalog.pg_type WHERE typname = '_pct'",
+            &[],
+        );
+        assert_eq!(companion.rows.len(), 1);
+        assert_eq!(companion.rows[0][0], ScalarValue::Int(main_typarray));
+        assert_eq!(companion.rows[0][1], ScalarValue::Text("b".to_string()));
+        assert_eq!(companion.rows[0][2], ScalarValue::Text("A".to_string()));
+        assert_eq!(companion.rows[0][3], main_oid);
+    });
+}
+
+#[test]
 fn composite_type_reflects_in_pg_type_and_pg_attribute() {
     with_isolated_state(|| {
         run_statement("CREATE TYPE addr AS (street TEXT, zip INT)", &[]);


### PR DESCRIPTION
Follow-up to #169/#170 — fills in the \`typarray\` gap for user-defined enum, composite, and range types.

## Why

Library drivers (sqlx, tokio-postgres) resolve \`my_type[]\` column declarations by following \`pg_type.typarray → _my_type pg_type row → typelem\`. Since #169 and #170 emitted \`typarray = 0\` for all user types, that chain didn't resolve and driver introspection for arrays of user types failed.

## What

### Allocation
- Enum / Range: now allocate **2 OIDs** (type + array). Was 1.
- Composite: now allocates **3 OIDs** (type + class + array). Was 2.

\`array_oid\` added as a field to all three \`UserXxxType\` structs (consistent naming).

### pg_type rows

For each user type, two rows now emit:

**Main row**: \`typarray = array_oid\` (was 0)

**Companion row**: \`typname = \"_\" + base\`, \`typtype = 'b'\` (arrays are base type in pg_type), \`typcategory = 'A'\`, \`typelem = main_oid\`, \`typarray = 0\`, \`typstorage = 'x'\`

Shared \`user_type_row\` + \`array_companion_row\` helpers — one source of column semantics across all three kinds.

### Allocation refactor

- \`alloc_oids::<N>()\` destructures as \`let [type_oid, class_oid, array_oid] = ...\` — one catalog lock, clear call sites
- \`ensure_unique\` helper collapses three duplicate-before-alloc checks into one

## Scope flags (not silently carried)

| Gap | Reason |
|---|---|
| \`my_type[]\` as a column type **still won't parse** | \`TypeName\` has no variant for user types; analyzer name-lookup pass is a separate refactor |
| \`DROP TYPE _mood\` silently no-ops | Array companion is derived metadata, not tracked separately |
| \`CREATE TYPE _foo\` doesn't collide with an existing \`foo\`'s companion | Matches composite scope from #171 |

This PR makes companion rows **introspectable**. It does not make user arrays usable as column types.

## Discriminating test

```sql
CREATE TYPE mood AS ENUM ('happy', 'sad');
SELECT typarray FROM pg_type WHERE typname = 'mood';         -- <oid>
SELECT typtype, typcategory, typelem FROM pg_type WHERE typname = '_mood';
-- b, A, <mood's oid>
```

The round-trip \`main.typarray = companion.oid AND companion.typelem = main.oid\` is asserted for all three kinds.

## Test plan

- [x] \`cargo test --lib array_companion\` → 3/3
- [x] \`cargo test --lib\` → 911/911 (was 908 on main; +3 new)
- [x] \`cargo clippy --lib\` → clean
- [x] \`cargo check --tests --lib\` → clean

## Related

- Builds on #169 (enum + composite reflection), #170 (range reflection)
- Unblocks future sqlx/tokio-postgres \`my_type[]\` tests once the \`TypeName::User\` parser variant follow-up lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)