### PR TITLE
feat: TypeName::User — user-declared types usable as column types

### DIFF
--- a/src/commands/create_table.rs
+++ b/src/commands/create_table.rs
@@ -290,7 +290,12 @@ pub(crate) fn type_signature_from_ast(ty: TypeName) -> TypeSignature {
         TypeName::Date => TypeSignature::Date,
         TypeName::Timestamp | TypeName::TimestampTz => TypeSignature::Timestamp,
         TypeName::Vector(dim) => TypeSignature::Vector(dim),
-        TypeName::Array(_) | TypeName::Name => TypeSignature::Text,
+        // User-declared types (enum/composite/range) are persisted as Text
+        // today — enums store the label, ranges store the bounds literal, and
+        // composite value construction isn't yet wired. This preserves
+        // round-trip storage while the wire type comes from SqlType::Enum/
+        // Composite/Range via sql_type_from_ast.
+        TypeName::Array(_) | TypeName::Name | TypeName::User(_) => TypeSignature::Text,
     }
 }
 
@@ -330,6 +335,51 @@ pub(crate) fn sql_type_from_ast(ty: &TypeName) -> crate::types::SqlType {
         TN::Vector(dim) => SqlType::Vector(dim.unwrap_or(0)),
         TN::Array(inner) => SqlType::Array(Box::new(sql_type_from_ast(inner))),
         TN::Name => SqlType::Name,
+        TN::User(parts) => resolve_user_type(parts).unwrap_or(SqlType::Text),
+    }
+}
+
+/// Look up a user-declared type by name in ExtensionState. Returns `None` if
+/// the name isn't registered — callers (like `sql_type_from_ast`) fall back to
+/// SqlType::Text, which preserves the parser's historical permissive behaviour
+/// for unknown type names.
+fn resolve_user_type(parts: &[String]) -> Option<crate::types::SqlType> {
+    use crate::types::SqlType;
+    crate::tcop::engine::with_ext_read(|ext| {
+        if let Some(enum_ty) = ext.user_types.iter().find(|t| names_match(&t.name, parts)) {
+            return Some(SqlType::Enum(enum_ty.oid));
+        }
+        if let Some(comp) = ext
+            .user_composite_types
+            .iter()
+            .find(|t| names_match(&t.name, parts))
+        {
+            return Some(SqlType::Composite(comp.oid));
+        }
+        if let Some(range) = ext
+            .user_range_types
+            .iter()
+            .find(|t| names_match(&t.name, parts))
+        {
+            return Some(SqlType::Range(range.oid));
+        }
+        None
+    })
+}
+
+fn names_match(stored: &[String], requested: &[String]) -> bool {
+    if stored.len() == requested.len() {
+        stored
+            .iter()
+            .zip(requested.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b))
+    } else if requested.len() == 1 {
+        // Unqualified `mood` matches stored `public.mood` by last segment.
+        stored
+            .last()
+            .is_some_and(|s| s.eq_ignore_ascii_case(&requested[0]))
+    } else {
+        false
     }
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -258,6 +258,11 @@ pub enum TypeName {
     Array(Box<Self>), // e.g. int4[], text[][]
     Vector(Option<usize>),
     Name, // PostgreSQL name type (63-byte identifier)
+    /// User-declared type referenced by name (enum/composite/range).
+    /// Resolved to a concrete SqlType at analysis time via ExtensionState
+    /// lookup. Unknown names fall back to SqlType::Text for backwards
+    /// compatibility with the parser's historical permissive behaviour.
+    User(Vec<String>),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/parser/sql_parser/ddl.rs
+++ b/src/parser/sql_parser/ddl.rs
@@ -1975,7 +1975,7 @@ impl Parser {
                 };
                 return Ok(TypeName::Array(Box::new(inner_ty)));
             }
-            _other => TypeName::Text,
+            _other => TypeName::User(vec![base.clone()]),
         };
 
         // Parse vector(dim) modifier; ignore other type modifiers like varchar(255).

--- a/src/plpgsql/compiler.rs
+++ b/src/plpgsql/compiler.rs
@@ -2298,6 +2298,7 @@ fn type_name_to_decl_string(type_name: &TypeName) -> String {
         }
         TypeName::Array(inner) => format!("{}[]", type_name_to_decl_string(inner)),
         TypeName::Name => "name".to_string(),
+        TypeName::User(parts) => parts.join("."),
     }
 }
 

--- a/src/tcop/engine_tests.rs
+++ b/src/tcop/engine_tests.rs
@@ -6003,6 +6003,80 @@ fn composite_type_has_array_companion() {
 }
 
 #[test]
+fn user_enum_type_usable_as_column_type() {
+    with_isolated_state(|| {
+        run_statement("CREATE TYPE mood AS ENUM ('happy', 'sad')", &[]);
+        run_statement("CREATE TABLE feelings (who TEXT, m mood)", &[]);
+        run_statement("INSERT INTO feelings VALUES ('alice', 'happy')", &[]);
+        run_statement("INSERT INTO feelings VALUES ('bob', 'sad')", &[]);
+
+        let result = run_statement("SELECT who, m FROM feelings ORDER BY who", &[]);
+        assert_eq!(result.rows.len(), 2);
+        assert_eq!(result.rows[0][0], ScalarValue::Text("alice".to_string()));
+        assert_eq!(result.rows[0][1], ScalarValue::Text("happy".to_string()));
+        assert_eq!(result.rows[1][0], ScalarValue::Text("bob".to_string()));
+        assert_eq!(result.rows[1][1], ScalarValue::Text("sad".to_string()));
+    });
+}
+
+#[test]
+fn user_enum_column_reports_enum_oid_in_pg_attribute() {
+    with_isolated_state(|| {
+        run_statement("CREATE TYPE color AS ENUM ('red', 'blue')", &[]);
+        run_statement("CREATE TABLE paint (c color)", &[]);
+
+        let oid_row = run_statement(
+            "SELECT oid FROM pg_catalog.pg_type WHERE typname = 'color'",
+            &[],
+        );
+        let ScalarValue::Int(color_oid) = oid_row.rows[0][0] else {
+            panic!("oid should be int");
+        };
+
+        let attrs = run_statement(
+            "SELECT atttypid FROM pg_catalog.pg_attribute \
+             WHERE attname = 'c' AND attrelid = \
+               (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'paint')",
+            &[],
+        );
+        assert_eq!(attrs.rows.len(), 1);
+        assert_eq!(attrs.rows[0][0], ScalarValue::Int(color_oid));
+    });
+}
+
+#[test]
+fn user_range_type_usable_as_column_type() {
+    with_isolated_state(|| {
+        run_statement("CREATE TYPE pct AS RANGE (subtype = int4)", &[]);
+        run_statement("CREATE TABLE thresh (name TEXT, r pct)", &[]);
+        run_statement("INSERT INTO thresh VALUES ('low', '[0,50)')", &[]);
+
+        let result = run_statement("SELECT name, r FROM thresh", &[]);
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0][0], ScalarValue::Text("low".to_string()));
+        assert_eq!(result.rows[0][1], ScalarValue::Text("[0,50)".to_string()));
+    });
+}
+
+#[test]
+fn unknown_type_name_still_falls_back_to_text() {
+    // Backwards-compat: the parser used to silently route unknown type names
+    // to TypeName::Text. Now it routes to TypeName::User, but
+    // sql_type_from_ast falls back to Text when the name isn't registered in
+    // ExtensionState. So user code that happened to rely on the fallback
+    // (e.g. using `citext` without CREATE EXTENSION) still works.
+    with_isolated_state(|| {
+        run_statement("CREATE TABLE loose (x unregistered_type)", &[]);
+        run_statement("INSERT INTO loose VALUES ('anything goes')", &[]);
+        let result = run_statement("SELECT x FROM loose", &[]);
+        assert_eq!(
+            result.rows[0][0],
+            ScalarValue::Text("anything goes".to_string())
+        );
+    });
+}
+
+#[test]
 fn range_type_has_array_companion() {
     with_isolated_state(|| {
         run_statement("CREATE TYPE pct AS RANGE (subtype = int4)", &[]);


### PR DESCRIPTION
Capstone of the user-type thread (#169, #170, #171, #174).

## Before this PR

\`\`\`sql
CREATE TYPE mood AS ENUM ('happy', 'sad');
CREATE TABLE t (m mood);   -- \`mood\` silently falls back to Text
                           -- column has no OID linkage to the enum
\`\`\`

The parser's \`parse_type_name\` had \`_other => TypeName::Text\` for any unknown identifier. User types parsed but disappeared.

## After this PR

\`\`\`sql
CREATE TYPE mood AS ENUM ('happy', 'sad');
CREATE TABLE t (m mood);
-- SELECT atttypid FROM pg_attribute WHERE attname='m' → mood's pg_type.oid
\`\`\`

The parser captures unknown identifiers as \`TypeName::User(Vec<String>)\`; the analyzer (\`sql_type_from_ast\`) resolves them via \`ExtensionState\` lookup to the concrete \`SqlType::Enum/Composite/Range(oid)\`.

## Discriminating test

\`\`\`rust
run_statement(\"CREATE TYPE mood AS ENUM ('happy', 'sad')\", &[]);
run_statement(\"CREATE TABLE feelings (who TEXT, m mood)\", &[]);
run_statement(\"INSERT INTO feelings VALUES ('alice', 'happy')\", &[]);
run_statement(\"INSERT INTO feelings VALUES ('bob', 'sad')\", &[]);
let result = run_statement(\"SELECT who, m FROM feelings ORDER BY who\", &[]);
// round-trips: alice/happy, bob/sad
\`\`\`

Plus: \`pg_attribute.atttypid\` for the user-type column equals the user type's OID (not Text's 25).

## Changes

| File | Change |
|---|---|
| \`src/parser/ast.rs\` | New \`TypeName::User(Vec<String>)\` variant |
| \`src/parser/sql_parser/ddl.rs\` | \`_other => TypeName::User(vec![base.clone()])\` instead of Text |
| \`src/commands/create_table.rs\` | \`sql_type_from_ast\` resolves User via ExtensionState; \`type_signature_from_ast\` maps User → TypeSignature::Text for storage |
| \`src/plpgsql/compiler.rs\` | \`type_name_to_decl_string\` handles User |

## Name resolution rules

- Case-insensitive across all segments
- Unqualified \`mood\` matches stored \`public.mood\` by last-segment — matches testkit default schema
- Not found → falls back to \`SqlType::Text\` (preserves backwards-compat with parser's permissive behaviour)

## Backwards compatibility

The parser previously silently routed unknown type names to Text. Changing this to User could break tests that used made-up type names and relied on the Text fallback. Mitigation: \`sql_type_from_ast\` on an unregistered User falls back to Text, so the observable behaviour for unknown names is preserved.

Captured by the test \`unknown_type_name_still_falls_back_to_text\`:
\`\`\`sql
CREATE TABLE loose (x unregistered_type);
INSERT INTO loose VALUES ('anything goes');
SELECT x FROM loose;  -- 'anything goes'
\`\`\`

## Deferred (stated in commit)

- **Enum label validation on INSERT** — \`INSERT INTO t VALUES ('unknown_label')\` accepts any string today. Needs typed dispatch at insert time.
- **User composite value construction via \`ROW(...)\`** — separate feature.
- **Qualified user-type names in non-default schemas** — last-segment heuristic covers \`public.mood\`; exotic schema prefixes may not match all stored forms.

## Test plan

- [x] \`cargo test --lib user_\` → 3 new + 2 pre-existing pass
- [x] \`cargo test --lib unknown_type_name\` → 1/1 (backwards-compat guard)
- [x] \`cargo test --lib\` → 915/915 (was 911 on main; +4 new)
- [x] \`cargo clippy --lib\` → clean

## Related

- Builds on #169, #170, #171, #174
- #175 (citext, deferred) will benefit from this: \`citext\` column declarations now parse through TypeName::User
- Next natural step: typed analyzer dispatch for operator/function overloading (enables enum label validation, range-vs-range ops, citext comparisons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)